### PR TITLE
Fix datepicker first keypress ignored

### DIFF
--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -34,7 +34,7 @@ export default function DatePicker(props: Props): JSX.Element {
   }, [locale]);
 
   React.useEffect(() => {
-    if (props.value !== temporalValue) {
+    if (props.value !== temporalValue && props.value !== null) {
       setTemporalValue(props.value || null);
     }
   }, [props.value]);


### PR DESCRIPTION
On datepicker component when pressing any key, if the value is not a valid date, we just save the value in "temporalValue" variable and the value (of the component) is set to null.

We were reseting the temporal value to null for the first key pressed because temporalValue was the key pressed, then value was set to null (because the value was not valid), and then temporalValue was set again to null because it was different from the temporal value.

The fix is to set temporal value equal to "value", only if value is not null