### PR TITLE
Update datepicker value when received value changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.0.66",
+  "version": "2.0.67",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -33,6 +33,12 @@ export default function DatePicker(props: Props): JSX.Element {
     moment.locale([locale]);
   }, [locale]);
 
+  React.useEffect(() => {
+    if (props.value && props.value !== temporalValue) {
+      setTemporalValue(props.value);
+    }
+  }, [props.value]);
+
   const renderInput = (params: object) => (
     <>
       <TextField {...params} id={props.id} autoFocus={props.autoFocus} onKeyPress={props.onKeyPress} />

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -72,7 +72,7 @@ export default function DatePicker(props: Props): JSX.Element {
           value={temporalValue}
           onChange={(newValue: any) => {
             setTemporalValue(newValue);
-            props.onChange(newValue?.isValid() ? newValue?.toDate() : null);
+            props.onChange(newValue?.isValid() ? newValue?.format('YYYY-MM-DD') : null);
           }}
           renderInput={renderInput}
           disabled={props.disabled}

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -72,7 +72,7 @@ export default function DatePicker(props: Props): JSX.Element {
           value={temporalValue}
           onChange={(newValue: any) => {
             setTemporalValue(newValue);
-            props.onChange(newValue?.isValid() ? newValue?.format('YYYY-MM-DD') : null);
+            props.onChange(newValue?.isValid() ? newValue?.toDate() : null);
           }}
           renderInput={renderInput}
           disabled={props.disabled}


### PR DESCRIPTION
Now temporalValue is used to show the datepicker value and that value is initialized with the initial value that comes from props. But if that initial value changes, the datepicker does not updates its temporal value.
Added a useEffect to update temporalValue if 'values' props changes.

Also return selectedValue as a string to consider the timezone