### PR TITLE
SW-2432: Fix Contact Us Navigation Item is Difficult to See (Follow-up)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.0.31",
+  "version": "2.0.32",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/Navbar/styles.scss
+++ b/src/components/Navbar/styles.scss
@@ -16,11 +16,11 @@
   padding-left: $tw-sz-base-small;
   padding-right: $tw-sz-base-small;
   padding-top: $tw-sz-base-small;
-  mix-blend-mode: multiply;
 
   &.transparent {
     background-color: transparent !important;
     background-image: unset !important;
+    mix-blend-mode: multiply;
   }
 
   .nav-section {


### PR DESCRIPTION
This PR is a follow-up to adjust the newly added `mix-blend-mode: multiply` style rule to the `NavBar` when it's transparent, resolving an issue spotted by @hannah-cai [in a related PR](https://github.com/hannah-cai).