### PR TITLE
Textfield allow 0 value

### DIFF
--- a/src/components/Textfield/Textfield.tsx
+++ b/src/components/Textfield/Textfield.tsx
@@ -121,7 +121,7 @@ export default function TextField(props: Props): JSX.Element {
             {iconLeft && <Icon name={iconLeft} className='textfield-value--icon-left' />}
             <input
               autoFocus={autoFocus}
-              value={value || ''}
+              value={type === 'number' ? value : value || ''}
               disabled={readonly || disabled}
               placeholder={placeholder}
               onChange={textfieldOnChange}


### PR DESCRIPTION
For textfields we were only showing 'truthy values'. Allow when type is number, to have value 0.