### PR TITLE
SW-3184 Disable scroll on number input fields

### DIFF
--- a/src/components/Textfield/Textfield.tsx
+++ b/src/components/Textfield/Textfield.tsx
@@ -133,6 +133,7 @@ export default function TextField(props: Props): JSX.Element {
               placeholder={placeholder}
               onChange={textfieldOnChange}
               onKeyDown={onKeyDownHandler}
+              onWheel={(e) => e.currentTarget.blur()}
               {...typeProps}
             />
             {iconRight ? renderRightIcon() : null}


### PR DESCRIPTION
[SW-3184](https://terraformation.atlassian.net/browse/SW-3184) mention that values are being changed while scrolling when editing an inventory batch. I guess this behavior is unwanted in all inputs, that's why I'm adding the change here

[SW-3184]: https://terraformation.atlassian.net/browse/SW-3184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ