### PR TITLE
SW-2537 Fix preselected value on autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.0.47",
+  "version": "2.0.48",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -66,9 +66,7 @@ export default function Autocomplete({
       {errorText && (
         <div className='textfield-label-container'>
           <Icon name='error' className='textfield-error-text--icon' />
-          <label className='textfield-error-text'>
-            {errorText}
-          </label>
+          <label className='textfield-error-text'>{errorText}</label>
         </div>
       )}
     </div>
@@ -89,14 +87,14 @@ export default function Autocomplete({
       disabled={disabled}
       id={id}
       options={values}
-      getOptionLabel={(option: any) => (option ? (option.label || option) : '')}
+      getOptionLabel={(option: any) => (option ? option.label || option : '')}
       onChange={onChangeHandler}
       onInputChange={(event: any, value: any) => freeSolo && onChangeHandler(event, value)}
-      inputValue={(selected as Option)?.label || selected}
+      value={(selected as Option)?.label || selected}
       freeSolo={freeSolo}
       forcePopupIcon={true}
       renderInput={renderInput}
-      popupIcon={<Icon name='chevronDown' className='auto-complete--icon-right' size='medium'/>}
+      popupIcon={<Icon name='chevronDown' className='auto-complete--icon-right' size='medium' />}
       classes={{
         paper: 'auto-complete select',
         listbox: 'options-container',

--- a/src/stories/Autocomplete.stories.tsx
+++ b/src/stories/Autocomplete.stories.tsx
@@ -2,10 +2,7 @@ import { action } from '@storybook/addon-actions';
 import { Story } from '@storybook/react';
 import { Theme } from '@mui/material';
 import React from 'react';
-import Autocomplete, {
-  ValueType,
-  Props as AutocompleteProps,
-} from '../components/Autocomplete/Autocomplete';
+import Autocomplete, { ValueType, Props as AutocompleteProps } from '../components/Autocomplete/Autocomplete';
 import { makeStyles } from '@mui/styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -49,21 +46,27 @@ Complex.args = {
   id: '2',
   label: 'Complex Objects',
   placeholder: 'Pick a value',
-  values: [{
-    label: 'hello',
-    value: 1,
-  }, {
-    label: 'world',
-    value: 2,
-  }, {
-    label: 'yoyo',
-    value: 3,
-  }, {
-    label: 'ma',
-    value: 4,
-  }],
+  values: [
+    {
+      label: 'hello',
+      value: 1,
+    },
+    {
+      label: 'world',
+      value: 2,
+    },
+    {
+      label: 'yoyo',
+      value: 3,
+    },
+    {
+      label: 'ma',
+      value: 4,
+    },
+  ],
   onChange: () => true,
   selected: undefined,
   hideClearIcon: true,
   errorText: '',
+  isEqual: (option: any, value) => option.label === value,
 };


### PR DESCRIPTION
Replace use of inputValue with value because:

- inputValue only sets a value for the Input component
- The value prop sends the passed value through getOptionLabel and compares with the options list.