### PR TITLE
Update NPM Version Lookup

### DIFF
--- a/.github/scripts/compare-artifact-package-versions.sh
+++ b/.github/scripts/compare-artifact-package-versions.sh
@@ -12,7 +12,7 @@ if [[ $ARTIFACT_REGISTRY_PROVIDER == 'npm' ]]; then
   echo "Got package json version $PACKAGE_JSON_VERSION"
 
   echo "Checking if version exists in npm repository"
-  npm view @terraware/web-components@${PACKAGE_JSON_VERSION} maintainers > /tmp/npm-output
+  npm show @terraware/web-components versions --json | grep ${PACKAGE_JSON_VERSION} > /tmp/npm-output
   cat /tmp/npm-output
 
   if [ -s /tmp/npm-output ]; then


### PR DESCRIPTION
The previous version of the script used
`npm view @terraware/web-components@${PACKAGE_JSON_VERSION} maintainers`
to check for the existence of a package version.

If the version did not exist, this resulted in an error instead of
no output as expected by the remainder of the script.

Example:
```
Checking if version exists in npm repository
npm ERR! code E404
npm ERR! 404 No match found for version 2.0.26
npm ERR! 404 
npm ERR! 404  '@terraware/web-components@2.0.26' is not in this registry.
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2022-[12](https://github.com/terraware/web-components/actions/runs/3604879723/jobs/6074700271#step:10:13)-02T[20](https://github.com/terraware/web-components/actions/runs/3604879723/jobs/6074700271#step:10:21)_30_38_427Z-debug-0.log
Error: Process completed with exit code 1.
```

Instead, use
`npm show @terraware/web-components versions --json | grep ${PACKAGE_JSON_VERSION}`

This correctly outputs a line of text for a version that exists and nothing
for a version that does not.