### PR TITLE
Send fromColumn value when clicking a column-row on table

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -45,7 +45,7 @@ export interface Props<T> {
   columns: TableColumnType[];
   rows: T[];
   Renderer?: (props: RendererProps<T>) => JSX.Element;
-  onSelect?: (value: T) => void;
+  onSelect?: (value: T, fromColumn?: string) => void;
   DetailsRenderer?: (props: DetailsRendererProps) => JSX.Element;
   sortComparator?: (a: T, b: T, orderBy: keyof T) => number;
   sortHandler?: (order: SortOrder, orderBy: string) => void;
@@ -203,7 +203,7 @@ export default function EnhancedTable<T>({
   return (
     <>
       {showTopBar && <EnhancedTableToolbar numSelected={selectedRows ? selectedRows.length : 0} topBarButtons={topBarButtons} />}
-      <TableContainer id={id} sx={{overflowX: 'visible'}}>
+      <TableContainer id={id} sx={{ overflowX: 'visible' }}>
         <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
           <Table stickyHeader={stickyHeader} aria-labelledby='tableTitle' size='medium' aria-label='enhanced table' className={classes.table}>
             <TableHeader
@@ -262,7 +262,7 @@ export default function EnhancedTable<T>({
                               row={row as T}
                               column={c}
                               value={row[c.key]}
-                              onRowClick={onSelect && controlledOnSelect ? () => onSelect(row as T) : onClick}
+                              onRowClick={onSelect && controlledOnSelect ? () => onSelect(row as T, c.key) : onClick}
                               reloadData={reloadData}
                             />
                           ))}


### PR DESCRIPTION
Return the column from where the row was clicked when executing rowClicked function. This change is needed because we need to open different modals on rowClick depending on the column on seedlings table. Tested with changes from withdrawal and details. 