### PR TITLE
SW-3940 Fix tabs component to not depend on i18n string value 

### DIFF
--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -4,6 +4,7 @@ import { Box, Tab, useTheme } from '@mui/material';
 import { useDeviceInfo } from '../../utils';
 
 export type Tab = {
+  id: string;
   label: string;
   children: React.ReactNode;
   disabled?: boolean;
@@ -16,7 +17,7 @@ export type TabsProps = {
 };
 
 const Tabs = ({ tabs, onTabChange, activeTab }: TabsProps): JSX.Element => {
-  const [selectedTab, setSelectedTab] = useState<string>(activeTab ?? tabs[0]?.label ?? '');
+  const [selectedTab, setSelectedTab] = useState<string>(activeTab ?? tabs[0]?.id ?? '');
   const theme = useTheme();
   const { isMobile } = useDeviceInfo();
 
@@ -72,12 +73,12 @@ const Tabs = ({ tabs, onTabChange, activeTab }: TabsProps): JSX.Element => {
             }}
           >
             {tabs.map((tab, index) => (
-              <Tab label={tab.label} value={tab.label} sx={tabStyles} key={index} disabled={tab.disabled} />
+              <Tab label={tab.label} value={tab.id} sx={tabStyles} key={index} disabled={tab.disabled} />
             ))}
           </TabList>
         </Box>
         {tabs.map((tab, index) => (
-          <TabPanel value={tab.label} key={index} sx={tabPanelStyles}>
+          <TabPanel value={tab.id} key={index} sx={tabPanelStyles}>
             {tab.children}
           </TabPanel>
         ))}

--- a/src/stories/Tabs.stories.tsx
+++ b/src/stories/Tabs.stories.tsx
@@ -14,7 +14,7 @@ const Template: Story<TabsProps> = (args) => {
 };
 
 const OverrideTemplate: Story<TabsProps> = (args) => {
-  const [activeTab, setActiveTab] = useState<string>('Tab1');
+  const [activeTab, setActiveTab] = useState<string>('tab1');
 
   const onTabChange = (tab: string) => {
     if (tab !== 'tab3') {

--- a/src/stories/Tabs.stories.tsx
+++ b/src/stories/Tabs.stories.tsx
@@ -17,7 +17,7 @@ const OverrideTemplate: Story<TabsProps> = (args) => {
   const [activeTab, setActiveTab] = useState<string>('Tab1');
 
   const onTabChange = (tab: string) => {
-    if (tab !== 'Tab3') {
+    if (tab !== 'tab3') {
       setActiveTab(tab);
     }
   };
@@ -29,8 +29,8 @@ export const Default = Template.bind({});
 
 Default.args = {
   tabs: [
-    { label: 'Tab1', children: 'tab1 contents', disabled: false },
-    { label: 'Tab2', children: 'tab2 contents', disabled: false },
+    { id: 'tab1', label: 'Tab1', children: 'tab1 contents', disabled: false },
+    { id: 'tab2', label: 'Tab2', children: 'tab2 contents', disabled: false },
   ],
 };
 
@@ -38,8 +38,8 @@ export const OverrideActiveTab = OverrideTemplate.bind({});
 
 OverrideActiveTab.args = {
   tabs: [
-    { label: 'Tab1', children: 'tab1 contents', disabled: false },
-    { label: 'Tab2', children: 'tab2 contents', disabled: false },
-    { label: 'Tab3', children: 'tab3 contents', disabled: false },
+    { id: 'tab1', label: 'Tab1', children: 'tab1 contents', disabled: false },
+    { id: 'tab2', label: 'Tab2', children: 'tab2 contents', disabled: false },
+    { id: 'tab3', label: 'Tab3', children: 'tab3 contents', disabled: false },
   ],
 };


### PR DESCRIPTION
- introduce id in tabs, which will be the tab's value
- the label alone will be the i18n friendly string
- otherwise client code cannot depend on a deterministic id