### PR TITLE
Allow rendering full images in the view photos dialog

### DIFF
--- a/src/components/ViewPhotosDialog/index.tsx
+++ b/src/components/ViewPhotosDialog/index.tsx
@@ -135,7 +135,7 @@ export default function ViewPhotosDialog(props: ViewPhotosDialogProps): JSX.Elem
               <a href={p.url} target='blank'>
                 <img
                   className='view-photos-dialog-image'
-                  src={`${p.url}?maxHeight=400`}
+                  src={p.url}
                   alt={p.alt}
                   onLoad={() => finishLoading(i)}
                 />


### PR DESCRIPTION
- removed the height setting, which triggers loading thumbnails instead of full images
- this leaves it to the client to decide which image to view