### PR TITLE
Fix web-components package.json to publish all files in the distribution.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {
@@ -12,9 +12,6 @@
   },
   "homepage": "https://github.com/terraware/web-components#readme",
   "private": false,
-  "files": [
-    "dist"
-  ],
   "main": "index.js",
   "dependencies": {
     "@date-io/date-fns": "^2.14.0",


### PR DESCRIPTION
The `files` property limited publishing to `index.js` and `package.json` alone and skipped rest of the files.