### PR TITLE
Skip package/version bump in design-changes workflow

### DIFF
--- a/.github/workflows/design-workflow.yml
+++ b/.github/workflows/design-workflow.yml
@@ -48,9 +48,6 @@ jobs:
       - name: Build dictionary 
         run: yarn build-dictionary
 
-      - name: Bump package patch version
-        run: yarn bump patch
-
       - name: Config user
         run: |
           git config --global user.email ${{ github.event.inputs.email }}


### PR DESCRIPTION
- we have another deployment action that takes care of version bumps
- i would prefer for design-changes workflow to add a 'patch' label to the PR automatically, will see how we can do that