### PR TITLE
Adjust Cancel Icon Size for TextField

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/Textfield/Textfield.tsx
+++ b/src/components/Textfield/Textfield.tsx
@@ -91,7 +91,7 @@ export default function TextField(props: Props): JSX.Element {
 
     return (
       <button onClick={onClickRightIcon} className='textfield-value--icon-container'>
-        <Icon name={iconRight!} className='textfield-value--icon-right' />
+        <Icon name={iconRight!} className={`textfield-value--icon-right${iconRight === 'cancel' ? '--cancel' : ''}`} />
       </button>
     );
   };

--- a/src/components/Textfield/styles.scss
+++ b/src/components/Textfield/styles.scss
@@ -142,6 +142,15 @@
       fill: $tw-clr-icn-secondary;
       margin-left: $tw-spc-base-x-small;
       vertical-align: top;
+
+      &--cancel {
+        width: $tw-sz-base-small;
+        height: $tw-sz-base-small;
+        fill: $tw-clr-icn-secondary;
+        margin-left: $tw-spc-base-x-small;
+        padding-right: $tw-spc-base-xx-small;
+        vertical-align: top;
+      }
     }
 
     &--icon-left {

--- a/src/stories/TextfieldNew.stories.tsx
+++ b/src/stories/TextfieldNew.stories.tsx
@@ -12,7 +12,7 @@ export default {
       control: { type: 'radio' },
     },
     iconRight: {
-      options: ['calendar', 'chevronDown', null],
+      options: ['calendar', 'chevronDown', 'cancel', null],
       control: { type: 'radio' },
     },
     type: {


### PR DESCRIPTION
- when used as right icon,
  - make it 16x16
  - add some padding-right
- add right icon cancel option to story
<img width="610" alt="image" src="https://user-images.githubusercontent.com/114949086/202804725-4d5cd142-b854-49c1-b0c6-38a79b76db30.png">
