### PR TITLE
Support arrays of strings in messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/Message/Message.tsx
+++ b/src/components/Message/Message.tsx
@@ -7,8 +7,8 @@ import { useDeviceInfo } from '../../utils';
 export interface Props {
   type: 'page' | 'toast';
   priority: 'info' | 'critical' | 'warning' | 'success';
-  title?: string;
-  body: string;
+  title?: string | string[];
+  body: string | string[];
   actionText?: string;
   actionHandler?: () => void;
   pageButtons?: JSX.Element[];


### PR DESCRIPTION
Current page message in terraware-web needs support from array of strings for title and body (because of snackbar).
We can do extra handling in terraware-web instead but this PR might make it cleaner.