### PR TITLE
SW-3345 Fix the date format in datepicker

### DIFF
--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -37,7 +37,7 @@ export default function DatePicker(props: Props): JSX.Element {
     if (props.value !== temporalValue && props.value !== null) {
       setTemporalValue(props.value || null);
     }
-  }, [props.value]);
+  }, [props.value, temporalValue]);
 
   const renderInput = (params: object) => (
     <>
@@ -71,7 +71,7 @@ export default function DatePicker(props: Props): JSX.Element {
           onError={props.onError}
           minDate={props.minDate ? moment(props.minDate) : undefined}
           maxDate={props.maxDate ? moment(props.maxDate) : undefined}
-          inputFormat='yyyy-MM-DD'
+          inputFormat='YYYY-MM-DD'
           value={temporalValue}
           onChange={(newValue: any) => {
             setTemporalValue(newValue);


### PR DESCRIPTION
- we were using date-fns as the date library with `yyyy-MM-DD` as the date format
- with i18n timezones project, we switched to moment but missed updating the format to `YYYY-MM-DD`  [documented format for year](https://momentjscom.readthedocs.io/en/latest/moment/04-displaying/01-format/)
- `yyyy` has different semantics in moment and was causing the issues
- this PR updates the date format for moment (`YYYY-MM-DD`)