### PR TITLE
SW-2093 Select row only when clicking checkbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -252,7 +252,11 @@ export default function EnhancedTable<T>({
                         >
                           {showCheckbox && (
                             <TableCell padding='checkbox'>
-                              <Checkbox color='primary' checked={isItemSelected} />
+                              <Checkbox
+                                color='primary'
+                                checked={isItemSelected}
+                                onClick={(e) => (!isClickable || !isClickable(row as T) ? handleClick(e, row as T) : null)}
+                              />
                             </TableCell>
                           )}
                           {columns.map((c) => (


### PR DESCRIPTION
Table already had an option to make the row clickable or not. The problem was that if the row was not clickable, the checkbox didn't worked.

With this change if the row is clickable it will continue working as it used to, but if the row is not clickable only clicking on the checkbox will work.

Already tested with terraware-web