### PR TITLE
speed up design workflow by removing dependencies for yarn install

### DIFF
--- a/.github/workflows/design-workflow.yml
+++ b/.github/workflows/design-workflow.yml
@@ -33,7 +33,12 @@ jobs:
         run: git checkout -b $(echo design-workflow-${{ github.actor }}-${{ github.event.inputs.jira }}-$(date +%y-%m-%d-%s) | tr ' ' -)
 
       - name: Install Dependencies
-        run: yarn install --network-timeout 100000
+        run: |
+          npm pkg delete dependencies
+          yarn install --network-timeout 100000
+          git checkout package.json
+          git checkout yarn.lock
+          git status
 
       - name: Build dictionary 
         run: yarn build-dictionary


### PR DESCRIPTION
This PR removes dependencies from `yarn install` for the design workflow.
We only need dev dependencies installed for `yarn build-dictionary` - no need to download mui.
The speedup difference is now 40s versus 2 minutes and 30 seconds to download dependencies.