### PR TITLE
SW-1901 Add Ability to Float Table Header

### DIFF
--- a/src/components/table/TableHeader.tsx
+++ b/src/components/table/TableHeader.tsx
@@ -1,10 +1,14 @@
-import { Checkbox, TableCell, TableRow } from '@mui/material';
+import { Checkbox, TableCell, TableHead, TableRow } from '@mui/material';
+import { keyframes } from '@mui/system';
 import React from 'react';
 import { SortOrder } from './sort';
 import { TableColumnType } from './types';
 import { SortableContext } from '@dnd-kit/sortable';
 import TableHeaderItem from './TableHeaderItem';
 import { HeadCell } from '.';
+import useScrollDebounce from '../../utils/useScrollDebounce';
+
+const HEADER_POSITION_DEBOUNCE = 100;
 
 interface Props {
   onRequestSort: (event: React.MouseEvent<unknown>, property: string) => void;
@@ -15,6 +19,9 @@ interface Props {
   numSelected?: number;
   rowCount?: number;
   onSelectAllClick?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  containerRef?: React.MutableRefObject<HTMLDivElement | null>;
+  floatHeader?: boolean;
+  additionalOffset?: number;
 }
 
 function columnsToHeadCells(columns: TableColumnType[]): HeadCell[] {
@@ -28,14 +35,57 @@ function columnsToHeadCells(columns: TableColumnType[]): HeadCell[] {
 }
 
 export default function EnhancedTableHead(props: Props): JSX.Element {
-  const { order, orderBy, onRequestSort, numSelected, rowCount, onSelectAllClick } = props;
+  const {
+    order,
+    orderBy,
+    onRequestSort,
+    numSelected,
+    rowCount,
+    onSelectAllClick,
+    containerRef,
+    floatHeader,
+    additionalOffset
+  } = props;
   const [headCells, setHeadCells] = React.useState<HeadCell[]>(columnsToHeadCells(props.columns));
+  const [headerOffset, setHeaderOffset] = React.useState<number>(0);
+  const [lastHeaderOffset, setLastHeaderOffset] = React.useState<number>(0);
   React.useEffect(() => {
     setHeadCells(columnsToHeadCells(props.columns));
   }, [props.columns]);
 
+  useScrollDebounce((scrollPos) => {
+    if (floatHeader && containerRef && containerRef.current !== null) {
+      /**
+       * - The scroll position is negative when the window is scrolled downward.
+       * - The container position is positive when it is below the top of the screen.
+       * - If scrolled below the position of the container element, then we want to
+       *   offset the header downward so that it remains in view.
+       * - Additional offset may be added if, for example, an obstructing element
+       *   would conceal the header at the top of the screen.
+       */
+      const containerPos = containerRef.current.getBoundingClientRect();
+      const totalOffset = (additionalOffset || 0) - containerPos.y;
+      if (scrollPos.y < totalOffset) {
+        setLastHeaderOffset(headerOffset);
+        setHeaderOffset(totalOffset);
+      } else {
+        setLastHeaderOffset(headerOffset);
+        setHeaderOffset(0);
+      }
+    }
+  }, HEADER_POSITION_DEBOUNCE);
+
+  const headerMotion = keyframes`
+    from {
+      top: ${lastHeaderOffset}px;
+    }
+    to {
+      top: ${headerOffset}px;
+    }
+  `;
+
   return (
-    <thead>
+    <TableHead sx={{position: 'sticky', animation: `${headerMotion} 0.5s 1 ease`, top: `${headerOffset}px`}}>
       <TableRow id='table-header'>
         {numSelected !== undefined && rowCount !== undefined && rowCount > 0 && onSelectAllClick && (
           <TableCell padding='checkbox'>
@@ -53,6 +103,6 @@ export default function EnhancedTableHead(props: Props): JSX.Element {
           })}
         </SortableContext>
       </TableRow>
-    </thead>
+    </TableHead>
   );
 }

--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -1,5 +1,5 @@
 import { Box, Checkbox, Pagination, Table, TableBody, TableCell, TableContainer, TableRow, Theme, TooltipProps, Typography } from '@mui/material';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import EnhancedTableToolbar from './EnhancedTableToolbar';
 import { descendingComparator, getComparator, SortOrder, stableSort } from './sort';
 import TableCellRenderer from './TableCellRenderer';
@@ -61,6 +61,8 @@ export interface Props<T> {
   showPagination?: boolean;
   controlledOnSelect?: boolean;
   reloadData?: () => void;
+  floatHeader?: boolean;
+  headerWindowOffset?: number;
 }
 
 export type TopBarButton = {
@@ -93,6 +95,8 @@ export default function EnhancedTable<T>({
   showPagination = true,
   controlledOnSelect,
   reloadData,
+  floatHeader,
+  headerWindowOffset,
 }: Props<T>): JSX.Element {
   const classes = tableStyles();
   const [order, setOrder] = React.useState<SortOrder>(_order);
@@ -100,6 +104,7 @@ export default function EnhancedTable<T>({
   const [maxItemsPerPage] = useState(100);
   const [itemsToSkip, setItemsToSkip] = useState(0);
   const { isMobile } = useDeviceInfo();
+  const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (setSelectedRows && rows.length >= 0) {
@@ -201,7 +206,7 @@ export default function EnhancedTable<T>({
   return (
     <>
       {showTopBar && <EnhancedTableToolbar numSelected={selectedRows ? selectedRows.length : 0} topBarButtons={topBarButtons} />}
-      <TableContainer id={id}>
+      <TableContainer id={id} ref={containerRef}>
         <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
           <Table stickyHeader={true} aria-labelledby='tableTitle' size='medium' aria-label='enhanced table' className={classes.table}>
             <TableHeader
@@ -213,6 +218,9 @@ export default function EnhancedTable<T>({
               numSelected={showCheckbox ? selectedRows?.length : undefined}
               onSelectAllClick={showCheckbox ? handleSelectAllClick : undefined}
               rowCount={showCheckbox ? rows?.length : undefined}
+              containerRef={containerRef}
+              floatHeader={floatHeader}
+              additionalOffset={headerWindowOffset}
             />
             <TableBody>
               {rows.length < 1 && emptyTableMessage && (

--- a/src/stories/Table.stories.tsx
+++ b/src/stories/Table.stories.tsx
@@ -56,3 +56,10 @@ Default.args = {
     }
   }),
 };
+
+export const FloatingHeader = Template.bind({});
+
+FloatingHeader.args = {
+  ...Default.args,
+  floatHeader: true,
+};

--- a/src/utils/useScrollDebounce.ts
+++ b/src/utils/useScrollDebounce.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from 'react';
+
+interface Position {
+  x: number;
+  y: number;
+}
+
+const getScrollPosition = (): Position => {
+  const scrollPosition = document.body.getBoundingClientRect();
+
+  return {
+    x: scrollPosition.x || 0,
+    y: scrollPosition.y || 0,
+  };
+};
+
+/**
+ * Detects scroll events in the window and calls the effect with the scroll
+ * position when it has settled for longer than the debounceTime (ms).
+ */
+const useScrollDebounce = (
+  effect: (props: Position) => void,
+  debounceTime: number,
+) => {
+  const busy = useRef<boolean>(false);
+
+  useEffect(() => {
+    const handleScroll = async () => {
+      if (!busy.current) {
+        busy.current = true;
+        let pos = getScrollPosition();
+        let positionEqual = false;
+        while (!positionEqual) {
+          await new Promise((r) => setTimeout(r, debounceTime));
+          const newPos = getScrollPosition();
+          positionEqual = pos.y === newPos.y && pos.x === newPos.x;
+          pos = newPos;
+        }
+        effect(pos);
+        busy.current = false;
+      }
+    };
+    window.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [effect, debounceTime]);
+};
+
+export default useScrollDebounce;


### PR DESCRIPTION
- create a useScrollDebounce hook to detect scroll position and call effect after a settling time
- in TableHeader compare scroll position against the position of the table container and compute an offset to move the header by if scrolled below the top of the container
- an additional amount may be added to offset the header from the top of the screen
- smoothly animate moving the header to its new position when it updates
- add a story for the Floating Header case for Table