### PR TITLE
SW-1570 Add tooltip support to textfield labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/Textfield/Textfield.tsx
+++ b/src/components/Textfield/Textfield.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
+import { Tooltip } from '@mui/material';
 import Icon from '../Icon/Icon';
 import { IconName } from '../Icon/icons';
 import './styles.scss';
@@ -27,6 +28,7 @@ export interface Props {
   type: TextfieldType;
   onKeyDown?: (key: string) => void;
   onClickRightIcon?: () => void;
+  tooltipText?: string;
 }
 
 export default function TextField(props: Props): JSX.Element {
@@ -48,6 +50,7 @@ export default function TextField(props: Props): JSX.Element {
     type,
     onKeyDown,
     onClickRightIcon,
+    tooltipText,
   } = props;
 
   const textfieldClass = classNames({
@@ -90,6 +93,15 @@ export default function TextField(props: Props): JSX.Element {
     <div className={`textfield ${className}`}>
       <label htmlFor={id} className='textfield-label'>
         {label}
+        {tooltipText !== undefined && (
+          <div className='textfield-label--icon-tooltip-container'>
+            <Tooltip title={tooltipText} placement='top' arrow={true}>
+              <span>
+                <Icon name='info' className='textfield-label--icon-tooltip'/>
+              </span>
+            </Tooltip>
+          </div>
+        )}
       </label>
       {!display &&
         (type === 'text' ? (

--- a/src/components/Textfield/styles.scss
+++ b/src/components/Textfield/styles.scss
@@ -20,6 +20,17 @@
     display: block;
     width: 100%;
     max-width: 100%;
+
+    &--icon-tooltip-container {
+      display: inline-block;
+      margin-left: $tw-spc-base-small;
+    }
+
+    &--icon-tooltip {
+      width: $tw-fnt-frm-fld-label-line-height;
+      height: $tw-fnt-frm-fld-label-line-height;
+      fill: $tw-clr-frm-fld-value;
+    }
   }
 
   .textfield-help-text {

--- a/src/stories/TextfieldNew.stories.tsx
+++ b/src/stories/TextfieldNew.stories.tsx
@@ -1,5 +1,6 @@
 import { Story } from '@storybook/react';
 import React from 'react';
+import { Box } from '@mui/material';
 import TextField, { Props as TextFieldProps } from '../components/Textfield/Textfield';
 
 export default {
@@ -27,10 +28,16 @@ const Template: Story<TextFieldProps> = (args) => {
     setValue(v as string);
   };
 
-  return <TextField {...args} value={value} onChange={handleChange} />;
+  return (
+    <Box sx={{marginTop: '30px'}}>
+      <TextField {...args} value={value} onChange={handleChange} />
+    </Box>
+  );
 };
 
 export const Default = Template.bind({});
+
+export const WithTooltip = Template.bind({});
 
 Default.args = {
   label: 'Field Label',
@@ -42,4 +49,17 @@ Default.args = {
   readonly: false,
   display: false,
   type: 'text',
+};
+
+WithTooltip.args = {
+  label: 'Field Label',
+  disabled: false,
+  helperText: 'Help Text',
+  placeholder: 'placeholder',
+  errorText: '',
+  warningText: '',
+  readonly: false,
+  display: false,
+  type: 'text',
+  tooltipText: 'Hello world!',
 };


### PR DESCRIPTION
This is needed for some new tooltips in the text field labels.

<img width="1055" alt="Screen Shot 2022-09-07 at 3 08 12 PM" src="https://user-images.githubusercontent.com/1865174/188992759-d050f132-86b9-4238-b39b-d2c9107d606e.png">
