### PR TITLE
SW-3434 Textfield Can Preserve Newlines

### DIFF
--- a/src/components/Textfield/Textfield.tsx
+++ b/src/components/Textfield/Textfield.tsx
@@ -35,6 +35,7 @@ export interface Props {
   min?: number;
   max?: number;
   disabledCharacters?: string[];
+  preserveNewlines?: boolean;
 }
 
 export default function TextField(props: Props): JSX.Element {
@@ -62,6 +63,7 @@ export default function TextField(props: Props): JSX.Element {
     min,
     max,
     disabledCharacters,
+    preserveNewlines,
   } = props;
 
   const textfieldClass = classNames({
@@ -152,7 +154,7 @@ export default function TextField(props: Props): JSX.Element {
             onBlur={onBlur}
           />
         ))}
-      {display && <p className='textfield-value--display'>{value}</p>}
+      {display && <p className={`textfield-value--display${preserveNewlines ? ' preserve-newlines' : ''}`}>{value}</p>}
       {errorText && (
         <div className='textfield-label-container'>
           <Icon name='error' className='textfield-error-text--icon' />

--- a/src/components/Textfield/styles.scss
+++ b/src/components/Textfield/styles.scss
@@ -111,6 +111,10 @@
       line-height: $tw-fnt-frm-fld-text-value-line-height;
       padding: $tw-spc-base-x-small 0;
       margin: 0;
+
+      &.preserve-newlines {
+        white-space: pre-line;
+      }
     }
 
     &--disabled {

--- a/src/stories/TextfieldNew.stories.tsx
+++ b/src/stories/TextfieldNew.stories.tsx
@@ -67,6 +67,7 @@ Default.args = {
   display: false,
   type: 'text',
   autoFocus: false,
+  preserveNewlines: false,
 };
 
 WithTooltip.args = {
@@ -81,6 +82,7 @@ WithTooltip.args = {
   type: 'text',
   tooltipTitle: 'Hello world!',
   autoFocus: false,
+  preserveNewlines: false,
 };
 
 TextArea.args = {
@@ -94,6 +96,7 @@ TextArea.args = {
   display: false,
   type: 'textarea',
   autoFocus: false,
+  preserveNewlines: false,
 };
 
 NumberField.args = {
@@ -108,4 +111,5 @@ NumberField.args = {
   min: 5,
   max: 25,
   autoFocus: false,
+  preserveNewlines: false,
 };

--- a/src/stories/TextfieldNew.stories.tsx
+++ b/src/stories/TextfieldNew.stories.tsx
@@ -96,7 +96,7 @@ TextArea.args = {
   display: false,
   type: 'textarea',
   autoFocus: false,
-  preserveNewlines: false,
+  preserveNewlines: true,
 };
 
 NumberField.args = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11271,7 +11271,7 @@ loader-utils@1.2.3:
     emojis-list "^2.0.0"
     json5 "^1.0.1"
 
-loader-utils@2.0.0, loader-utils@^2.0.0, loader-utils@^2.0.4:
+loader-utils@2.0.0, loader-utils@^1.2.3, loader-utils@^2.0.0, loader-utils@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
   integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
@@ -11280,7 +11280,7 @@ loader-utils@2.0.0, loader-utils@^2.0.0, loader-utils@^2.0.4:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
-loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-utils@^1.1.0, loader-utils@^1.4.0:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.2.tgz#29a957f3a63973883eb684f10ffd3d151fec01a3"
   integrity sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==


### PR DESCRIPTION
When in display mode, setting the preserveNewlines prop to true will cause newlines to be displayed. This is off by default, preserving the previous behavior of collapsing newlines.

![image](https://user-images.githubusercontent.com/114949086/231867284-9ff2f90a-6b19-47c5-9972-a7a975e445e9.png)
![image](https://user-images.githubusercontent.com/114949086/231867345-26872bf5-3d57-4334-ab39-533c363fe098.png)
