### PR TITLE
Handle error response when npm show package-version returns an error

### DIFF
--- a/.github/scripts/compare-artifact-package-versions.sh
+++ b/.github/scripts/compare-artifact-package-versions.sh
@@ -7,20 +7,20 @@ echo "Artifact Registry Provider = $ARTIFACT_REGISTRY_PROVIDER"
 # TODO: add support for AWS Code artifact
 if [[ $ARTIFACT_REGISTRY_PROVIDER == 'npm' ]]; then
 
-  echo "Checking version in git package.json"
+  echo "Checking local version in git package.json"
   PACKAGE_JSON_VERSION=`node -e "process.stdout.write(require(__dirname + '../../dist/package.json').version)"`
   echo "Got package json version $PACKAGE_JSON_VERSION"
 
+  NOT_FOUND=false
   echo "Checking if version exists in npm repository"
-  npm show @terraware/web-components versions --json > /tmp/npm-versions
-  VERSION_EXISTS=false
-  while read line; do
-    if ( echo $line | grep ${PACKAGE_JSON_VERSION} ) then
-      VERSION_EXISTS=true
-    fi
-  done < /tmp/npm-versions
+  npm show @terraware/web-components@${PACKAGE_JSON_VERSION} maintainer > /dev/null 2>&1 || NOT_FOUND=true
 
-  if ( $VERSION_EXISTS ); then
+  # check status code of command to see if it succeeded
+  # if version exists, npm returns with status code 0 (standard status code semantics of 0=success, non-0=error)
+  # if version doesn't exist, npm returns a 404 not found and exits with status code 1
+  # for false errors (such as when npm is down) the build will break anyways
+
+  if [[ $NOT_FOUND == false ]]; then
     echo "Package is up to date"
   else
     echo "Package needs update"


### PR DESCRIPTION
- the previous approach `npm show <version> <property>` was in the right direction as it checks for the specific version directly
- we just need to handle the error, which can be done in the script