### PR TITLE
SW-2490 Checkbox style fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.0.35",
+  "version": "2.0.36",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.0.34",
+  "version": "2.0.35",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -67,7 +67,7 @@ export default function Checkbox(props: Props): JSX.Element {
         fontSize: '16px',
         fontWeight: 500,
         lineHeight: '24px',
-        margin: theme.spacing(1, 0, 0, 1),
+        margin: theme.spacing(1, 0, 0, 0),
       }}
     />
   );

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -21,6 +21,9 @@ export const CheckboxStyle = (theme: Theme) => ({
   '&:focus > .MuiSvgIcon-root': {
     border: `2px solid ${theme.palette.TwClrBgSelected}`,
   },
+  '&.Mui-disabled': {
+    opacity: 0.7,
+  },
 });
 
 export interface Props {
@@ -48,6 +51,7 @@ export default function Checkbox(props: Props): JSX.Element {
       disabled={props.disabled}
       control={(
         <MUICheckbox
+          disabled={props.disabled}
           disableRipple={true}
           id={'check-' + props.id}
           checked={props.value ?? false}

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -1,5 +1,27 @@
-import { Checkbox as MUICheckbox, FormControlLabel } from '@mui/material';
+import { Checkbox as MUICheckbox, FormControlLabel, Theme, useTheme } from '@mui/material';
 import React, { SyntheticEvent } from 'react';
+
+export const CheckboxStyle = (theme: Theme) => ({
+  backgroundColor: theme.palette.TwClrBaseWhite,
+  padding: theme.spacing(0, 1, 0, 0),
+  '& .MuiSvgIcon-root': {
+    fill: theme.palette.TwClrBrdrSecondary,
+  },
+  '&:hover > .MuiSvgIcon-root': {
+    fill: theme.palette.TwClrBrdrHover,
+  },
+  '&.Mui-checked > .MuiSvgIcon-root': {
+    fill: theme.palette.TwClrBgSelected,
+    color: theme.palette.TwClrBgSelected,
+  },
+  '&.MuiCheckbox-indeterminate > .MuiSvgIcon-root': {
+    fill: theme.palette.TwClrBgSelected,
+    color: theme.palette.TwClrBgSelected,
+  },
+  '&:focus > .MuiSvgIcon-root': {
+    border: `2px solid ${theme.palette.TwClrBgSelected}`,
+  },
+});
 
 export interface Props {
   id: string;
@@ -12,6 +34,8 @@ export interface Props {
 }
 
 export default function Checkbox(props: Props): JSX.Element {
+  const theme = useTheme();
+
   const onChange = (event: SyntheticEvent<Element, Event>, checked: boolean) => {
     props.onChange(props.id, checked);
   };
@@ -22,8 +46,25 @@ export default function Checkbox(props: Props): JSX.Element {
       onChange={onChange}
       label={props.label}
       disabled={props.disabled}
-      control={<MUICheckbox id={'check-' + props.id} color='primary' checked={props.value ?? false} />}
+      control={(
+        <MUICheckbox
+          disableRipple={true}
+          id={'check-' + props.id}
+          checked={props.value ?? false}
+          size='medium'
+          sx={CheckboxStyle(theme)}
+        />
+      )}
       className={props.className}
+      sx={{
+        alignItems: 'flex-start',
+        color: theme.palette.TwClrTxt,
+        fontFamily: 'Inter',
+        fontSize: '16px',
+        fontWeight: 500,
+        lineHeight: '24px',
+        margin: theme.spacing(1, 0, 0, 1),
+      }}
     />
   );
 }

--- a/src/components/table/TableHeader.tsx
+++ b/src/components/table/TableHeader.tsx
@@ -52,6 +52,7 @@ export default function EnhancedTableHead(props: Props): JSX.Element {
         {numSelected !== undefined && rowCount !== undefined && rowCount > 0 && onSelectAllClick && (
           <TableCell padding='checkbox' className={classes.headerCell}>
             <Checkbox
+              disableRipple={true}
               sx={CheckboxStyle(theme)}
               color='primary'
               indeterminate={numSelected > 0 && numSelected < rowCount}

--- a/src/components/table/TableHeader.tsx
+++ b/src/components/table/TableHeader.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, TableCell, TableHead, TableRow, Theme } from '@mui/material';
+import { Checkbox, TableCell, TableHead, TableRow, Theme, useTheme } from '@mui/material';
 import React from 'react';
 import { SortOrder } from './sort';
 import { TableColumnType } from './types';
@@ -6,6 +6,7 @@ import { SortableContext } from '@dnd-kit/sortable';
 import TableHeaderItem from './TableHeaderItem';
 import { HeadCell } from '.';
 import { makeStyles } from '@mui/styles';
+import { CheckboxStyle } from '../Checkbox';
 
 const useStyles = makeStyles((theme: Theme) => ({
   headerCell: {
@@ -28,6 +29,7 @@ interface Props {
 
 export default function EnhancedTableHead(props: Props): JSX.Element {
   const classes = useStyles();
+  const theme = useTheme();
   const { order, orderBy, onRequestSort, numSelected, rowCount, onSelectAllClick } = props;
   const [headCells, setHeadCells] = React.useState<HeadCell[]>(columnsToHeadCells(props.columns));
   React.useEffect(() => {
@@ -50,6 +52,7 @@ export default function EnhancedTableHead(props: Props): JSX.Element {
         {numSelected !== undefined && rowCount !== undefined && rowCount > 0 && onSelectAllClick && (
           <TableCell padding='checkbox' className={classes.headerCell}>
             <Checkbox
+              sx={CheckboxStyle(theme)}
               color='primary'
               indeterminate={numSelected > 0 && numSelected < rowCount}
               checked={rowCount > 0 && numSelected === rowCount}

--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -267,6 +267,7 @@ export default function EnhancedTable<T>({
                           {showCheckbox && (
                             <TableCell padding='checkbox' className={classes.cellDefault}>
                               <Checkbox
+                                disableRipple={true}
                                 sx={CheckboxStyle(theme)}
                                 color='primary'
                                 checked={isItemSelected}

--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Checkbox, Pagination, Table, TableBody, TableCell, TableContainer, TableRow, Theme, TooltipProps, Typography } from '@mui/material';
+import { Box, Checkbox, Pagination, Table, TableBody, TableCell, TableContainer, TableRow, Theme, TooltipProps, Typography, useTheme } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import EnhancedTableToolbar from './EnhancedTableToolbar';
 import { descendingComparator, getComparator, SortOrder, stableSort } from './sort';
@@ -10,6 +10,7 @@ import { DndContext, KeyboardSensor, MouseSensor, TouchSensor, useSensor, useSen
 import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import { useDeviceInfo } from '../../utils';
 import { IconName } from '../Icon/icons';
+import { CheckboxStyle } from '../Checkbox';
 
 const tableStyles = makeStyles((theme: Theme) => ({
   hover: {
@@ -107,6 +108,7 @@ export default function EnhancedTable<T>({
   hideHeader,
 }: Props<T>): JSX.Element {
   const classes = tableStyles();
+  const theme = useTheme();
   const [order, setOrder] = React.useState<SortOrder>(_order);
   const [orderBy, setOrderBy] = React.useState(_orderBy);
   const [maxItemsPerPage] = useState(100);
@@ -265,6 +267,7 @@ export default function EnhancedTable<T>({
                           {showCheckbox && (
                             <TableCell padding='checkbox' className={classes.cellDefault}>
                               <Checkbox
+                                sx={CheckboxStyle(theme)}
                                 color='primary'
                                 checked={isItemSelected}
                                 onClick={(e) => (!isClickable || !isClickable(row as T) ? handleClick(e, row as T) : null)}

--- a/src/stories/Checkbox.stories.tsx
+++ b/src/stories/Checkbox.stories.tsx
@@ -23,9 +23,9 @@ const Template: Story<CheckboxProps> = (args) => {
   };
 
   const classes = useStyles();
-  const className = classes[args.useClassName];
+  const className = classes.narrowWidth;
 
-  return <Checkbox className={className} {...args} onChange={toggleChange} value={value} />;
+  return <Checkbox {...args} onChange={toggleChange} value={value} className={className}/>;
 };
 
 export const Default = Template.bind({});
@@ -43,5 +43,4 @@ TopAlignLongLabel.args = {
   name: 'Alignment Test',
   label: 'The Quick Brown Fox Jumped Over The Silly Lazy Goat',
   disabled: false,
-  useClassName: 'narrowWidth',
 };

--- a/src/stories/Checkbox.stories.tsx
+++ b/src/stories/Checkbox.stories.tsx
@@ -1,12 +1,19 @@
 import { action } from '@storybook/addon-actions';
 import { Story } from '@storybook/react';
 import React from 'react';
+import { makeStyles } from '@mui/styles';
 import Checkbox, { Props as CheckboxProps } from '../components/Checkbox';
 
 export default {
   title: 'Checkbox',
   component: Checkbox,
 };
+
+const useStyles = makeStyles(() => ({
+  narrowWidth: {
+    width: '200px',
+  },
+}));
 
 const Template: Story<CheckboxProps> = (args) => {
   const [value, setValue] = React.useState(true);
@@ -15,14 +22,26 @@ const Template: Story<CheckboxProps> = (args) => {
     setValue(_value);
   };
 
-  return <Checkbox {...args} onChange={toggleChange} value={value} />;
+  const classes = useStyles();
+  const className = classes[args.useClassName];
+
+  return <Checkbox className={className} {...args} onChange={toggleChange} value={value} />;
 };
 
 export const Default = Template.bind({});
+export const TopAlignLongLabel = Template.bind({});
 
 Default.args = {
   id: '1',
   name: 'Test',
-  label: <p>Test</p>,
+  label: 'Test',
   disabled: false,
+};
+
+TopAlignLongLabel.args = {
+  id: '2',
+  name: 'Alignment Test',
+  label: 'The Quick Brown Fox Jumped Over The Silly Lazy Goat',
+  disabled: false,
+  useClassName: 'narrowWidth',
 };

--- a/src/stories/Table.stories.tsx
+++ b/src/stories/Table.stories.tsx
@@ -31,7 +31,7 @@ function Renderer(props: RendererProps<any>): JSX.Element {
 const Template: Story<TableProps<{ name: string; lastname: string }>> = (
   args
 ) => {
-  const [selectedRows, setSelectedRows] = useState([]);
+  const [selectedRows, setSelectedRows] = useState<any>([]);
   const styles = useStyles();
   args.columns[1].className = styles.italic;
 

--- a/src/stories/Table.stories.tsx
+++ b/src/stories/Table.stories.tsx
@@ -1,5 +1,5 @@
 import { Story } from '@storybook/react';
-import React from 'react';
+import React, { useState } from 'react';
 import Table, { Props as TableProps } from '../components/table/index';
 import CellRenderer from '..//components/table/TableCellRenderer';
 import { RendererProps } from '../components/table/types';
@@ -31,13 +31,15 @@ function Renderer(props: RendererProps<any>): JSX.Element {
 const Template: Story<TableProps<{ name: string; lastname: string }>> = (
   args
 ) => {
+  const [selectedRows, setSelectedRows] = useState([]);
   const styles = useStyles();
   args.columns[1].className = styles.italic;
 
-  return <Table {...args} Renderer={Renderer} />;
+  return <Table {...args} Renderer={Renderer} selectedRows={selectedRows} setSelectedRows={setSelectedRows} />;
 };
 
 export const Default = Template.bind({});
+export const Selectable = Template.bind({});
 
 Default.args = {
   orderBy: 'name',
@@ -55,4 +57,10 @@ Default.args = {
       return { name: `Jane${j}`, middlename: 'John', lastname: 'Doe' };
     }
   }),
+};
+
+Selectable.args = {
+  ...Default.args,
+  showCheckbox: true,
+  controlledOnSelect: true,
 };


### PR DESCRIPTION
- border radius and width are not fixed since it's an icon not css
- added comment in figma for ^
- more fixes to be done in web repo
- check out vercel

<img width="515" alt="Table - Selectable ⋅ Storybook 2022-12-08 08-54-33" src="https://user-images.githubusercontent.com/1865174/206515261-071e3187-c54d-4f3d-b415-975e913b0760.png">

<img width="408" alt="Checkbox - Top Align Long Label ⋅ Storybook 2022-12-08 08-54-17" src="https://user-images.githubusercontent.com/1865174/206515267-459d7724-7f5d-4d4c-a7b1-a974cf777a6a.png">

<img width="371" alt="Checkbox - Default ⋅ Storybook 2022-12-08 08-54-01" src="https://user-images.githubusercontent.com/1865174/206515268-00318e24-49dd-482c-a780-7677b77afd21.png">

