### PR TITLE
Fix Select component story to allow modifying the 'selectedValue'.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/Select/SelectT.tsx
+++ b/src/components/Select/SelectT.tsx
@@ -72,10 +72,10 @@ export default function SelectT<T>(props: SelectTProps<T>): JSX.Element {
   const dropdownRef = useRef<HTMLUListElement>(null);
 
   useEffect(() => {
-    if (options && selectedValue && selectedIndex === -1) {
-      let newIndex = -1;
+    let newIndex = -1;
+    if (options && selectedValue) {
       options.find((option, index) => {
-        if (newIndex === -1 && isEqual(option, selectedValue)) {
+        if (isEqual(option, selectedValue)) {
           newIndex = index;
 
           return true;
@@ -83,11 +83,9 @@ export default function SelectT<T>(props: SelectTProps<T>): JSX.Element {
 
         return false;
       });
-      if (newIndex !== -1) {
-        setSelectedIndex(newIndex);
-      }
-    } else if (!options) {
-      setSelectedIndex(-1);
+    }
+    if (newIndex !== selectedIndex) {
+      setSelectedIndex(newIndex);
     }
   }, [options, selectedValue, selectedIndex]);
 

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -16,7 +16,7 @@ const Template: Story<SelectProps> = (args) => {
     setValue(str);
   };
 
-  return <Select {...args} selectedValue={value} onChange={handleChange} />;
+  return <Select {...args} onChange={handleChange} />;
 };
 
 export const Default = Template.bind({});
@@ -30,6 +30,7 @@ Default.args = {
   warningText: '',
   readonly: false,
   options: ['test 1', 'test 2', 'test 3'],
+  selectedValue: 'test2',
 };
 
 type Value = {
@@ -72,7 +73,6 @@ const TemplateSelectT: Story<SelectTProps<Value>> = (args) => {
       renderOption={renderOption}
       toT={toT}
       displayLabel={displayLabel}
-      selectedValue={value}
     />
   );
 };
@@ -96,5 +96,9 @@ ComplexSelect.args = {
   }, {
     name: 'Yoda',
     age: 500
-  }]
+  }],
+  selectedValue: {
+    name: 'Eeyore',
+    age: 8
+  },
 };

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -30,7 +30,7 @@ Default.args = {
   warningText: '',
   readonly: false,
   options: ['test 1', 'test 2', 'test 3'],
-  selectedValue: 'test2',
+  selectedValue: 'test 2',
 };
 
 type Value = {


### PR DESCRIPTION
The selectedValue was being set programmatically in my previous change https://github.com/terraware/web-components/commit/940359e9939e99dfc65446da571df396b4eab869#diff-3eff1d6531741c6efbea89561d7b39aa17e4f3e8f4f26d3f8b3942d89801fa2d

This breaks the ability to test selectedValue using the props form in storybook.

This PR change allows modifying and pre-selecting the selectedValue.