### PR TITLE
SW-3503 Fix cannot sort table columns that show dates

### DIFF
--- a/src/components/table/sort.ts
+++ b/src/components/table/sort.ts
@@ -20,8 +20,9 @@ export function descendingComparator<T>(a: T, b: T, orderBy: keyof T): number {
 }
 
 function descendingNumComparator<T>(a: T, b: T, orderBy: keyof T): number | null {
-  const aNumValue = parseFloat((a[orderBy] ?? '0.0') as string);
-  const bNumValue = parseFloat((b[orderBy] ?? '0.0') as string);
+  const aNumValue = Number((a[orderBy] ?? '0.0') as string);
+  const bNumValue = Number((b[orderBy] ?? '0.0') as string);
+
   if (!isNaN(aNumValue) && !isNaN(bNumValue)) {
     return bNumValue - aNumValue;
   }

--- a/src/stories/Table.stories.tsx
+++ b/src/stories/Table.stories.tsx
@@ -39,21 +39,19 @@ const Template: Story<TableProps<{ name: string; lastname: string }>> = (args) =
       Renderer={Renderer}
       selectedRows={selectedRows}
       setSelectedRows={setSelectedRows}
-      topBarButtons={
-        [
-          {
-            buttonType: 'productive',
-            buttonText: 'Click',
-            onButtonClick: () => window.alert('click')
-          },
-          {
-            buttonType: 'passive',
-            buttonText: 'Disabled',
-            onButtonClick: () => window.alert('you should not see this'),
-            disabled: true,
-          },
-        ]
-      }
+      topBarButtons={[
+        {
+          buttonType: 'productive',
+          buttonText: 'Click',
+          onButtonClick: () => window.alert('click'),
+        },
+        {
+          buttonType: 'passive',
+          buttonText: 'Disabled',
+          onButtonClick: () => window.alert('you should not see this'),
+          disabled: true,
+        },
+      ]}
     />
   );
 };
@@ -70,12 +68,14 @@ Default.args = {
     { key: 'lastname', name: 'Lastname', type: 'string' },
     { key: 'occupation', name: 'Occupation', type: 'string' },
     { key: 'available', name: 'Available', type: 'boolean' },
+    { key: 'date', name: 'Date', type: 'string' },
+    { key: 'pets', name: 'Pets', type: 'string' },
   ],
   rows: Array(150)
     .fill({ name: '', middlename: '', lastname: '', occupation: '' })
     .map((i, j) => {
       if (j % 2 === 0) {
-        return { name: `Constanza_${j}`, middlename: '', lastname: 'Uanini', occupation: 'Artist' };
+        return { name: `Constanza_${j}`, middlename: '', lastname: 'Uanini', occupation: 'Artist', date: '2023-02-03', pets: 5 };
       } else if (j % 3 === 0) {
         return {
           name: `Carlos_${j}`,
@@ -83,6 +83,8 @@ Default.args = {
           lastname: 'Thurber',
           occupation: 'Freelancer',
           available: 'false',
+          date: '2023-04-12',
+          pets: 10,
         };
       } else {
         return {
@@ -91,6 +93,8 @@ Default.args = {
           lastname: 'Doe',
           occupation: 'Business analyst',
           available: 'true',
+          date: '2023-04-27',
+          pets: 12,
         };
       }
     }),


### PR DESCRIPTION
The problem was with using parseFloat. It was returning the value up to the dash character -, ignoring the characters following it. So it was basically comparing the year, if the dates were all same year it didn't change anything when sorting (it did "sort" if you had dates from different years)

Change to use it Number, so that if it cannot compare values as a number, it will continue the logic to compare as a string.

Added a number column and a date column to the stories to test the change