### PR TITLE
Fix font-color on nav, fix font-sizes on table cells

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.0.32",
+  "version": "2.0.33",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/Navbar/styles.scss
+++ b/src/components/Navbar/styles.scss
@@ -82,6 +82,8 @@
     button {
       background: none;
       border: none;
+      color: $tw-clr-txt;
+      font-family: 'Inter';
       padding-right: $tw-spc-base-small;
       padding-left: 20px;
     }
@@ -151,7 +153,4 @@
     margin-bottom: 32px;
   }
 
-  button {
-    font-family: 'Inter';
-  }
 }

--- a/src/components/table/TableCellRenderer.tsx
+++ b/src/components/table/TableCellRenderer.tsx
@@ -60,7 +60,7 @@ export function CellDateRenderer({
 
   return (
     <TableCell id={id} align='left' className={`${classes.date} ${classes.default} ${className}`}>
-      <Typography component='p' variant='body1'>
+      <Typography component='p' variant='body1' fontSize='14px'>
         {cellDateFormatter(value)}
       </Typography>
     </TableCell>
@@ -80,7 +80,7 @@ export function CellTextRenderer({
 
   return (
     <TableCell id={id} align='left' title={typeof value === 'string' ? value : ''} className={`${classes.default} ${className}`}>
-      <Typography component='p' variant='body1' noWrap={true} classes={{ root: classes.textRoot }}>
+      <Typography component='p' variant='body1' noWrap={true} classes={{ root: classes.textRoot }} fontSize='14px'>
         {value}
       </Typography>
     </TableCell>
@@ -100,7 +100,7 @@ export function CellBooleanRenderer({
 
   return (
     <TableCell id={id} align='left' className={`${classes.default} ${className}`}>
-      <Typography component='p' variant='body1'>
+      <Typography component='p' variant='body1' fontSize='14px'>
         {value === 'true' ? 'YES' : 'NO'}
       </Typography>
     </TableCell>
@@ -120,7 +120,7 @@ export function CellNotesRenderer({
 
   return (
     <TableCell id={id} align='left' className={`${classes.default} ${className}`}>
-      <Typography id={id} component='p' variant='body1'>
+      <Typography id={id} component='p' variant='body1' fontSize='14px'>
         {value && value.length > 0 ? <Notes /> : ''}
       </Typography>
     </TableCell>
@@ -151,7 +151,7 @@ export function CellEditRenderer({
         }}
       >
         <Box display='flex'>
-          <Typography component='p' variant='body1'>
+          <Typography component='p' variant='body1' fontSize='14px'>
             Edit
           </Typography>
           <Edit fontSize='small' className={classes.editIcon} />


### PR DESCRIPTION
- set 14px as table cell font size
- set nav color as tw-clr-txt
- feel free to play around with the vercel/storybook link

<img width="508" alt="Table - Default ⋅ Storybook 2022-12-07 19-30-08" src="https://user-images.githubusercontent.com/1865174/206349990-baacf83c-743f-4bd6-b40c-e2d5e7d9ea63.png">

<img width="181" alt="Navbar - Default ⋅ Storybook 2022-12-07 19-29-44" src="https://user-images.githubusercontent.com/1865174/206349992-80f7ebfd-898e-4f84-806d-daba589ef20e.png">
