### PR TITLE
SW-2487 Clicking on disabled fields on Add People form causes the height and padding to change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.0.27",
+  "version": "2.0.28",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/Textfield/styles.scss
+++ b/src/components/Textfield/styles.scss
@@ -124,6 +124,7 @@
       &:active {
         border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-secondary;
         outline: 0;
+        padding: #{$tw-spc-base-x-small - $tw-sz-frm-fld-text-input-stroke};
       }
 
       &:focus-within {


### PR DESCRIPTION
Padding for active fields is different, but if field is disabled we want to keep the base padding