### PR TITLE
SW-3712 add a fillColor property on Icon component

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,16 +1,31 @@
+import React from 'react';
+import { makeStyles } from '@mui/styles';
 import { Size } from '../Size';
 import icons, { IconName } from './icons';
 import './styles.scss';
-import React from 'react';
+
+type StyleProps = {
+  fillColor?: string;
+};
+
+const useStyles = makeStyles(() => ({
+  icon: {
+    '& path': {
+      fill: (props: StyleProps) => props.fillColor ?? 'inherit',
+    }
+  }
+}));
 
 export interface Props {
   name: IconName;
   size?: Size;
   className?: string;
+  fillColor?: string;
 }
 
-export default function Icon({ size = 'small', name, className }: Props): JSX.Element {
+export default function Icon({ size = 'small', name, className, fillColor }: Props): JSX.Element {
+  const classes = useStyles({ fillColor });
   const SVGComponent = icons[name];
 
-  return <SVGComponent className={`tw-icon tw-icon--${size} ${className ?? className}`} />;
+  return <SVGComponent className={`tw-icon tw-icon--${size} ${className ?? className} ${classes.icon}`} />;
 }


### PR DESCRIPTION
- make it easier to fill an icon with color
- avoids having to override fill with nested css
- did not extend Button with similar pattern, different use-case (icon fill is propagated from button)

<img width="475" alt="Icon - Default ⋅ Storybook 2023-06-21 14-47-09" src="https://github.com/terraware/web-components/assets/1865174/d4ca3484-b11a-4a05-af99-3e69a1b31025">
