### PR TITLE
SW-2021 Replace Design Token Names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/Autocomplete/styles.scss
+++ b/src/components/Autocomplete/styles.scss
@@ -14,7 +14,7 @@
     font-size: $tw-fnt-frm-fld-label-font-size;
     font-weight: $tw-fnt-frm-fld-label-font-weight;
     line-height: $tw-fnt-frm-fld-label-line-height;
-    color: $tw-clr-frm-fld-label;
+    color: $tw-clr-txt-secondary;
     margin-bottom: $tw-spc-base-xx-small;
     display: block;
     width: 100%;
@@ -22,7 +22,7 @@
   }
 
   .MuiInputBase-root {
-    border: 1px solid $tw-clr-base-semantic-passive;
+    border: 1px solid $tw-clr-bg-info;
     position: unset;
     padding: 0;
   }

--- a/src/components/Autocomplete/styles.scss
+++ b/src/components/Autocomplete/styles.scss
@@ -1,4 +1,5 @@
 @import '../../style-dictionary-dist/textfield_variables.scss';
+@import '../../style-dictionary-dist2/terraware.scss';
 
 @font-face {
   font-family: 'Inter';

--- a/src/components/Button/styles.scss
+++ b/src/components/Button/styles.scss
@@ -1,4 +1,5 @@
 @import '../../style-dictionary-dist/button_variables.scss';
+@import '../../style-dictionary-dist2/terraware.scss';
 
 @font-face {
   font-family: 'Inter';

--- a/src/components/Button/styles.scss
+++ b/src/components/Button/styles.scss
@@ -35,7 +35,7 @@
         left: calc(#{-$tw-sz-btn-stroke} * 2);
         right: calc(#{-$tw-sz-btn-stroke} * 2);
         border-radius: calc(#{$tw-sz-btn-small-height + $tw-sz-btn-stroke * 4} / 2);
-        border: $tw-sz-btn-stroke solid $tw-clr-btn-stroke-focus;
+        border: $tw-sz-btn-stroke solid $tw-clr-brdr-focus;
       }
     }
 
@@ -78,7 +78,7 @@
         left: calc(#{-$tw-sz-btn-stroke} * 2);
         right: calc(#{-$tw-sz-btn-stroke} * 2);
         border-radius: calc(#{$tw-sz-btn-medium-height + $tw-sz-btn-stroke * 4} / 2);
-        border: $tw-sz-btn-stroke solid $tw-clr-btn-stroke-focus;
+        border: $tw-sz-btn-stroke solid $tw-clr-brdr-focus;
       }
     }
     &.button-with-icon {
@@ -120,7 +120,7 @@
         left: calc(#{-$tw-sz-btn-stroke} * 2);
         right: calc(#{-$tw-sz-btn-stroke} * 2);
         border-radius: calc(#{$tw-sz-btn-large-height + $tw-sz-btn-stroke * 4} / 2);
-        border: $tw-sz-btn-stroke solid $tw-clr-btn-stroke-focus;
+        border: $tw-sz-btn-stroke solid $tw-clr-brdr-focus;
       }
     }
     &.button-with-icon {
@@ -161,7 +161,7 @@
         left: calc(#{-$tw-sz-btn-stroke} * 2);
         right: calc(#{-$tw-sz-btn-stroke} * 2);
         border-radius: calc(#{$tw-sz-btn-x-large-height + $tw-sz-btn-stroke * 4} / 2);
-        border: $tw-sz-btn-stroke solid $tw-clr-btn-stroke-focus;
+        border: $tw-sz-btn-stroke solid $tw-clr-brdr-focus;
       }
     }
     &.button-with-icon {
@@ -189,44 +189,44 @@
 }
 
 .productive-primary {
-  background-color: $tw-clr-btn-productive-primary-fill;
-  color: $tw-clr-btn-productive-primary-label;
+  background-color: $tw-clr-bg-brand;
+  color: $tw-clr-txt-on-brand;
 
   svg {
-    fill: $tw-clr-btn-productive-primary-label;
+    fill: $tw-clr-txt-on-brand;
   }
 
   &:hover {
-    background: $tw-clr-btn-productive-primary-fill-hover;
+    background: $tw-clr-bg-brand-hover;
   }
 
   &:active {
-    background-color: $tw-clr-btn-productive-primary-fill-active;
+    background-color: $tw-clr-bg-brand-active;
   }
 
   &:disabled {
-    background-color: rgba($tw-clr-btn-productive-primary-fill, 0.4);
-    color: rgba($tw-clr-btn-productive-primary-label, 0.4);
+    background-color: rgba($tw-clr-bg-brand, 0.4);
+    color: rgba($tw-clr-txt-on-brand, 0.4);
     svg {
-      fill: rgba($tw-clr-btn-productive-primary-label, 0.4);
+      fill: rgba($tw-clr-txt-on-brand, 0.4);
     }
   }
 }
 
 .productive-secondary {
-  background-color: $tw-clr-btn-productive-secondary-fill;
-  color: $tw-clr-btn-productive-secondary-label;
+  background-color: $tw-clr-bg-brand-ghost;
+  color: $tw-clr-txt-brand;
   svg {
-    fill: $tw-clr-btn-productive-secondary-label;
+    fill: $tw-clr-txt-brand;
   }
 
-  border: $tw-sz-btn-stroke solid $tw-clr-btn-productive-secondary-stroke;
+  border: $tw-sz-btn-stroke solid $tw-clr-brdr-brand;
   &:hover {
-    background: $tw-clr-btn-productive-secondary-fill-hover;
+    background: $tw-clr-bg-brand-ghost-hover;
   }
 
   &:active {
-    background-color: $tw-clr-btn-productive-secondary-fill-active;
+    background-color: $tw-clr-bg-brand-ghost-active;
   }
 
   &:focus {
@@ -267,51 +267,51 @@
   }
 
   &:disabled {
-    background-color: rgba($tw-clr-btn-productive-secondary-fill, 0.4);
-    border: $tw-sz-btn-stroke solid rgba($tw-clr-btn-productive-secondary-stroke, 0.4);
-    color: rgba($tw-clr-btn-productive-secondary-label, 0.4);
+    background-color: rgba($tw-clr-bg-brand-ghost, 0.4);
+    border: $tw-sz-btn-stroke solid rgba($tw-clr-brdr-brand, 0.4);
+    color: rgba($tw-clr-txt-brand, 0.4);
     svg {
-      fill: rgba($tw-clr-btn-productive-secondary-label, 0.4);
+      fill: rgba($tw-clr-txt-brand, 0.4);
     }
   }
 }
 
 .passive-primary {
-  background-color: $tw-clr-btn-passive-primary-fill;
-  color: $tw-clr-btn-passive-primary-label;
+  background-color: $tw-clr-bg-tertiary;
+  color: $tw-clr-txt;
   svg {
-    fill: $tw-clr-btn-passive-primary-label;
+    fill: $tw-clr-txt;
   }
   &:hover {
-    background: $tw-clr-btn-passive-primary-fill-hover;
+    background: $tw-clr-bg-tertiary-hover;
   }
 
   &:active {
-    background-color: $tw-clr-btn-passive-primary-fill-active;
+    background-color: $tw-clr-bg-tertiary-active;
   }
 
   &:disabled {
-    background-color: rgba($tw-clr-btn-passive-primary-fill, 0.4);
-    color: rgba($tw-clr-btn-passive-primary-label, 0.4);
+    background-color: rgba($tw-clr-bg-tertiary, 0.4);
+    color: rgba($tw-clr-txt, 0.4);
     svg {
-      fill: rgba($tw-clr-btn-passive-primary-label, 0.4);
+      fill: rgba($tw-clr-txt, 0.4);
     }
   }
 }
 
 .passive-secondary {
-  background-color: $tw-clr-btn-passive-secondary-fill;
-  color: $tw-clr-btn-passive-secondary-label;
+  background-color: $tw-clr-bg-ghost;
+  color: $tw-clr-txt;
   svg {
-    fill: $tw-clr-btn-passive-secondary-label;
+    fill: $tw-clr-txt;
   }
-  border: $tw-sz-btn-stroke solid $tw-clr-btn-passive-secondary-stroke;
+  border: $tw-sz-btn-stroke solid $tw-clr-brdr;
   &:hover {
-    background: $tw-clr-btn-passive-secondary-fill-hover;
+    background: $tw-clr-bg-ghost-hover;
   }
 
   &:active {
-    background-color: $tw-clr-btn-passive-secondary-fill-active;
+    background-color: $tw-clr-bg-ghost-active;
   }
 
   &:focus {
@@ -324,11 +324,11 @@
   }
 
   &:disabled {
-    background-color: rgba($tw-clr-btn-passive-secondary-fill, 0.4);
-    border: $tw-sz-btn-stroke solid rgba($tw-clr-btn-passive-secondary-stroke, 0.4);
-    color: rgba($tw-clr-btn-passive-secondary-label, 0.4);
+    background-color: rgba($tw-clr-bg-ghost, 0.4);
+    border: $tw-sz-btn-stroke solid rgba($tw-clr-brdr, 0.4);
+    color: rgba($tw-clr-txt, 0.4);
     svg {
-      fill: rgba($tw-clr-btn-passive-secondary-label, 0.4);
+      fill: rgba($tw-clr-txt, 0.4);
     }
   }
 
@@ -362,49 +362,49 @@
 }
 
 .destructive-primary {
-  background-color: $tw-clr-btn-destructive-primary-fill;
-  color: $tw-clr-btn-destructive-primary-label;
+  background-color: $tw-clr-bg-danger;
+  color: $tw-clr-txt-on-danger;
   svg {
-    fill: $tw-clr-btn-destructive-primary-label;
+    fill: $tw-clr-txt-on-danger;
   }
   &:hover {
-    background: $tw-clr-btn-destructive-primary-fill-hover;
+    background: $tw-clr-bg-danger-hover;
   }
 
   &:active {
-    background-color: $tw-clr-btn-destructive-primary-fill-active;
+    background-color: $tw-clr-bg-danger-active;
   }
 
   &:disabled {
-    background-color: rgba($tw-clr-btn-destructive-primary-fill, 0.4);
-    color: rgba($tw-clr-btn-destructive-primary-label, 0.4);
+    background-color: rgba($tw-clr-bg-danger, 0.4);
+    color: rgba($tw-clr-txt-on-danger, 0.4);
     svg {
-      fill: rgba($tw-clr-btn-destructive-primary-label, 0.4);
+      fill: rgba($tw-clr-txt-on-danger, 0.4);
     }
   }
 }
 
 .destructive-secondary {
-  background-color: $tw-clr-btn-destructive-secondary-fill;
-  color: $tw-clr-btn-destructive-secondary-label;
+  background-color: $tw-clr-bg-danger-ghost;
+  color: $tw-clr-txt-danger;
   svg {
-    fill: $tw-clr-btn-destructive-secondary-label;
+    fill: $tw-clr-txt-danger;
   }
-  border: $tw-sz-btn-stroke solid $tw-clr-btn-destructive-secondary-stroke;
+  border: $tw-sz-btn-stroke solid $tw-clr-brdr-danger;
   &:hover {
-    background: $tw-clr-btn-destructive-secondary-fill-hover;
+    background: $tw-clr-bg-danger-ghost-hover;
   }
 
   &:active {
-    background-color: $tw-clr-btn-destructive-secondary-fill-active;
+    background-color: $tw-clr-bg-danger-ghost-active;
   }
 
   &:disabled {
-    background-color: rgba($tw-clr-btn-destructive-secondary-fill, 0.4);
-    border: $tw-sz-btn-stroke solid rgba($tw-clr-btn-destructive-secondary-stroke, 0.4);
-    color: rgba($tw-clr-btn-destructive-secondary-label, 0.4);
+    background-color: rgba($tw-clr-bg-danger-ghost, 0.4);
+    border: $tw-sz-btn-stroke solid rgba($tw-clr-brdr-danger, 0.4);
+    color: rgba($tw-clr-txt-danger, 0.4);
     svg {
-      fill: rgba($tw-clr-btn-destructive-secondary-label, 0.4);
+      fill: rgba($tw-clr-txt-danger, 0.4);
     }
   }
 

--- a/src/components/DatePicker/styles.scss
+++ b/src/components/DatePicker/styles.scss
@@ -14,7 +14,7 @@
     font-size: $tw-fnt-frm-fld-label-font-size;
     font-weight: $tw-fnt-frm-fld-label-font-weight;
     line-height: $tw-fnt-frm-fld-label-line-height;
-    color: $tw-clr-frm-fld-label;
+    color: $tw-clr-txt-secondary;
     margin-bottom: $tw-spc-base-xx-small;
     display: block;
     width: 100%;
@@ -23,15 +23,15 @@
 
   &--error {
     .MuiInputBase-root {
-      border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke-error;
-      background-color: $tw-clr-frm-fld-text-input-fill-error;
+      border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-danger;
+      background-color: $tw-clr-bg-danger-tertiary;
 
       &:hover {
-        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke-error;
+        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-danger;
       }
 
       &:active {
-        border: $tw-sz-frm-fld-text-input-stroke-active solid $tw-clr-frm-fld-text-input-stroke-error;
+        border: $tw-sz-frm-fld-text-input-stroke-active solid $tw-clr-brdr-danger;
       }
     }
   }
@@ -45,12 +45,12 @@
       font-size: $tw-fnt-frm-fld-error-text-font-size;
       font-weight: $tw-fnt-frm-fld-error-text-font-weight;
       line-height: $tw-fnt-frm-fld-error-text-line-height;
-      color: $tw-clr-frm-fld-error-text;
+      color: $tw-clr-txt-danger;
       width: 100%;
       max-width: 100%;
 
       &--icon {
-        fill: $tw-clr-frm-fld-error-text;
+        fill: $tw-clr-txt-danger;
         width: $tw-fnt-frm-fld-error-text-line-height;
         height: $tw-fnt-frm-fld-error-text-line-height;
         margin-right: $tw-spc-base-x-small;
@@ -59,7 +59,7 @@
   }
 
   .MuiInputBase-root {
-    border: 1px solid $tw-clr-base-semantic-passive;
+    border: 1px solid $tw-clr-bg-info;
     position: unset;
   }
 

--- a/src/components/DatePicker/styles.scss
+++ b/src/components/DatePicker/styles.scss
@@ -1,4 +1,5 @@
 @import '../../style-dictionary-dist/textfield_variables.scss';
+@import '../../style-dictionary-dist2/terraware.scss';
 
 @font-face {
   font-family: 'Inter';

--- a/src/components/DialogBox/styles.scss
+++ b/src/components/DialogBox/styles.scss
@@ -1,4 +1,5 @@
 @import '../../style-dictionary-dist/dialogBox_variables.scss';
+@import '../../style-dictionary-dist2/terraware.scss';
 
 @font-face {
   font-family: 'Inter';

--- a/src/components/DialogBox/styles.scss
+++ b/src/components/DialogBox/styles.scss
@@ -40,7 +40,7 @@
 }
 
 .dialog-box {
-  border: 1px solid $tw-clr-dvdr-fill;
+  border: 1px solid $tw-clr-brdr-tertiary;
   box-shadow: $tw-elvtn-base-800;
   border-radius: $tw-sz-base-small;
   display: flex;
@@ -69,7 +69,7 @@
 
   &--header {
     background-color: $tw-clr-base-gray-050;
-    border-bottom: 1px solid $tw-clr-dvdr-fill;
+    border-bottom: 1px solid $tw-clr-brdr-tertiary;
     padding: $tw-spc-base-small $tw-spc-base-medium;
     display: flex;
     justify-content: space-between;
@@ -80,14 +80,14 @@
       font-size: $tw-fnt-dlg-bx-title-font-size;
       font-weight: $tw-fnt-dlg-bx-title-font-weight;
       line-height: $tw-fnt-dlg-bx-title-line-height;
-      color: $tw-clr-text-fill;
+      color: $tw-clr-txt;
       text-align: center;
       margin: 0;
       width: 100%;
     }
 
     .icon-close {
-      fill: $tw-clr-icon-fill-passive;
+      fill: $tw-clr-icn-secondary;
       height: $tw-sz-base-medium;
       width: $tw-sz-base-medium;
     }
@@ -95,7 +95,7 @@
 
   &--body {
     background: $tw-clr-base-white;
-    border-bottom: 1px solid $tw-clr-dvdr-fill;
+    border-bottom: 1px solid $tw-clr-brdr-tertiary;
     padding: $tw-spc-base-medium;
     text-align: center;
     &.scrolled {
@@ -116,7 +116,7 @@
     font-size: $tw-fnt-dlg-bx-message-font-size;
     font-weight: $tw-fnt-dlg-bx-message-font-weight;
     line-height: $tw-fnt-dlg-bx-message-line-height;
-    color: $tw-clr-text-fill;
+    color: $tw-clr-txt;
     width: 100%;
     text-align: center;
   }

--- a/src/components/ErrorBox/styles.scss
+++ b/src/components/ErrorBox/styles.scss
@@ -12,7 +12,7 @@
   background: $tw-clr-base-red-050;
   padding: 16px;
   margin: 0 auto;
-  border: 1px solid $tw-clr-icon-fill-critical;
+  border: 1px solid $tw-clr-icn-danger;
   border-radius: 8px;
   flex-direction: column;
 
@@ -31,7 +31,7 @@
   font-size: $tw-fnt-base-font-size-body-02;
   font-weight: $tw-fnt-frm-fld-error-text-font-weight;
   line-height: $tw-fnt-frm-fld-error-text-line-height;
-  color: $tw-clr-text-fill;
+  color: $tw-clr-txt;
   display: block;
   width: 100%;
   max-width: 100%;
@@ -44,7 +44,7 @@
   font-size: $tw-fnt-base-font-size-body-02;
   font-weight: $tw-fnt-base-headline-01-semi-bold-font-weight;
   line-height: $tw-fnt-frm-fld-error-text-line-height;
-  color: $tw-clr-text-fill;
+  color: $tw-clr-txt;
   display: block;
   width: 100%;
   max-width: 100%;
@@ -58,6 +58,6 @@
 }
 
 .error-icon {
-  fill: $tw-clr-frm-fld-error-text;
+  fill: $tw-clr-txt-danger;
   margin-right: $tw-spc-base-x-small;
 }

--- a/src/components/ErrorBox/styles.scss
+++ b/src/components/ErrorBox/styles.scss
@@ -1,4 +1,5 @@
 @import '../../style-dictionary-dist/textfield_variables.scss';
+@import '../../style-dictionary-dist2/terraware.scss';
 
 @font-face {
   font-family: 'Inter';

--- a/src/components/Message/styles.scss
+++ b/src/components/Message/styles.scss
@@ -1,4 +1,5 @@
 @import '../../style-dictionary-dist/message_variables.scss';
+@import '../../style-dictionary-dist2/terraware.scss';
 
 @font-face {
   font-family: 'Inter';

--- a/src/components/Message/styles.scss
+++ b/src/components/Message/styles.scss
@@ -38,7 +38,7 @@
       font-size: $tw-fnt-mssg-title-font-size;
       font-weight: $tw-fnt-mssg-title-font-weight;
       line-height: $tw-fnt-mssg-title-line-height;
-      color: $tw-clr-text-fill;
+      color: $tw-clr-txt;
       padding: 0;
       margin: 0 0 $tw-spc-base-x-small 0;
     }
@@ -53,7 +53,7 @@
       font-size: $tw-fnt-mssg-body-font-size;
       font-weight: $tw-fnt-mssg-body-font-weight;
       line-height: $tw-fnt-mssg-body-line-height;
-      color: $tw-clr-text-fill;
+      color: $tw-clr-txt;
       padding: 0;
       margin: 0;
     }
@@ -84,7 +84,7 @@
     font-size: $tw-fnt-mssg-body-font-size;
     font-weight: $tw-fnt-mssg-body-font-weight;
     line-height: $tw-fnt-mssg-body-line-height;
-    color: $tw-clr-text-fill-productive;
+    color: $tw-clr-txt-brand;
     margin-left: $tw-spc-base-x-small;
     background: none;
     border: 0;
@@ -95,7 +95,7 @@
   &--left-side {
     padding: $tw-spc-base-small $tw-spc-base-small 0 $tw-spc-base-small;
     .left-side--icon {
-      fill: $tw-clr-icon-fill-text-inv;
+      fill: $tw-clr-icn-inverse;
       width: $tw-sz-base-medium;
       height: $tw-sz-base-medium;
     }
@@ -103,14 +103,14 @@
 
   .toast-message--close-icon {
     margin-left: $tw-spc-base-x-small;
-    fill: $tw-clr-icon-fill-passive;
+    fill: $tw-clr-icn-secondary;
     width: $tw-sz-base-medium;
     height: $tw-sz-base-medium;
   }
 
   .page-message--close-icon {
     margin-left: $tw-spc-base-x-small;
-    fill: $tw-clr-icon-fill-passive;
+    fill: $tw-clr-icn-secondary;
     width: $tw-sz-base-medium;
     height: $tw-sz-base-medium;
   }
@@ -124,72 +124,72 @@
 
   &--info {
     &.tw-message--page {
-      border: 1px solid $tw-clr-base-semantic-passive;
-      background-color: $tw-clr-base-semantic-passive-bg;
+      border: 1px solid $tw-clr-bg-info;
+      background-color: $tw-clr-bg-info-tertiary;
       .main-content--icon {
-        fill:$tw-clr-base-semantic-passive;
+        fill:$tw-clr-bg-info;
       }
     }
-    border: 1px solid $tw-clr-icon-fill-passive;
+    border: 1px solid $tw-clr-icn-secondary;
     &.tw-message--toast {
-      box-shadow: 0 2px $tw-clr-icon-fill-passive;
+      box-shadow: 0 2px $tw-clr-icn-secondary;
     }
     .tw-message--left-side {
-      background-color: $tw-clr-icon-fill-passive;
+      background-color: $tw-clr-icn-secondary;
     }
   }
 
   &--critical {
     &.tw-message--page {
-      border: 1px solid $tw-clr-base-semantic-critical;
-      background-color: $tw-clr-base-semantic-critical-bg;
+      border: 1px solid $tw-clr-bg-danger;
+      background-color: $tw-clr-bg-danger-tertiary;
 
       .main-content--icon {
-        fill: $tw-clr-base-semantic-critical
+        fill: $tw-clr-bg-danger
       }
     }
-    border: 1px solid $tw-clr-icon-fill-critical;
+    border: 1px solid $tw-clr-icn-danger;
     &.tw-message--toast {
-      box-shadow: 0 2px $tw-clr-icon-fill-critical;
+      box-shadow: 0 2px $tw-clr-icn-danger;
     }
     .tw-message--left-side {
-      background-color: $tw-clr-icon-fill-critical;
+      background-color: $tw-clr-icn-danger;
     }
   }
 
   &--warning {
     &.tw-message--page {
-      border: 1px solid $tw-clr-base-semantic-warning;
-      background-color: $tw-clr-base-semantic-warning-bg;
+      border: 1px solid $tw-clr-bg-warning;
+      background-color: $tw-clr-bg-warning-tertiary;
 
       .main-content--icon {
-        fill: $tw-clr-base-semantic-warning;
+        fill: $tw-clr-bg-warning;
       }
     }
-    border: 1px solid $tw-clr-icon-fill-warning;
+    border: 1px solid $tw-clr-icn-warning;
     &.tw-message--toast {
-      box-shadow: 0 2px $tw-clr-icon-fill-warning;
+      box-shadow: 0 2px $tw-clr-icn-warning;
     }
     .tw-message--left-side {
-      background-color: $tw-clr-icon-fill-warning;
+      background-color: $tw-clr-icn-warning;
     }
   }
 
   &--success {
     &.tw-message--page {
-      border: 1px solid $tw-clr-base-semantic-success;
-      background-color: $tw-clr-base-semantic-success-bg;
+      border: 1px solid $tw-clr-bg-success;
+      background-color: $tw-clr-bg-success-tertiary;
 
       .main-content--icon {
-        fill: $tw-clr-base-semantic-success;
+        fill: $tw-clr-bg-success;
       }
     }
-    border: 1px solid $tw-clr-icon-fill-success;
+    border: 1px solid $tw-clr-icn-success;
     &.tw-message--toast {
-      box-shadow: 0 2px $tw-clr-icon-fill-success;
+      box-shadow: 0 2px $tw-clr-icn-success;
     }
     .tw-message--left-side {
-      background-color: $tw-clr-icon-fill-success;
+      background-color: $tw-clr-icn-success;
     }
   }
 

--- a/src/components/Navbar/styles.scss
+++ b/src/components/Navbar/styles.scss
@@ -1,4 +1,5 @@
 @import '../../style-dictionary-dist/navbar_variables.scss';
+@import '../../style-dictionary-dist2/terraware.scss';
 
 @font-face {
   font-family: 'Inter';

--- a/src/components/Navbar/styles.scss
+++ b/src/components/Navbar/styles.scss
@@ -6,7 +6,7 @@
 }
 
 .navbar {
-  background-color: $tw-clr-nvgtn-side-nav-item-fill;
+  background-color: $tw-clr-bg-hover;
   height: 100%;
   position: fixed;
   z-index: 1100;
@@ -15,7 +15,7 @@
   flex-direction: column;
 
   .logo {
-    background-color: $tw-clr-nvgtn-side-nav-item-fill;
+    background-color: $tw-clr-bg-hover;
     padding-bottom: $tw-spc-base-small 0;
     margin-bottom: $tw-spc-base-small 0;
 
@@ -25,10 +25,10 @@
     }
   }
   .nav-section {
-    background-color: $tw-clr-nvgtn-side-nav-section-fill;
+    background-color: $tw-clr-bg-hover;
     padding: $tw-spc-base-x-small $tw-spc-base-small;
     .divider {
-      border-top: $tw-sz-dvdr-stroke solid $tw-clr-dvdr-fill;
+      border-top: $tw-sz-dvdr-stroke solid $tw-clr-brdr-tertiary;
     }
 
     &--title {
@@ -37,7 +37,7 @@
       font-weight: $tw-fnt-nvgtn-side-nav-section-title-font-weight;
       line-height: $tw-fnt-nvgtn-side-nav-section-title-line-height;
       text-transform: $tw-fnt-nvgtn-side-nav-section-title-text-transform;
-      color: $tw-clr-nvgtn-side-nav-section-title;
+      color: $tw-clr-txt;
       display: block;
       margin-top: $tw-spc-base-small;
     }
@@ -48,8 +48,8 @@
     font-size: $tw-fnt-nvgtn-side-nav-item-label-font-size;
     font-weight: $tw-fnt-nvgtn-side-nav-item-label-font-weight;
     line-height: $tw-fnt-nvgtn-side-nav-item-label-line-height;
-    color: $tw-clr-nvgtn-side-nav-item-label;
-    background-color: $tw-clr-nvgtn-side-nav-item-fill;
+    color: $tw-clr-txt;
+    background-color: $tw-clr-bg-hover;
 
     .nav-item-content {
       padding: $tw-sz-base-small;
@@ -71,14 +71,14 @@
     }
 
     &:hover {
-      background-color: $tw-clr-nvgtn-side-nav-item-fill-hover;
+      background-color: $tw-clr-bg-secondary;
       // .nav-item {
-      //   background-color: $tw-clr-nvgtn-side-nav-item-fill-hover;
+      //   background-color: $tw-clr-bg-secondary;
       // }
     }
 
     &:active {
-      background-color: $tw-clr-nvgtn-side-nav-item-fill-active;
+      background-color: $tw-clr-bg-secondary-hover;
     }
 
     button {
@@ -89,27 +89,27 @@
     }
 
     &--children-selected {
-      background-color: $tw-clr-nvgtn-side-nav-item-fill-active;
+      background-color: $tw-clr-bg-secondary-hover;
 
       &:hover {
-        background-color: $tw-clr-nvgtn-side-nav-item-fill-active;
+        background-color: $tw-clr-bg-secondary-hover;
 
         & > .nav-item-content {
-          background-color: $tw-clr-nvgtn-side-nav-item-fill-hover;
+          background-color: $tw-clr-bg-secondary;
         }
       }
 
       .nav-item {
-        background-color: $tw-clr-nvgtn-side-nav-item-fill-active;
+        background-color: $tw-clr-bg-secondary-hover;
 
         &:hover {
-          background-color: $tw-clr-nvgtn-side-nav-item-fill-hover;
+          background-color: $tw-clr-bg-secondary;
         }
       }
     }
 
     &--selected {
-      background-color: $tw-clr-nvgtn-side-nav-item-fill-active;
+      background-color: $tw-clr-bg-secondary-hover;
       position: relative;
     }
 
@@ -121,11 +121,11 @@
       top: 0;
       bottom: 0;
       width: $tw-sz-nvgtn-side-nav-item-indicator;
-      background-color: $tw-clr-nvgtn-side-nav-item-indicator-fill;
+      background-color: $tw-clr-bg-selected;
     }
 
     &--icon {
-      fill: $tw-clr-icon-fill-text;
+      fill: $tw-clr-icn;
       margin-right: $tw-spc-base-x-small;
       line-height: $tw-sz-icon-small;
       height: $tw-sz-icon-small;
@@ -138,13 +138,13 @@
       margin-left: $tw-spc-base-x-small;
 
       path {
-        fill: $tw-clr-icon-fill-passive;
+        fill: $tw-clr-icn-secondary;
       }
     }
 
     .subnavbar .nav-item {
       padding-right: $tw-spc-base-small;
-      background-color: $tw-clr-nvgtn-side-nav-item-fill-active;
+      background-color: $tw-clr-bg-secondary-hover;
 
       &-content {
         padding-left: calc(#{$tw-spc-base-small} * 2);

--- a/src/components/Select/styles.scss
+++ b/src/components/Select/styles.scss
@@ -34,7 +34,7 @@
     font-size: $tw-fnt-frm-fld-help-text-font-size;
     font-weight: $tw-fnt-frm-fld-help-text-font-weight;
     line-height: $tw-fnt-frm-fld-help-text-line-height;
-    color: $tw-clr-frm-fld-help-text;
+    color: $tw-clr-txt-secondary;
     display: block;
     width: 100%;
     max-width: 100%;
@@ -46,7 +46,7 @@
     font-size: $tw-fnt-frm-fld-text-value-font-size;
     font-weight: $tw-fnt-frm-fld-text-value-font-weight;
     line-height: $tw-fnt-frm-fld-text-value-line-height;
-    color: $tw-clr-frm-fld-value;
+    color: $tw-clr-txt;
     padding-top: 0;
     padding-bottom: 0;
     &::placeholder {
@@ -62,20 +62,20 @@
   }
 
   .textfield-value {
-    background-color: $tw-clr-frm-fld-text-input-fill;
-    border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke;
+    background-color: $tw-clr-bg;
+    border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-secondary;
     padding: $tw-spc-base-x-small;
     border-radius: $tw-rds-frm-fld-text-input;
     border-width: $tw-sz-frm-fld-text-input-stroke;
     display: flex;
 
     &:hover {
-      border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke-hover;
+      border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-hover;
     }
 
     &:active {
-      border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke-hover;
-      outline: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke-hover;
+      border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-hover;
+      outline: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-hover;
     }
 
     input {
@@ -85,7 +85,7 @@
       font-size: $tw-fnt-frm-fld-text-value-font-size;
       font-weight: $tw-fnt-frm-fld-text-value-font-weight;
       line-height: $tw-fnt-frm-fld-text-value-line-height;
-      color: $tw-clr-frm-fld-value;
+      color: $tw-clr-txt;
       background: transparent;
       padding-top: 0;
       padding-bottom: 0;
@@ -114,62 +114,62 @@
       opacity: $tw-opcty-semantic-off;
       pointer-events: none;
       &:hover {
-        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke;
+        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-secondary;
       }
 
       &:active {
-        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke;
+        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-secondary;
       }
     }
 
     &--icon-right {
       width: $tw-fnt-frm-fld-text-value-line-height;
       height: $tw-fnt-frm-fld-text-value-line-height;
-      fill: $tw-clr-frm-fld-value;
+      fill: $tw-clr-txt;
     }
 
     &--icon-left {
       width: $tw-fnt-frm-fld-text-value-line-height;
       height: $tw-fnt-frm-fld-text-value-line-height;
-      fill: $tw-clr-frm-fld-value;
+      fill: $tw-clr-txt;
       margin-right: $tw-spc-base-x-small;
     }
 
     &--error {
-      border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke-error;
-      background-color: $tw-clr-frm-fld-text-input-fill-error;
+      border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-danger;
+      background-color: $tw-clr-bg-danger-tertiary;
 
       &:hover {
-        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke-error;
+        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-danger;
       }
 
       &:active {
-        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke-error;
-        outline: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke-error;
+        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-danger;
+        outline: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-danger;
       }
     }
 
     &--warning {
-      border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke-warning;
-      background-color: $tw-clr-frm-fld-text-input-fill-warning;
+      border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-warning;
+      background-color: $tw-clr-bg-warning-tertiary;
 
       &:hover {
-        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke-warning;
+        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-warning;
       }
 
       &:active {
-        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke-warning;
-        outline: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke-warning;
+        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-warning;
+        outline: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-warning;
       }
     }
 
     &--readonly {
       &:hover {
-        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke;
+        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-secondary;
       }
 
       &:active {
-        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke;
+        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-secondary;
       }
     }
 
@@ -183,13 +183,13 @@
     font-size: $tw-fnt-frm-fld-error-text-font-size;
     font-weight: $tw-fnt-frm-fld-error-text-font-weight;
     line-height: $tw-fnt-frm-fld-error-text-line-height;
-    color: $tw-clr-frm-fld-error-text;
+    color: $tw-clr-txt-danger;
     display: block;
     width: 100%;
     max-width: 100%;
 
     &--icon {
-      fill: $tw-clr-frm-fld-error-text;
+      fill: $tw-clr-txt-danger;
       width: $tw-fnt-frm-fld-error-text-line-height;
       height: $tw-fnt-frm-fld-error-text-line-height;
       margin-right: $tw-spc-base-x-small;
@@ -201,13 +201,13 @@
     font-size: $tw-fnt-frm-fld-warning-text-font-size;
     font-weight: $tw-fnt-frm-fld-warning-text-font-weight;
     line-height: $tw-fnt-frm-fld-warning-text-line-height;
-    color: $tw-clr-frm-fld-warning-text;
+    color: $tw-clr-txt-warning;
     display: block;
     width: 100%;
     max-width: 100%;
 
     &--icon {
-      fill: $tw-clr-frm-fld-warning-text;
+      fill: $tw-clr-txt-warning;
       width: $tw-fnt-frm-fld-error-text-line-height;
       height: $tw-fnt-frm-fld-error-text-line-height;
       margin-right: $tw-spc-base-x-small;
@@ -228,8 +228,8 @@
     top: 42px;
     list-style-type: none;
     padding: $tw-spc-base-x-small 0;
-    background: $tw-clr-frm-fld-select-menu-fill;
-    border: 1px solid $tw-clr-frm-fld-select-menu-stroke;
+    background: $tw-clr-bg;
+    border: 1px solid $tw-clr-brdr-secondary;
     margin: 0;
     margin-top: $tw-spc-base-xx-small;
     border-radius: $tw-rds-frm-fld-text-input;
@@ -250,18 +250,18 @@
       cursor: pointer;
 
       &:hover {
-        background-color: $tw-clr-frm-fld-select-menu-item-fill-hover;
-        color: $tw-clr-frm-fld-value;
+        background-color: $tw-clr-bg-selected-ghost-hover;
+        color: $tw-clr-txt;
       }
 
       &:active {
-        background-color: $tw-clr-frm-fld-select-menu-item-fill-active;
-        color: $tw-clr-frm-fld-value;
+        background-color: $tw-clr-bg-selected-ghost-active;
+        color: $tw-clr-txt;
       }
 
       &--selected {
-        background-color: $tw-clr-frm-fld-select-menu-item-fill-selected;
-        color: $tw-clr-frm-fld-select-value-selected;
+        background-color: $tw-clr-bg-selected;
+        color: $tw-clr-txt-on-selected;
       }
 
       &--disabled {

--- a/src/components/Select/styles.scss
+++ b/src/components/Select/styles.scss
@@ -1,4 +1,5 @@
 @import '../../style-dictionary-dist/textfield_variables.scss';
+@import '../../style-dictionary-dist2/terraware.scss';
 
 @font-face {
   font-family: 'Inter';

--- a/src/components/Textfield/styles.scss
+++ b/src/components/Textfield/styles.scss
@@ -15,7 +15,7 @@
     font-size: $tw-fnt-frm-fld-label-font-size;
     font-weight: $tw-fnt-frm-fld-label-font-weight;
     line-height: $tw-fnt-frm-fld-label-line-height;
-    color: $tw-clr-frm-fld-label;
+    color: $tw-clr-txt-secondary;
     margin-bottom: $tw-spc-base-xx-small;
     display: block;
     width: 100%;
@@ -29,7 +29,7 @@
     &--icon-tooltip {
       width: $tw-fnt-frm-fld-label-line-height;
       height: $tw-fnt-frm-fld-label-line-height;
-      fill: $tw-clr-frm-fld-value;
+      fill: $tw-clr-txt;
     }
   }
 
@@ -38,7 +38,7 @@
     font-size: $tw-fnt-frm-fld-help-text-font-size;
     font-weight: $tw-fnt-frm-fld-help-text-font-weight;
     line-height: $tw-fnt-frm-fld-help-text-line-height;
-    color: $tw-clr-frm-fld-help-text;
+    color: $tw-clr-txt-secondary;
     display: block;
     width: 100%;
     max-width: 100%;
@@ -50,7 +50,7 @@
     font-size: $tw-fnt-frm-fld-text-value-font-size;
     font-weight: $tw-fnt-frm-fld-text-value-font-weight;
     line-height: $tw-fnt-frm-fld-text-value-line-height;
-    color: $tw-clr-frm-fld-value;
+    color: $tw-clr-txt;
     padding-top: 0;
     padding-bottom: 0;
     &::placeholder {
@@ -66,8 +66,8 @@
   }
 
   .textfield-value {
-    background-color: $tw-clr-frm-fld-text-input-fill;
-    border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke;
+    background-color: $tw-clr-bg;
+    border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-secondary;
     padding: $tw-spc-base-x-small;
     border-radius: $tw-rds-frm-fld-text-input;
     border-width: $tw-sz-frm-fld-text-input-stroke;
@@ -76,12 +76,12 @@
     display: flex;
 
     &:hover {
-      border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke-hover;
+      border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-hover;
     }
 
     &:active {
-      border: math.div($tw-sz-frm-fld-text-input-stroke-active, 2) solid $tw-clr-frm-fld-text-input-stroke-hover;
-      outline: math.div($tw-sz-frm-fld-text-input-stroke-active, 2) solid $tw-clr-frm-fld-text-input-stroke-hover;
+      border: math.div($tw-sz-frm-fld-text-input-stroke-active, 2) solid $tw-clr-brdr-hover;
+      outline: math.div($tw-sz-frm-fld-text-input-stroke-active, 2) solid $tw-clr-brdr-hover;
     }
 
     input {
@@ -91,7 +91,7 @@
       font-size: $tw-fnt-frm-fld-text-value-font-size;
       font-weight: $tw-fnt-frm-fld-text-value-font-weight;
       line-height: $tw-fnt-frm-fld-text-value-line-height;
-      color: $tw-clr-frm-fld-value;
+      color: $tw-clr-txt;
       background: transparent;
       padding-top: 0;
       padding-bottom: 0;
@@ -119,11 +119,11 @@
     &--disabled {
       opacity: $tw-opcty-semantic-off;
       &:hover {
-        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke;
+        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-secondary;
       }
 
       &:active {
-        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke;
+        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-secondary;
       }
     }
 
@@ -135,50 +135,50 @@
     &--icon-right {
       width: $tw-fnt-frm-fld-text-value-line-height;
       height: $tw-fnt-frm-fld-text-value-line-height;
-      fill: $tw-clr-frm-fld-value;
+      fill: $tw-clr-txt;
     }
 
     &--icon-left {
       width: $tw-fnt-frm-fld-text-value-line-height;
       height: $tw-fnt-frm-fld-text-value-line-height;
-      fill: $tw-clr-frm-fld-value;
+      fill: $tw-clr-txt;
       margin-right: $tw-spc-base-x-small;
     }
 
     &--error {
-      border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke-error;
-      background-color: $tw-clr-frm-fld-text-input-fill-error;
+      border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-danger;
+      background-color: $tw-clr-bg-danger-tertiary;
 
       &:hover {
-        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke-error;
+        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-danger;
       }
 
       &:active {
-        border: $tw-sz-frm-fld-text-input-stroke-active solid $tw-clr-frm-fld-text-input-stroke-error;
+        border: $tw-sz-frm-fld-text-input-stroke-active solid $tw-clr-brdr-danger;
       }
     }
 
     &--warning {
-      border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke-warning;
-      background-color: $tw-clr-frm-fld-text-input-fill-warning;
+      border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-warning;
+      background-color: $tw-clr-bg-warning-tertiary;
 
       &:hover {
-        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke-warning;
+        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-warning;
       }
 
       &:active {
-        border: $tw-sz-frm-fld-text-input-stroke-active solid $tw-clr-frm-fld-text-input-stroke-warning;
+        border: $tw-sz-frm-fld-text-input-stroke-active solid $tw-clr-brdr-warning;
       }
     }
 
     &--readonly {
-      background-color: $tw-clr-frm-fld-text-input-fill-read-only;
+      background-color: $tw-clr-bg-secondary;
       &:hover {
-        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke;
+        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-secondary;
       }
 
       &:active {
-        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-frm-fld-text-input-stroke;
+        border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-secondary;
       }
     }
   }
@@ -188,13 +188,13 @@
     font-size: $tw-fnt-frm-fld-error-text-font-size;
     font-weight: $tw-fnt-frm-fld-error-text-font-weight;
     line-height: $tw-fnt-frm-fld-error-text-line-height;
-    color: $tw-clr-frm-fld-error-text;
+    color: $tw-clr-txt-danger;
     display: block;
     width: 100%;
     max-width: 100%;
 
     &--icon {
-      fill: $tw-clr-frm-fld-error-text;
+      fill: $tw-clr-txt-danger;
       width: $tw-fnt-frm-fld-error-text-line-height;
       height: $tw-fnt-frm-fld-error-text-line-height;
       margin-right: $tw-spc-base-x-small;
@@ -206,13 +206,13 @@
     font-size: $tw-fnt-frm-fld-warning-text-font-size;
     font-weight: $tw-fnt-frm-fld-warning-text-font-weight;
     line-height: $tw-fnt-frm-fld-warning-text-line-height;
-    color: $tw-clr-frm-fld-warning-text;
+    color: $tw-clr-txt-warning;
     display: block;
     width: 100%;
     max-width: 100%;
 
     &--icon {
-      fill: $tw-clr-frm-fld-warning-text;
+      fill: $tw-clr-txt-warning;
       width: $tw-fnt-frm-fld-error-text-line-height;
       height: $tw-fnt-frm-fld-error-text-line-height;
       margin-right: $tw-spc-base-x-small;

--- a/src/components/Textfield/styles.scss
+++ b/src/components/Textfield/styles.scss
@@ -1,6 +1,7 @@
 @use 'sass:math';
 
 @import '../../style-dictionary-dist/textfield_variables.scss';
+@import '../../style-dictionary-dist2/terraware.scss';
 
 @font-face {
   font-family: 'Inter';


### PR DESCRIPTION
- import `terrware.scss` into stylesheets
- use new semantic color token names

mappings per the [semantic mapping spreadsheet](https://docs.google.com/spreadsheets/d/1ECFEO33DP0GgesPagynY5MIIx_4lFn3rJh_PWjcfqLI/edit?usp=sharing)