### PR TITLE
SW-2733 Support localized content

### DIFF
--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -56,6 +56,9 @@ export default function DatePicker(props: Props): JSX.Element {
   // set timezone, defaulting to 'UTC'
   moment.tz.setDefault(props.defaultTimeZone ?? 'UTC');
 
+  // TODO: Localize the yyyy-mm-dd placeholder string that is shown to users when the input is
+  //       empty. It appears to be generated programmatically deep in the guts of the MUI DatePicker
+  //       code, and it most likely uses the browser's locale.
   return (
     <div className={`date-picker ${props.className} ${props.errorText ? 'date-picker--error' : ''}`}>
       <LocalizationProvider dateAdapter={AdapterMoment} dateLibInstance={moment} adapterLocale={locale}>

--- a/src/components/ProgressCircle/ProgressCircle.tsx
+++ b/src/components/ProgressCircle/ProgressCircle.tsx
@@ -6,17 +6,20 @@ export interface Props {
   size?: 'small' | 'medium' | 'large';
   determinate: true | false;
   value?: number;
+  /** Returns a human-readable representation of a percentage such as "5%" */
+  renderPercentText: (percent: number) => string;
   hideValue?: boolean;
 }
 
 export default function ProgressCircle(props: Props): JSX.Element {
-  const { size = 'small', determinate, value, hideValue } = props;
+  const { size = 'small', determinate, value, renderPercentText, hideValue } = props;
 
   return (
     <Box className='circle-container'>
       <CircularProgress variant='determinate' value={100} className={`circle-track circle-track--${size}`} />
       <Box className='label-container'>
-        {value && !hideValue && <p className={`progress-circle-label--{size}`}>{`${Math.round(value)}%`}</p>}
+        {value && !hideValue &&
+            <p className={`progress-circle-label--{size}`}>{renderPercentText(Math.round(value))}</p>}
       </Box>
       <CircularProgress
         value={value}

--- a/src/components/TextTruncated/index.tsx
+++ b/src/components/TextTruncated/index.tsx
@@ -68,14 +68,15 @@ function computeFromStringList(strings: string[], maxLength: number): TextDispla
 export interface Props {
   stringList: string[];
   maxLengthPx: number;
-  moreSeparator?: string;
-  moreText?: string;
+  moreSeparator: string;
+  moreText: string;
+  listSeparator: string;
   textStyle?: Record<string, any>;
   showAllStyle?: Record<string, any>;
 }
 
 export default function TextTruncated(props: Props): JSX.Element {
-  const { stringList, maxLengthPx, moreSeparator = '... ', moreText = 'more', textStyle, showAllStyle } = props;
+  const { stringList, listSeparator, maxLengthPx, moreSeparator, moreText, textStyle, showAllStyle } = props;
   const [showAllOpen, setShowAllOpen] = useState(false);
   const classes = useStyles();
   const [canvasContext, setCanvasContext] = useState<CanvasRenderingContext2D>();
@@ -88,7 +89,7 @@ export default function TextTruncated(props: Props): JSX.Element {
 
   const pixelsPerChar = useMemo(() => {
     // compute the pixels per character, averaged over the comma-separated joined stringList
-    const fullText = stringList.join(', ');
+    const fullText = stringList.join(listSeparator);
     let result = 0;
     if (canvasContext) {
       const fontSize = (textStyle && textStyle.fontSize) || theme.typography.fontSize;
@@ -101,7 +102,7 @@ export default function TextTruncated(props: Props): JSX.Element {
     return result / fullText.length;
   }, [stringList, textStyle, canvasContext, theme.typography.fontFamily, theme.typography.fontSize]);
 
-  let maxExcludingSuffix = stringList.join(', ').length;
+  let maxExcludingSuffix = stringList.join(listSeparator).length;
   if (pixelsPerChar > 0) {
     const maxChars = maxLengthPx / pixelsPerChar;
     maxExcludingSuffix = maxChars - moreSeparator.length - moreText.length - 1 - Math.ceil(Math.log10(stringList.length));

--- a/src/components/table/EnhancedTableToolbar.tsx
+++ b/src/components/table/EnhancedTableToolbar.tsx
@@ -18,17 +18,18 @@ const styles = makeStyles((theme: Theme) => ({
 
 interface EnhancedTableToolbarProps {
   numSelected: number;
+  renderNumSelectedText?: (numSelected: number) => string;
   topBarButtons?: TopBarButton[];
 }
 
 export default function EnhancedTableToolbar(props: EnhancedTableToolbarProps): JSX.Element | null {
-  const { numSelected, topBarButtons } = props;
+  const { numSelected, renderNumSelectedText, topBarButtons } = props;
   const classes = styles();
 
-  return numSelected > 0 ? (
+  return renderNumSelectedText && numSelected > 0 ? (
     <Toolbar className={classes.toolbar}>
       <Typography color='inherit' variant='subtitle1' component='div' className={classes.flexText}>
-        {numSelected} selected
+        {renderNumSelectedText(numSelected)}
       </Typography>
       {topBarButtons?.map((tbButton) => {
         return (

--- a/src/components/table/TableCellRenderer.tsx
+++ b/src/components/table/TableCellRenderer.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 export type TableRowType = Record<string, any>;
 
 export default function CellRenderer(props: RendererProps<TableRowType>): JSX.Element {
-  const { column, value, onRowClick, index, className } = props;
+  const { column, value, onRowClick, index, className, booleanFalseText, booleanTrueText, editText } = props;
   const id = `row${index}-${column.key}`;
 
   if (column.type === 'date' && typeof value === 'string' && value) {
@@ -33,9 +33,9 @@ export default function CellRenderer(props: RendererProps<TableRowType>): JSX.El
   } else if (column.type === 'notes' && value && typeof value === 'string') {
     return <CellNotesRenderer id={id} value={value} className={className} />;
   } else if (column.type === 'boolean') {
-    return <CellBooleanRenderer id={id} value={value} className={className} />;
+    return <CellBooleanRenderer id={id} value={value} className={className} booleanFalseText={booleanFalseText} booleanTrueText={booleanTrueText} />;
   } else if (column.type === 'edit') {
-    return <CellEditRenderer id={id} onRowClick={onRowClick} className={className} />;
+    return <CellEditRenderer id={id} onRowClick={onRowClick} className={className} editText={editText} />;
   }
 
   return <CellTextRenderer id={id} value={value} className={className} />;
@@ -91,17 +91,21 @@ export function CellBooleanRenderer({
   id,
   value,
   className,
+  booleanFalseText,
+  booleanTrueText,
 }: {
   id: string;
   value?: string | number | any[] | ReactNode;
   className?: string;
+  booleanFalseText: string;
+  booleanTrueText: string;
 }): JSX.Element {
   const classes = useStyles();
 
   return (
     <TableCell id={id} align='left' className={`${classes.default} ${className}`}>
       <Typography component='p' variant='body1' fontSize='14px'>
-        {value === 'true' ? 'YES' : 'NO'}
+        {value === 'true' ? booleanTrueText : booleanFalseText}
       </Typography>
     </TableCell>
   );
@@ -131,10 +135,12 @@ export function CellEditRenderer({
   id,
   onRowClick,
   className,
+  editText,
 }: {
   id: string;
   onRowClick?: () => void;
   className?: string;
+  editText: string;
 }): JSX.Element {
   const classes = useStyles();
 
@@ -152,7 +158,7 @@ export function CellEditRenderer({
       >
         <Box display='flex'>
           <Typography component='p' variant='body1' fontSize='14px'>
-            Edit
+            {editText}
           </Typography>
           <Edit fontSize='small' className={classes.editIcon} />
         </Box>

--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -44,7 +44,15 @@ export interface HeadCell {
   tooltipTitle?: TooltipProps['title'];
 }
 
-export interface Props<T> {
+export interface LocalizationProps {
+  renderNumSelectedText?: (numSelected: number) => string;
+  renderPaginationText?: (from: number, to: number, total: number) => string;
+  booleanFalseText: string;
+  booleanTrueText: string;
+  editText: string;
+}
+
+export interface Props<T> extends LocalizationProps {
   id?: string;
   orderBy: string;
   order?: SortOrder;
@@ -67,7 +75,6 @@ export interface Props<T> {
   topBarButtons?: TopBarButton[];
   selectedRows?: T[];
   setSelectedRows?: React.Dispatch<React.SetStateAction<T[]>>;
-  showPagination?: boolean;
   controlledOnSelect?: boolean;
   reloadData?: () => void;
   stickyHeader?: boolean;
@@ -102,11 +109,15 @@ export default function EnhancedTable<T extends TableRowType>({
   topBarButtons,
   selectedRows,
   setSelectedRows,
-  showPagination = true,
   controlledOnSelect,
   reloadData,
   stickyHeader = true,
   hideHeader,
+  booleanFalseText,
+  booleanTrueText,
+  editText,
+  renderNumSelectedText,
+  renderPaginationText,
 }: Props<T>): JSX.Element {
   const classes = tableStyles();
   const theme = useTheme();
@@ -263,7 +274,13 @@ export default function EnhancedTable<T extends TableRowType>({
 
   return (
     <>
-      {showTopBar && <EnhancedTableToolbar numSelected={selectedRows ? selectedRows.length : 0} topBarButtons={topBarButtons} />}
+      {showTopBar && (
+        <EnhancedTableToolbar
+          numSelected={selectedRows ? selectedRows.length : 0}
+          renderNumSelectedText={renderNumSelectedText}
+          topBarButtons={topBarButtons}
+        />
+      )}
       <TableContainer id={id} sx={{ overflowX: 'visible' }}>
         <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
           <Table stickyHeader={stickyHeader} aria-labelledby='tableTitle' size='medium' aria-label='enhanced table' className={classes.table}>
@@ -334,6 +351,9 @@ export default function EnhancedTable<T extends TableRowType>({
                                 value={row[c.key]}
                                 onRowClick={onSelect && controlledOnSelect ? (newValue?: string) => onSelect(row as T, c.key, newValue) : onClick}
                                 reloadData={reloadData}
+                                booleanFalseText={booleanFalseText}
+                                booleanTrueText={booleanTrueText}
+                                editText={editText}
                               />
                             ))}
                         </TableRow>
@@ -345,7 +365,7 @@ export default function EnhancedTable<T extends TableRowType>({
           </Table>
         </DndContext>
       </TableContainer>
-      {showPagination && (
+      {renderPaginationText && (
         <Box display='flex' alignItems='center' justifyContent='flex-end' paddingTop='24px'>
           {/*
             Calculate pagination numbers to show.
@@ -354,16 +374,16 @@ export default function EnhancedTable<T extends TableRowType>({
           {rows.length ? (
             itemsToSkip + maxItemsPerPage < rows.length ? (
               <Typography paddingRight='24px' fontSize='14px'>
-                {itemsToSkip + 1} to {itemsToSkip + maxItemsPerPage} of {rows.length}
+                {renderPaginationText(itemsToSkip + 1, itemsToSkip + maxItemsPerPage, rows.length)}
               </Typography>
             ) : (
               <Typography paddingRight='24px' fontSize='14px'>
-                {itemsToSkip + 1} to {rows.length} of {rows.length}
+                {renderPaginationText(itemsToSkip + 1, rows.length, rows.length)}
               </Typography>
             )
           ) : (
             <Typography paddingRight='24px' fontSize='14px'>
-              0 of 0
+              {renderPaginationText(0, 0, 0)}
             </Typography>
           )}
           <Pagination

--- a/src/components/table/types.ts
+++ b/src/components/table/types.ts
@@ -17,6 +17,9 @@ export interface RendererProps<T> {
   onRowClick?: (newValue?: string) => void;
   reloadData?: () => void;
   className?: string;
+  booleanFalseText: string;
+  booleanTrueText: string;
+  editText: string;
 }
 
 export type EnhancedTableDetailsRow = {

--- a/src/stories/ProgressCircle.stories.tsx
+++ b/src/stories/ProgressCircle.stories.tsx
@@ -10,3 +10,7 @@ export default {
 const Template: Story<ProgressCircleProps> = (args) => <ProgressCircle {...args} />;
 
 export const Default = Template.bind({});
+
+Default.args = {
+  renderPercentText: (pct) => `${pct}%`,
+};

--- a/src/stories/Table.stories.tsx
+++ b/src/stories/Table.stories.tsx
@@ -68,6 +68,7 @@ Default.args = {
     { key: 'middlename', name: 'Middlename', type: 'string', tooltipTitle: 'Middle name is optional' },
     { key: 'lastname', name: 'Lastname', type: 'string' },
     { key: 'occupation', name: 'Occupation', type: 'string' },
+    { key: 'available', name: 'Available', type: 'boolean' },
   ],
   rows: Array(50)
     .fill({ name: '', middlename: '', lastname: '', occupation: '' })
@@ -75,12 +76,29 @@ Default.args = {
       if (j % 2 === 0) {
         return { name: `Constanza_${j}`, middlename: '', lastname: 'Uanini', occupation: 'Artist' };
       } else if (j % 3 === 0) {
-        return { name: `Carlos_${j}`, middlename: '--', lastname: 'Thurber', occupation: 'Freelancer' };
+        return {
+          name: `Carlos_${j}`,
+          middlename: '--',
+          lastname: 'Thurber',
+          occupation: 'Freelancer',
+          available: 'false',
+        };
       } else {
-        return { name: `Jane${j}`, middlename: 'John', lastname: 'Doe', occupation: 'Business analyst' };
+        return {
+          name: `Jane${j}`,
+          middlename: 'John',
+          lastname: 'Doe',
+          occupation: 'Business analyst',
+          available: 'true',
+        };
       }
     }),
   showTopBar: false,
+  booleanFalseText: 'No',
+  booleanTrueText: 'Yes',
+  editText: 'Edit',
+  renderNumSelectedText: (num) => `${num} selected`,
+  renderPaginationText: (from, to, total) => `${from} to ${to} of ${total}`,
 };
 
 Selectable.args = {

--- a/src/stories/TextTruncated.stories.tsx
+++ b/src/stories/TextTruncated.stories.tsx
@@ -20,4 +20,6 @@ Default.args = {
   maxLengthPx: 200,
   showAllStyle: {fontSize: 14},
   textStyle: {fontSize: 14},
+  moreSeparator: '...',
+  moreText: 'more',
 };


### PR DESCRIPTION
Add properties to components that can show text or punctuation to allow (or 
rather, require) callers to pass in appropriately localized values. In cases
where the localized strings need to be rendered dynamically, callers pass in
functions that return the strings.