### PR TITLE
MultiSelect Fixes

### DIFF
--- a/src/components/MultiSelect/index.tsx
+++ b/src/components/MultiSelect/index.tsx
@@ -85,9 +85,9 @@ export default function MultiSelect<K, V>(props: MultiSelectProps<K, V>): JSX.El
               />)
             : (<p className='multi-select__placeholder-text' >{placeHolder}</p>)
           }
-          <IconButton className={'multi-select__values__icon-button'} aria-label='show-options'>
-              <Icon name={openedOptions ? 'chevronUp' : 'chevronDown'} className='multi-select__values__icon-right' />
-          </IconButton>
+          <div className={'multi-select__values__icon-button'} aria-label='show-options'>
+            <Icon name={openedOptions ? 'chevronUp' : 'chevronDown'} className='multi-select__values__icon-right' />
+          </div>
         </div>
         {options && unselectedOptions.length > 0 && openedOptions && (
           <div className='multi-select__options-container'>

--- a/src/components/MultiSelect/styles.scss
+++ b/src/components/MultiSelect/styles.scss
@@ -61,12 +61,12 @@
     border-radius: $tw-sz-base-x-small;
     border-width: $tw-sz-frm-fld-text-input-stroke;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
 
     &__icon-button {
-      width: fit-content;
-      height: fit-content;
+      width: $tw-fnt-frm-fld-text-value-line-height;
+      height: $tw-fnt-frm-fld-text-value-line-height;
       padding: 0;
     }
 

--- a/src/components/Pill/index.tsx
+++ b/src/components/Pill/index.tsx
@@ -23,7 +23,7 @@ export default function Pill<IdType>(props: PillProps<IdType>): JSX.Element {
       }
     }}>
       {label && (<p className='label'>{label}:</p>)}
-      <p className='value'>{value}</p>
+      <p className={`value${label ? '' : ' value--no-label'}`}>{value}</p>
       {onRemove ? (
         <IconButton onClick={(ev) => {
           ev.stopPropagation();

--- a/src/components/Pill/styles.scss
+++ b/src/components/Pill/styles.scss
@@ -26,6 +26,10 @@
     color: $tw-clr-txt;
     font-weight: 600;
     margin: 0;
+
+    &--no-label {
+      padding-left: 0;
+    }
   }
 
   .icon {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import ErrorBox from './components/ErrorBox/ErrorBox';
 import Icon from './components/Icon/Icon';
 import IconTooltip from './components/IconTooltip';
 import icons from './components/Icon/icons';
+import MultiSelect from './components/MultiSelect';
 import Navbar from './components/Navbar/Navbar';
 import NavFooter from './components/Navbar/NavFooter';
 import NavItem from './components/Navbar/NavItem';
@@ -59,6 +60,7 @@ export {
   Icon,
   IconTooltip,
   Message,
+  MultiSelect,
   NavFooter,
   NavItem,
   NavSection,


### PR DESCRIPTION
- `align-items: flex-start` to position the chevron correctly
- change IconButton to a div to avoid capturing focus and then blurring
- rm padding in pill when there is no label