### PR TITLE
Fix IconTooltip Icon Spacing

### DIFF
--- a/src/components/IconTooltip/index.tsx
+++ b/src/components/IconTooltip/index.tsx
@@ -14,8 +14,8 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   icon: {
     fill: theme.palette.ClrBaseGray800,
-    paddingLeft: '.5em',
-    paddingRight: '.5em',
+    marginLeft: '.5em',
+    marginRight: '.5em',
     verticalAlign: 'text-top',
   },
   tooltip: {


### PR DESCRIPTION
- `box-sizing: border-box` causes padding to be inside the 20x20 box
- this shrinks down the icon to tiny size
- replace padding with margin, which is outside the box
- TODO: figure out how to add `box-sizing: border-box` in
the correct places in Storybook so that things render the same as in 
the terraware-web app.

In the app, this element inherits `box-sizing: border-box`:
![image](https://user-images.githubusercontent.com/114949086/195873094-74839ad8-6c95-4809-877a-3e0528b0cd99.png)

It's not seen in Storybook, as the `box-sizing` is not applied there:
![image](https://user-images.githubusercontent.com/114949086/195873241-2238b914-3e8f-4568-8af6-365a2eae239d.png)

Changing the padding to margin allows that spacing to be outside the 20x20 box of the icon, thereby not crushing the icon glyph:
![image](https://user-images.githubusercontent.com/114949086/195873448-1f676899-ad0e-4f57-b805-cc10315b9981.png)
