### PR TITLE
Debug Publish RC job

### DIFF
--- a/.github/workflows/publish-rc.yaml
+++ b/.github/workflows/publish-rc.yaml
@@ -9,9 +9,15 @@ jobs:
   publish-rc:
     # This job only runs for pull request comments
     name: Publish RC PR comment
-    if: ${{ github.event.issue.pull_request }} && contains(github.event.comment.body, 'publish rc')
+    if: github.event.issue.pull_request && contains(github.event.comment.body, 'publish rc')
     runs-on: ubuntu-latest
     steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: |
+          echo "$GITHUB_CONTEXT"
+
       - name: Get Branch
         id: 'get-branch'
         run: echo ::set-output name=branch::$(gh pr view $PR_NUMBER --repo $REPO --json headRefName --jq '.headRefName')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.3.60",
+  "version": "2.3.61-rc.0",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Dump GH context to see if I can determine why the Publish RC job is firing even when the comment does not contain 'publish rc'