### PR TITLE
Auto-version Comment and Label Only on PR Opened

### DIFF
--- a/.github/workflows/open-pr.yml
+++ b/.github/workflows/open-pr.yml
@@ -3,6 +3,7 @@ name: Open PR
 on:
   pull_request:
     branches: [main]
+    types: [opened]
 
 jobs:
   version-label-comment:


### PR DESCRIPTION
Only run when PR is opened to avoid inadvertently adding patch labels.