### PR TITLE
SW-2677 Time Zone and Locale for Datepicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.0.63",
+  "version": "2.0.64",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -29,9 +29,9 @@ export interface Props {
 
 export default function DatePicker(props: Props): JSX.Element {
   const [temporalValue, setTemporalValue] = useState(props.value || null);
-  const locale = props.locale ?? 'en';
+  const locale = props.locale ?? window.navigator.language ?? 'en';
   React.useEffect(() => {
-    moment.locale([window.navigator.language, locale]);
+    moment.locale([locale]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [window.navigator.language, locale]);
 
@@ -49,9 +49,8 @@ export default function DatePicker(props: Props): JSX.Element {
     </>
   );
 
-  // set timezone, defaulting to browser
-  const browserTimeZone = Intl.DateTimeFormat(locale).resolvedOptions().timeZone;
-  moment.tz.setDefault(props.defaultTimeZone ?? browserTimeZone);
+  // set timezone, defaulting to 'UTC'
+  moment.tz.setDefault(props.defaultTimeZone ?? 'UTC');
 
   return (
     <div className={`date-picker ${props.className} ${props.errorText ? 'date-picker--error' : ''}`}>

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -2,7 +2,6 @@ import moment from 'moment-timezone';
 import 'moment/min/locales';
 import React, { useState, KeyboardEventHandler } from 'react';
 import { TextField, Theme } from '@mui/material';
-import { makeStyles } from '@mui/styles';
 import { LocalizationProvider, DesktopDatePicker } from '@mui/x-date-pickers';
 import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
 import Icon from '../Icon/Icon';
@@ -29,11 +28,10 @@ export interface Props {
 
 export default function DatePicker(props: Props): JSX.Element {
   const [temporalValue, setTemporalValue] = useState(props.value || null);
-  const locale = props.locale ?? window.navigator.language ?? 'en';
+  const locale = props.locale ?? 'en';
   React.useEffect(() => {
     moment.locale([locale]);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [window.navigator.language, locale]);
+  }, [locale]);
 
   const renderInput = (params: object) => (
     <>

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -18,6 +18,8 @@ export interface Props {
   onKeyPress?: KeyboardEventHandler;
   minDate?: any;
   maxDate?: any;
+  defaultTimeZone?: string;
+  locale?: string;
   errorText?: string;
   helperText?: string;
   disabled?: boolean;
@@ -27,10 +29,11 @@ export interface Props {
 
 export default function DatePicker(props: Props): JSX.Element {
   const [temporalValue, setTemporalValue] = useState(props.value || null);
+  const locale = props.locale ?? 'en';
   React.useEffect(() => {
-    moment.locale([window.navigator.language, 'en']);
+    moment.locale([window.navigator.language, locale]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [window.navigator.language]);
+  }, [window.navigator.language, locale]);
 
   const renderInput = (params: object) => (
     <>
@@ -46,12 +49,13 @@ export default function DatePicker(props: Props): JSX.Element {
     </>
   );
 
-  // set default timezone to UTC
-  moment.tz.setDefault('UTC');
+  // set timezone, defaulting to browser
+  const browserTimeZone = Intl.DateTimeFormat(locale).resolvedOptions().timeZone;
+  moment.tz.setDefault(props.defaultTimeZone ?? browserTimeZone);
 
   return (
     <div className={`date-picker ${props.className} ${props.errorText ? 'date-picker--error' : ''}`}>
-      <LocalizationProvider dateAdapter={AdapterMoment} dateLibInstance={moment}>
+      <LocalizationProvider dateAdapter={AdapterMoment} dateLibInstance={moment} adapterLocale={locale}>
         {props.label && (
           <label htmlFor={props.id} className='textfield-label'>
             {props.label}

--- a/src/stories/DatePicker.stories.tsx
+++ b/src/stories/DatePicker.stories.tsx
@@ -44,7 +44,7 @@ Default.args = {
   minDate: undefined,
   maxDate: Date.now(),
   defaultTimeZone: undefined,
-  locale: 'en',
+  locale: undefined,
   errorText: '',
   helperText: '',
   autoFocus: false,

--- a/src/stories/DatePicker.stories.tsx
+++ b/src/stories/DatePicker.stories.tsx
@@ -43,6 +43,8 @@ Default.args = {
   label: 'Datepicker',
   minDate: undefined,
   maxDate: Date.now(),
+  defaultTimeZone: undefined,
+  locale: 'en',
   errorText: '',
   helperText: '',
   autoFocus: false,


### PR DESCRIPTION
The Datepicker component may now accept a time zone and locale as props.

Changing the time zone between e.g. Pacific/Honolulu and Asia/Tokyo, causes the current date to shift, indicating that the component is respecting the change in time zone:
<img width="1496" alt="image" src="https://user-images.githubusercontent.com/114949086/211641661-0fb65620-d16c-410e-bbdf-fb4dcf25ef69.png">
<img width="1496" alt="image" src="https://user-images.githubusercontent.com/114949086/211641719-c165aad1-f276-4d60-b84e-490110af8f90.png">

Changing the locale causes the language of the datepicker to change:
<img width="1496" alt="image" src="https://user-images.githubusercontent.com/114949086/211641852-6aef253f-fca1-4a86-8609-88ea5a795d69.png">
<img width="1496" alt="image" src="https://user-images.githubusercontent.com/114949086/211641915-2b819a18-471e-48a2-b26b-1d860654261b.png">
