### PR TITLE
SW-2608 Add ID to autocomplete to allow for easier tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.0.55",
+  "version": "2.0.56",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -66,7 +66,7 @@ export default function Autocomplete({
       {errorText && (
         <div className='textfield-label-container'>
           <Icon name='error' className='textfield-error-text--icon' />
-          <label className='textfield-error-text'>{errorText}</label>
+          <label htmlFor={id} className='textfield-error-text'>{errorText}</label>
         </div>
       )}
     </div>


### PR DESCRIPTION
Need a way to find which field the error text is attached to.  This follows a pattern that most of the other error text fields are already following.