### PR TITLE
Fix TextField Cancel Icon Sizing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/Textfield/styles.scss
+++ b/src/components/Textfield/styles.scss
@@ -148,7 +148,7 @@
         height: $tw-sz-base-small;
         fill: $tw-clr-icn-secondary;
         margin-left: $tw-spc-base-x-small;
-        padding-right: $tw-spc-base-xx-small;
+        margin-right: $tw-spc-base-xx-small;
         vertical-align: top;
       }
     }


### PR DESCRIPTION
- incorrectly used padding instead of margin, which 
allowed the icon to become squished
- change spacing to margin-right

<img width="337" alt="image" src="https://user-images.githubusercontent.com/114949086/202818142-9221bf65-85fd-43b0-8511-88d24336d32a.png">

#### Before (in terraware-web):
<img width="125" alt="image" src="https://user-images.githubusercontent.com/114949086/202818387-729bf08c-0519-4080-8540-883b86ef701a.png">
