### PR TITLE
SW-2432: Fix Contact Us Navigation Item is Difficult to See

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.0.30",
+  "version": "2.0.31",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/Navbar/styles.scss
+++ b/src/components/Navbar/styles.scss
@@ -16,6 +16,7 @@
   padding-left: $tw-sz-base-small;
   padding-right: $tw-sz-base-small;
   padding-top: $tw-sz-base-small;
+  mix-blend-mode: multiply;
 
   &.transparent {
     background-color: transparent !important;


### PR DESCRIPTION
This PR applies the style `mix-blend-mode: multiply` to the `NavBar` to make it easier for users to see the Contact Us nav item.

## Screenshots

### AFTER
![localhost_3000_home (6)](https://user-images.githubusercontent.com/1474361/206284275-ec2f218b-c007-4490-a7a9-671e15d10af9.png)

### BEFORE

![localhost_3000_home (7)](https://user-images.githubusercontent.com/1474361/206284282-77cb3bd6-c8f3-4022-a753-5726bf256329.png)
