### PR TITLE
SW-2509 Autocomplete component enhancements and fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.0.38",
+  "version": "2.0.39",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -1,14 +1,8 @@
 import { Box, Autocomplete as MUIAutocomplete, TextField, Theme } from '@mui/material';
 import React, { ChangeEvent } from 'react';
-import { makeStyles } from '@mui/styles';
 import Icon from '../Icon/Icon';
+import '../Select/styles.scss';
 import './styles.scss';
-
-const useStyles = makeStyles((theme: Theme) => ({
-  paper: {
-    marginTop: theme.spacing(1),
-  },
-}));
 
 export type Option = {
   value: any;
@@ -35,8 +29,6 @@ export type DropdownItem = {
 };
 
 export default function Autocomplete({ id, label, values, onChange, selected, freeSolo, disabled, className, hideClearIcon }: Props): JSX.Element {
-  const classes = useStyles();
-
   const onChangeHandler = (event: ChangeEvent<any>, value: string | null) => {
     if (event) {
       if (value) {
@@ -79,7 +71,8 @@ export default function Autocomplete({ id, label, values, onChange, selected, fr
       renderInput={renderInput}
       popupIcon={<Icon name='chevronDown' className='auto-complete--icon-right' size='medium'/>}
       classes={{
-        paper: classes.paper,
+        paper: 'auto-complete select',
+        listbox: 'options-container',
       }}
       sx={{
         '& .MuiAutocomplete-popupIndicator:hover': {

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -1,17 +1,32 @@
-import { Autocomplete as MUIAutocomplete, TextField } from '@mui/material';
+import { Box, Autocomplete as MUIAutocomplete, TextField, Theme } from '@mui/material';
 import React, { ChangeEvent } from 'react';
+import { makeStyles } from '@mui/styles';
+import Icon from '../Icon/Icon';
 import './styles.scss';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  paper: {
+    marginTop: theme.spacing(1),
+  },
+}));
+
+export type Option = {
+  value: any;
+  label: string;
+};
+
+export type ValueType = string | Option;
 
 export interface Props {
   id: string;
   label: string;
-  values: string[];
-  onChange: (id: string, value: string) => void;
-  selected: string | undefined;
+  values: ValueType[];
+  onChange: (id: string, value: ValueType) => void;
+  selected: ValueType | undefined;
   freeSolo: boolean;
   disabled?: boolean;
   className?: string;
-  isV1?: boolean; // deprecated
+  hideClearIcon?: boolean;
 }
 
 export type DropdownItem = {
@@ -19,7 +34,9 @@ export type DropdownItem = {
   value: string;
 };
 
-export default function Autocomplete({ id, label, values, onChange, selected, freeSolo, disabled, className, isV1 }: Props): JSX.Element {
+export default function Autocomplete({ id, label, values, onChange, selected, freeSolo, disabled, className, hideClearIcon }: Props): JSX.Element {
+  const classes = useStyles();
+
   const onChangeHandler = (event: ChangeEvent<any>, value: string | null) => {
     if (event) {
       if (value) {
@@ -32,27 +49,51 @@ export default function Autocomplete({ id, label, values, onChange, selected, fr
 
   const renderInput = (params: object) => (
     <div className={`auto-complete ${className}`}>
-      {label && isV1 !== true && (
+      {label && (
         <label htmlFor={id} className='textfield-label'>
           {label}
         </label>
       )}
-      <TextField label={isV1 ? label : undefined} {...params} variant='outlined' size='small' placeholder={label} />
+      <TextField {...params} variant='outlined' size='small' placeholder={label} />
     </div>
   );
 
+  const optionalArgs: any = {};
+
+  if (hideClearIcon) {
+    optionalArgs.clearIcon = null;
+  }
+
   return (
     <MUIAutocomplete
+      disableRipple={true}
       disabled={disabled}
       id={id}
       options={values}
-      getOptionLabel={(option) => (option ? option : '')}
+      getOptionLabel={(option: any) => (option ? (option.label || option) : '')}
       onChange={onChangeHandler}
       onInputChange={onChangeHandler}
-      inputValue={selected}
+      inputValue={(selected as Option)?.label || selected}
       freeSolo={freeSolo}
       forcePopupIcon={true}
       renderInput={renderInput}
+      popupIcon={<Icon name='chevronDown' className='auto-complete--icon-right' size='medium'/>}
+      classes={{
+        paper: classes.paper,
+      }}
+      sx={{
+        '& .MuiAutocomplete-popupIndicator:hover': {
+          background: 'transparent',
+        },
+        '& .MuiAutocomplete-popupIndicator': {
+          background: 'transparent',
+          transform: 'none',
+        },
+        '& .MuiTouchRipple-root': {
+          display: 'none',
+        },
+      }}
+      {...optionalArgs}
     />
   );
 }

--- a/src/components/Autocomplete/styles.scss
+++ b/src/components/Autocomplete/styles.scss
@@ -51,4 +51,39 @@
     fill: $tw-clr-icn;
     margin-left: $tw-spc-base-x-small;
   }
+
+  &.select {
+    .options-container {
+      top: 0;
+      margin-top: $tw-spc-base-x-small;
+
+      .MuiAutocomplete-option {
+        font-family: $tw-fnt-frm-fld-select-value-font-family;
+        font-size: $tw-fnt-frm-fld-select-value-font-size;
+        font-weight: $tw-fnt-frm-fld-select-value-font-weight;
+        line-height: $tw-fnt-frm-fld-select-value-line-height;
+        padding: $tw-spc-base-x-small $tw-spc-base-small;
+        cursor: pointer;
+
+        &:hover {
+          background-color: $tw-clr-bg-selected-ghost-hover;
+          color: $tw-clr-txt;
+        }
+
+        &:active {
+          background-color: $tw-clr-bg-selected-ghost-active;
+          color: $tw-clr-txt;
+        }
+
+        &[aria-selected="true"], &[aria-selected="true"]:hover {
+          background-color: $tw-clr-bg-selected;
+          color: $tw-clr-txt-on-selected;
+        }
+
+        &:disabled {
+          opacity: $tw-opcty-semantic-off;
+        }
+      }
+    }
+  }
 }

--- a/src/components/Autocomplete/styles.scss
+++ b/src/components/Autocomplete/styles.scss
@@ -44,4 +44,11 @@
       border-color: $tw-clr-brdr-hover;
     }
   }
+
+  &--icon-right {
+    width: $tw-fnt-frm-fld-text-value-line-height;
+    height: $tw-fnt-frm-fld-text-value-line-height;
+    fill: $tw-clr-icn;
+    margin-left: $tw-spc-base-x-small;
+  }
 }

--- a/src/components/Select/styles.scss
+++ b/src/components/Select/styles.scss
@@ -124,6 +124,7 @@
       height: $tw-fnt-frm-fld-text-value-line-height;
       fill: $tw-clr-icn;
       margin-left: $tw-spc-base-x-small;
+      flex-shrink: 0;
     }
 
     &--icon-left {

--- a/src/components/Select/styles.scss
+++ b/src/components/Select/styles.scss
@@ -276,7 +276,7 @@
         color: $tw-clr-txt;
       }
 
-      &--selected {
+      &--selected, &--selected:hover {
         background-color: $tw-clr-bg-selected;
         color: $tw-clr-txt-on-selected;
       }

--- a/src/stories/Autocomplete.stories.tsx
+++ b/src/stories/Autocomplete.stories.tsx
@@ -3,6 +3,7 @@ import { Story } from '@storybook/react';
 import { Theme } from '@mui/material';
 import React from 'react';
 import Autocomplete, {
+  ValueType,
   Props as AutocompleteProps,
 } from '../components/Autocomplete/Autocomplete';
 import { makeStyles } from '@mui/styles';
@@ -21,8 +22,8 @@ export default {
 
 const Template: Story<AutocompleteProps> = (args) => {
   const classes = useStyles();
-  const [selected, setSelected] = React.useState('');
-  const handleChange = (id: string, value: string) => {
+  const [selected, setSelected] = React.useState<ValueType>('');
+  const handleChange = (id: string, value: ValueType) => {
     action('onChange')(value);
     setSelected(value);
   };
@@ -32,7 +33,7 @@ const Template: Story<AutocompleteProps> = (args) => {
 
 export const Default = Template.bind({});
 
-export const V1 = Template.bind({});
+export const Complex = Template.bind({});
 
 Default.args = {
   id: '1',
@@ -42,11 +43,23 @@ Default.args = {
   selected: '',
 };
 
-V1.args = {
-  id: '1',
-  label: 'Test',
-  values: ['Test 1', 'Test 2', 'Hello'],
+Complex.args = {
+  id: '2',
+  label: 'Pick a value',
+  values: [{
+    label: 'hello',
+    value: 1,
+  }, {
+    label: 'world',
+    value: 2,
+  }, {
+    label: 'yoyo',
+    value: 3,
+  }, {
+    label: 'ma',
+    value: 4,
+  }],
   onChange: () => true,
-  selected: '',
-  isV1: true,
+  selected: undefined,
+  hideClearIcon: true,
 };


### PR DESCRIPTION
- update chevron/caret to use homegrown icon as per designers' request
- support complex objects of type { label: string, value: any } so we can support selecting values based on unique values/ids
- some other minor style fixes
- pre-requisite for some withdrawal log / plants dashboard features
- remove V1 deprecated functionality

<img width="309" alt="Autocomplete - Complex ⋅ Storybook 2022-12-08 14-14-13" src="https://user-images.githubusercontent.com/1865174/206580093-8b59a0d0-28a7-456f-8614-31ff4a519a87.png">
