### PR TITLE
SW-2518 Remove fieldset border and apply border styling

### DIFF
--- a/src/components/Autocomplete/styles.scss
+++ b/src/components/Autocomplete/styles.scss
@@ -26,6 +26,20 @@
     border-radius: $tw-spc-base-x-small;
     position: unset;
     padding: 0;
+
+    &:hover {
+      border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-hover;
+    }
+    &:active {
+      border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-active;
+      outline: $tw-sz-frm-fld-text-input-stroke-active solid $tw-clr-brdr-active;
+    }
+    &:focus-within {
+      border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-active;
+      outline: $tw-sz-frm-fld-text-input-stroke-active solid $tw-clr-brdr-active;
+      outline-offset: -$tw-sz-frm-fld-text-input-stroke;
+    }
+
   }
 
   .Mui-disabled {
@@ -45,17 +59,13 @@
     padding: calc(#{$tw-spc-base-xx-small} * 2.5) calc(#{$tw-spc-base-xx-small} * 3);
   }
 
+  fieldset {
+    border: none;
+  }
+
   & .MuiInputBase-input {
     height: '21px';
   };
-  & .MuiOutlinedInput-root {
-    &:hover fieldset {
-      border-color: $tw-clr-brdr-hover;
-    }
-    .Mui-focused fieldset {
-      border-color: $tw-clr-brdr-hover;
-    }
-  }
 
   &--icon-right {
     width: $tw-fnt-frm-fld-text-value-line-height;

--- a/src/components/DatePicker/styles.scss
+++ b/src/components/DatePicker/styles.scss
@@ -59,9 +59,22 @@
   }
 
   .MuiInputBase-root {
-    border: 1px solid $tw-clr-bg-info;
+    border: 1px solid $tw-clr-brdr-secondary;
     border-radius: $tw-sz-base-x-small;
     position: unset;
+    &:hover {
+      border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-hover;
+    }
+    &:active {
+      border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-active;
+      outline: $tw-sz-frm-fld-text-input-stroke-active solid $tw-clr-brdr-active;
+    }
+    
+    &:focus-within {
+      border: $tw-sz-frm-fld-text-input-stroke solid $tw-clr-brdr-active;
+      outline: $tw-sz-frm-fld-text-input-stroke-active solid $tw-clr-brdr-active;
+      outline-offset: -$tw-sz-frm-fld-text-input-stroke;
+    }
   }
 
   .MuiInputBase-input {
@@ -78,12 +91,8 @@
     border-radius: $tw-sz-base-x-small 0 0 $tw-sz-base-x-small;
   }
 
-  .MuiOutlinedInput-root {
-    &:hover fieldset {
-      border-color: $tw-clr-brdr-hover;
-    }
-    &.Mui-focused fieldset {
-      border-color: $tw-clr-brdr-hover;
-    }
+  fieldset {
+    border: none;
   }
+
 }


### PR DESCRIPTION
There was an issue where the fieldset border was overlapping the input border which caused the color to be slightly off.  
Removed all fieldset borders and applied all border styling to the input element instead.