### PR TITLE
SW-1541 Support complex objects in autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/Autocomplete.tsx
+++ b/src/components/Autocomplete.tsx
@@ -1,36 +1,39 @@
 import { Autocomplete as MUIAutocomplete, TextField } from '@mui/material';
 import React, { ChangeEvent } from 'react';
 
-export interface Props {
+export interface Props<T> {
   id: string;
   label: string;
-  values: string[];
-  onChange: (id: string, value: string) => void;
-  selected: string | undefined;
+  options: T[];
+  onChange: (id: string, value: T | string) => void;
+  selected: T | undefined;
   disabled?: boolean;
   freeSolo: boolean;
+  renderOption?: (props: object, option: T, state: object) => React.ReactNode;
+  optionLabel: (option: any) => string;
+  optionSelected?: (option: T, value: T) => boolean;
+  defaultValue: T;
 }
 
-export type DropdownItem = {
-  label: string;
-  value: string;
-};
-
-export default function Autocomplete({
+export default function Autocomplete<T>({
   id,
   label,
-  values,
+  options,
   onChange,
   selected,
   disabled,
   freeSolo,
-}: Props): JSX.Element {
-  const onChangeHandler = (event: ChangeEvent<any>, value: string | null) => {
+  renderOption,
+  optionLabel,
+  optionSelected,
+  defaultValue,
+}: Props<T>): JSX.Element {
+  const onChangeHandler = (event: ChangeEvent<any>, value: string | T | null) => {
     if (event) {
       if (value) {
         onChange(id, value);
       } else {
-        onChange(id, '');
+        onChange(id, defaultValue);
       }
     }
   };
@@ -39,14 +42,39 @@ export default function Autocomplete({
     <MUIAutocomplete
       disabled={disabled}
       id={id}
-      options={values}
-      getOptionLabel={(option) => (option ? option : '')}
+      options={options}
+      getOptionLabel={optionLabel}
+      isOptionEqualToValue={optionSelected}
+      renderOption={renderOption}
       onChange={onChangeHandler}
       onInputChange={onChangeHandler}
-      inputValue={selected}
+      inputValue={optionLabel(selected)}
       freeSolo={freeSolo}
       forcePopupIcon={true}
       renderInput={(params) => <TextField {...params} label={label} variant='outlined' size='small' />}
+    />
+  );
+}
+
+// Default string based autocomplete
+
+export interface SimpleAutocompleteProps {
+  id: string;
+  label: string;
+  options: string[];
+  onChange: (id: string, value: string) => void;
+  selected: string | undefined;
+  disabled?: boolean;
+  freeSolo: boolean;
+}
+
+export function SimpleAutocomplete(props: SimpleAutocompleteProps): JSX.Element {
+  return (
+    <Autocomplete
+      {...props}
+      optionLabel={(option) => (option ? option : '')}
+      optionSelected={(option, value) => option === value}
+      defaultValue={''}
     />
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
  * Defines the public components
  */
 
-import Autocomplete from './components/Autocomplete';
+import Autocomplete, { SimpleAutocomplete } from './components/Autocomplete';
 import Button from './components/Button/Button';
 import Checkbox from './components/Checkbox';
 import DatePicker from './components/DatePicker';
@@ -58,6 +58,7 @@ export {
   ProgressCircle,
   RadioButton,
   Select,
+  SimpleAutocomplete,
   stableSort,
   SummaryBox,
   Svg,

--- a/src/stories/Autocomplete.stories.tsx
+++ b/src/stories/Autocomplete.stories.tsx
@@ -21,7 +21,7 @@ const defaultValue: Value = {
   commonName: '',
 };
 
-const AutocompleteTemplate: Story<AutocompleteProps<Value>> = (args) => {
+const Template: Story<AutocompleteProps<Value>> = (args) => {
   const [selected, setSelected] = React.useState<Value>(defaultValue);
   const handleChange = (id: string, value: Value | string) => {
     action('onChange')(value);
@@ -75,9 +75,9 @@ const AutocompleteTemplate: Story<AutocompleteProps<Value>> = (args) => {
   );
 };
 
-export const AutocompleteStory = AutocompleteTemplate.bind({});
+export const Default = Template.bind({});
 
-AutocompleteStory.args = {
+Default.args = {
   id: '1',
   label: 'Test',
   options: [

--- a/src/stories/Autocomplete.stories.tsx
+++ b/src/stories/Autocomplete.stories.tsx
@@ -1,6 +1,7 @@
 import { action } from '@storybook/addon-actions';
 import { Story } from '@storybook/react';
 import React from 'react';
+import { Typography } from '@mui/material';
 import Autocomplete, {
   Props as AutocompleteProps,
 } from '../components/Autocomplete';
@@ -10,22 +11,88 @@ export default {
   component: Autocomplete,
 };
 
-const Template: Story<AutocompleteProps> = (args) => {
-  const [selected, setSelected] = React.useState('');
-  const handleChange = (id: string, value: string) => {
-    action('onChange')(value);
-    setSelected(value);
-  };
-
-  return <Autocomplete {...args} selected={selected} onChange={handleChange} />;
+type Value = {
+  scientificName: string;
+  commonName?: string;
 };
 
-export const Default = Template.bind({});
+const defaultValue: Value = {
+  scientificName: '',
+  commonName: '',
+};
 
-Default.args = {
+const AutocompleteTemplate: Story<AutocompleteProps<Value>> = (args) => {
+  const [selected, setSelected] = React.useState<Value>(defaultValue);
+  const handleChange = (id: string, value: Value | string) => {
+    action('onChange')(value);
+    if (typeof value === 'string') {
+      setSelected({ scientificName: value });
+    } else {
+      setSelected(value);
+    }
+  };
+
+  const optionLabel = (option: any) => {
+    if (typeof option === 'string') {
+      return option as string;
+    }
+    const value = option as Value;
+
+    return value.scientificName;
+  };
+
+  const optionSelected = (option: Value, value: Value) => {
+    return option.scientificName === value.scientificName;
+  };
+
+  const renderOption = (props: object, option: Value, state: object) => {
+    if (typeof option === 'string') {
+      return (
+        <div {...props}>{option as string}</div>
+      );
+    }
+
+    return (
+      <div {...props}>
+        <Typography variant='body1' sx={{ fontWeight: 'bold' }}>{option.scientificName}</Typography>
+        &nbsp;
+        &nbsp;
+        <Typography variant='body1' sx={{ fontStyle: 'italic' }}>({option.commonName})</Typography>
+      </div>
+    );
+  };
+
+  return (
+    <Autocomplete
+      {...args}
+      selected={selected}
+      onChange={handleChange}
+      optionSelected={optionSelected}
+      optionLabel={optionLabel}
+      defaultValue={defaultValue}
+      renderOption={renderOption}
+    />
+  );
+};
+
+export const AutocompleteStory = AutocompleteTemplate.bind({});
+
+AutocompleteStory.args = {
   id: '1',
   label: 'Test',
-  values: ['Test 1', 'Test 2', 'Hello'],
-  onChange: () => true,
-  selected: '',
+  options: [
+    {
+      scientificName: 'sci 1',
+      commonName: 'comm 1',
+    },
+    {
+      scientificName: 'sci 2',
+      commonName: 'comm 2',
+    },
+    {
+      scientificName: 'sci 3',
+      commonName: 'comm 3',
+    },
+  ],
+  freeSolo: true
 };

--- a/src/stories/SimpleAutocomplete.stories.tsx
+++ b/src/stories/SimpleAutocomplete.stories.tsx
@@ -11,7 +11,7 @@ export default {
   component: SimpleAutocomplete,
 };
 
-const SimpleAutocompleteTemplate: Story<SimpleAutocompleteProps> = (args) => {
+const Template: Story<SimpleAutocompleteProps> = (args) => {
   const [selected, setSelected] = React.useState('');
   const handleChange = (id: string, value: string) => {
     action('onChange')(value);
@@ -21,9 +21,9 @@ const SimpleAutocompleteTemplate: Story<SimpleAutocompleteProps> = (args) => {
   return <SimpleAutocomplete {...args} selected={selected} onChange={handleChange} />;
 };
 
-export const SimpleAutocompleteStory = SimpleAutocompleteTemplate.bind({});
+export const Default = Template.bind({});
 
-SimpleAutocompleteStory.args = {
+Default.args = {
   id: '1',
   label: 'Test',
   options: ['Test 1', 'Test 2', 'Hello'],

--- a/src/stories/SimpleAutocomplete.stories.tsx
+++ b/src/stories/SimpleAutocomplete.stories.tsx
@@ -1,0 +1,32 @@
+import { action } from '@storybook/addon-actions';
+import { Story } from '@storybook/react';
+import React from 'react';
+import  {
+  SimpleAutocompleteProps,
+  SimpleAutocomplete,
+} from '../components/Autocomplete';
+
+export default {
+  title: 'SimpleAutocomplete',
+  component: SimpleAutocomplete,
+};
+
+const SimpleAutocompleteTemplate: Story<SimpleAutocompleteProps> = (args) => {
+  const [selected, setSelected] = React.useState('');
+  const handleChange = (id: string, value: string) => {
+    action('onChange')(value);
+    setSelected(value);
+  };
+
+  return <SimpleAutocomplete {...args} selected={selected} onChange={handleChange} />;
+};
+
+export const SimpleAutocompleteStory = SimpleAutocompleteTemplate.bind({});
+
+SimpleAutocompleteStory.args = {
+  id: '1',
+  label: 'Test',
+  options: ['Test 1', 'Test 2', 'Hello'],
+  onChange: () => true,
+  selected: '',
+};


### PR DESCRIPTION
Today autocomplete only supports strings.
Extend this to support complex objects with custom rendering.
Renamed old Autocomplete to SimpleAutocomplete (to support basic string based autocomplete).

<img width="875" alt="SimpleAutocomplete - Simple Autocomplete Story ⋅ Storybook 2022-08-30 12-08-42" src="https://user-images.githubusercontent.com/1865174/187528271-a6cad258-663e-4b04-9e16-aa39f73ceeb4.png">

<img width="793" alt="Autocomplete - Autocomplete Story ⋅ Storybook 2022-08-30 12-08-24" src="https://user-images.githubusercontent.com/1865174/187528276-667efffe-bf6a-4d6c-a8fa-b6967d6a1023.png">
