### PR TITLE
SW-1831 add white background to datepicker text input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/DatePicker/styles.scss
+++ b/src/components/DatePicker/styles.scss
@@ -65,5 +65,6 @@
 
   input {
     padding: calc(#{$tw-spc-base-xx-small} * 2.5) calc(#{$tw-spc-base-xx-small} * 3);
+    background-color: $tw-clr-base-white;
   }
 }

--- a/src/stories/DatePicker.stories.tsx
+++ b/src/stories/DatePicker.stories.tsx
@@ -1,4 +1,5 @@
 import { Story as StoryBook } from '@storybook/react';
+import { Box, useTheme } from '@mui/material';
 import { action } from '@storybook/addon-actions';
 import React, { ReactElement, useState } from 'react';
 import DatePicker, { Props as DatePickerProps } from '../components/DatePicker/DatePicker';
@@ -23,14 +24,17 @@ const onError = (reason: any, value: any) => {
 
 const Template: StoryBook<DatePickerProps> = (args) => {
   const [value, setValue] = useState<string|undefined|null>();
+  const theme = useTheme();
 
   return (
-    <DatePicker
-      {...args}
-      value={value}
-      onChange={(i, v) => setValue(v)}
-      onError={onError}
-    />
+    <Box sx={{backgroundColor: theme.palette.gray[200]}} width='200px' padding={2}>
+      <DatePicker
+        {...args}
+        value={value}
+        onChange={(i, v) => setValue(v)}
+        onError={onError}
+      />
+    </Box>
   );
 };
 


### PR DESCRIPTION
- currently uses parent background
- updated storybook to capture this behavior

<img width="148" alt="DatePicker - Default ⋅ Storybook 2022-09-30 15-14-04" src="https://user-images.githubusercontent.com/1865174/193363932-cb17efa4-32dc-4692-8dcc-6ba051e65501.png">
