### PR TITLE
SW-2040 Update passive icon-only button styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "1.0.54",
+  "version": "1.0.55",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/Button/styles.scss
+++ b/src/components/Button/styles.scss
@@ -204,7 +204,7 @@
     &.button-no-label.button-with-icon {
       padding-left: 6px;
       padding-right: 6px;
-      .tw-icon--small {
+      .tw-icon--medium {
         margin-right: 0;
       }
     }
@@ -219,7 +219,7 @@
     &.button-no-label.button-with-icon {
       padding-left: 8px;
       padding-right: 8px;
-      .tw-icon--small {
+      .tw-icon--large {
         margin-right: 0;
       }
     }
@@ -234,7 +234,7 @@
     &.button-no-label.button-with-icon {
       padding-left: 10px;
       padding-right: 10px;
-      .tw-icon--small {
+      .tw-icon--xlarge {
         margin-right: 0;
       }
     }
@@ -277,6 +277,14 @@
         (#{$tw-sz-btn-small-height} - (2 * #{$tw-sz-btn-stroke}) - #{$tw-fnt-btn-label-small-line-height}) / 2
       )
       calc((#{$tw-sz-btn-small-height} - 2 * #{$tw-sz-btn-stroke}) / 2);
+
+    &.button-no-label.button-with-icon {
+      padding-left: 4px;
+      padding-right: 4px;
+      .tw-icon--small {
+        margin-right: 0;
+      }
+    }
   }
 
   &--medium {
@@ -284,6 +292,14 @@
         (#{$tw-sz-btn-medium-height} - (2 * #{$tw-sz-btn-stroke}) - #{$tw-fnt-btn-label-medium-line-height}) / 2
       )
       calc((#{$tw-sz-btn-medium-height} - 2 * #{$tw-sz-btn-stroke}) / 2);
+
+    &.button-no-label.button-with-icon {
+      padding-left: 6px;
+      padding-right: 6px;
+      .tw-icon--medium {
+        margin-right: 0;
+      }
+    }
   }
 
   &--large {
@@ -291,6 +307,14 @@
         (#{$tw-sz-btn-large-height} - (2 * #{$tw-sz-btn-stroke}) - #{$tw-fnt-btn-label-large-line-height}) / 2
       )
       calc((#{$tw-sz-btn-large-height} - 2 * #{$tw-sz-btn-stroke}) / 2);
+
+    &.button-no-label.button-with-icon {
+      padding-left: 8px;
+      padding-right: 8px;
+      .tw-icon--large {
+        margin-right: 0;
+      }
+    }
   }
 
   &--xlarge {
@@ -298,6 +322,14 @@
         (#{$tw-sz-btn-x-large-height} - (2 * #{$tw-sz-btn-stroke}) - #{$tw-fnt-btn-label-x-large-line-height}) / 2
       )
       calc((#{$tw-sz-btn-x-large-height} - 2 * #{$tw-sz-btn-stroke}) / 2);
+
+    &.button-no-label.button-with-icon {
+      padding-left: 10px;
+      padding-right: 10px;
+      .tw-icon--xlarge {
+        margin-right: 0;
+      }
+    }
   }
 }
 
@@ -337,6 +369,14 @@
         (#{$tw-sz-btn-small-height} - (2 * #{$tw-sz-btn-stroke}) - #{$tw-fnt-btn-label-small-line-height}) / 2
       )
       calc((#{$tw-sz-btn-small-height} - 2 * #{$tw-sz-btn-stroke}) / 2);
+
+    &.button-no-label.button-with-icon {
+      padding-left: 4px;
+      padding-right: 4px;
+      .tw-icon--small {
+        margin-right: 0;
+      }
+    }
   }
 
   &--medium {
@@ -344,6 +384,14 @@
         (#{$tw-sz-btn-medium-height} - (2 * #{$tw-sz-btn-stroke}) - #{$tw-fnt-btn-label-medium-line-height}) / 2
       )
       calc((#{$tw-sz-btn-medium-height} - 2 * #{$tw-sz-btn-stroke}) / 2);
+
+    &.button-no-label.button-with-icon {
+      padding-left: 6px;
+      padding-right: 6px;
+      .tw-icon--medium {
+        margin-right: 0;
+      }
+    }
   }
 
   &--large {
@@ -351,6 +399,14 @@
         (#{$tw-sz-btn-large-height} - (2 * #{$tw-sz-btn-stroke}) - #{$tw-fnt-btn-label-large-line-height}) / 2
       )
       calc((#{$tw-sz-btn-large-height} - 2 * #{$tw-sz-btn-stroke}) / 2);
+
+    &.button-no-label.button-with-icon {
+      padding-left: 8px;
+      padding-right: 8px;
+      .tw-icon--large {
+        margin-right: 0;
+      }
+    }
   }
 
   &--xlarge {
@@ -358,5 +414,13 @@
         (#{$tw-sz-btn-x-large-height} - (2 * #{$tw-sz-btn-stroke}) - #{$tw-fnt-btn-label-x-large-line-height}) / 2
       )
       calc((#{$tw-sz-btn-x-large-height} - 2 * #{$tw-sz-btn-stroke}) / 2);
+
+    &.button-no-label.button-with-icon {
+      padding-left: 10px;
+      padding-right: 10px;
+      .tw-icon--medium {
+        margin-right: 0;
+      }
+    }
   }
 }


### PR DESCRIPTION
Forgot to include passive and secondary icon-only button styling updates with my last PR.  This should fix all icon-only buttons.
<img width="56" alt="Screen Shot 2022-11-01 at 9 55 07 AM" src="https://user-images.githubusercontent.com/104874529/199291438-97441cec-6a40-4aff-aaa8-07612eb611ae.png">
<img width="49" alt="Screen Shot 2022-11-01 at 9 55 13 AM" src="https://user-images.githubusercontent.com/104874529/199291444-c693169e-cdce-4dd5-beb6-af72ece6c8bf.png">
<img width="49" alt="Screen Shot 2022-11-01 at 9 55 31 AM" src="https://user-images.githubusercontent.com/104874529/199291447-9f6c5c24-c940-40aa-941d-52870d0eaec9.png">
<img width="43" alt="Screen Shot 2022-11-01 at 9 55 39 AM" src="https://user-images.githubusercontent.com/104874529/199291450-05242d3a-06aa-40ae-90ad-5cd34f268264.png">
<img width="48" alt="Screen Shot 2022-11-01 at 9 55 44 AM" src="https://user-images.githubusercontent.com/104874529/199291454-a4da0938-6fc0-4d9b-80fb-57f8cd1c54b9.png">
<img width="49" alt="Screen Shot 2022-11-01 at 9 55 50 AM" src="https://user-images.githubusercontent.com/104874529/199291458-e5838f8e-5286-4b23-aa08-e195528de51e.png">
