### PR TITLE
Update Button Enabled/Disabled on Open

### DIFF
--- a/src/components/ViewPhotosDialog/index.tsx
+++ b/src/components/ViewPhotosDialog/index.tsx
@@ -72,6 +72,7 @@ export default function ViewPhotosDialog(props: ViewPhotosDialogProps): JSX.Elem
   useEffect(() => {
     if (myCarousel.current) {
       myCarousel.current.goToSlide(selectedSlide);
+      handleChange();
     }
   }, [selectedSlide]);
 

--- a/src/components/ViewPhotosDialog/index.tsx
+++ b/src/components/ViewPhotosDialog/index.tsx
@@ -67,12 +67,12 @@ export default function ViewPhotosDialog(props: ViewPhotosDialogProps): JSX.Elem
 
   useEffect(() => {
     setSelectedSlide(initialSelectedSlide);
+    handleChange();
   }, [initialSelectedSlide, open]);
 
   useEffect(() => {
     if (myCarousel.current) {
       myCarousel.current.goToSlide(selectedSlide);
-      handleChange();
     }
   }, [selectedSlide]);
 


### PR DESCRIPTION
The prev/next buttons' disabled state was not being updated on first load. This is exemplified by the case where only one photo was shown. 

This is fixed by adding a call to handleChange in the [initialSelectedSlide, open] useEffect. Thus, it should only be called additionally when the dialog is first opened.

<img width="1496" alt="image" src="https://user-images.githubusercontent.com/114949086/236255302-24ae9fa9-448b-49ef-a61c-6b20f0495a49.png">
