### PR TITLE
Use DialogBox Scrolled Prop

### DIFF
--- a/src/components/DialogBox/styles.scss
+++ b/src/components/DialogBox/styles.scss
@@ -118,7 +118,6 @@
     border-bottom: 1px solid $tw-clr-brdr-tertiary;
     padding: $tw-spc-base-medium;
     text-align: center;
-    overflow: scroll;
     &.scrolled {
       overflow: auto;
     }

--- a/src/components/ViewPhotosDialog/index.tsx
+++ b/src/components/ViewPhotosDialog/index.tsx
@@ -81,6 +81,7 @@ export default function ViewPhotosDialog(props: ViewPhotosDialogProps): JSX.Elem
       open={open}
       title={title}
       size='large'
+      scrolled={true}
       middleButtons={[
         <Button
           label={prevButtonLabel}


### PR DESCRIPTION
The DialogBox component had the `scrolled` prop, which I had missed
earlier. Use that for ViewPhotosDialog instead of making all dialog
boxes scrolled.