### PR TITLE
SW-1755: Add Species Tooltips (Follow ups)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/IconTooltip/index.tsx
+++ b/src/components/IconTooltip/index.tsx
@@ -9,18 +9,15 @@ import { useDeviceInfo } from '../../utils';
 const useStyles = makeStyles((theme: Theme) => ({
   arrow: {
     color: theme.palette.ClrBaseGray800,
-    marginLeft: '3px',
-    marginTop: '-1px',
   },
   icon: {
     fill: theme.palette.ClrBaseGray800,
-    paddingLeft: '.5em',
-    paddingRight: '.5em',
+    marginLeft: '.5em',
+    marginRight: '.5em',
     verticalAlign: 'text-top',
   },
   tooltip: {
     backgroundColor: theme.palette.ClrBaseGray800,
-    borderRadius: '8px',
     color: theme.palette.ClrBaseWhite,
     padding: '8px',
     '& a': {


### PR DESCRIPTION
This PR includes a few fixes related to styling:

- `IconTooltip` popover arrow isn't centered
- `IconTooltip` arrow sometimes appears disconnected
- `IconTooltip` icon sometimes renders too small