### PR TITLE
SW-4241 Allow disabled table row checkboxes and tooltip titles for the checkbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.3.65",
+  "version": "2.3.66-rc.0",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test-coverage": "cp tsconfig.json tsconfig.json.bak && react-scripts test . --coverage --coverageDirectory='docs/coverage' && mv tsconfig.json.bak tsconfig.json",
     "eject": "react-scripts eject",
     "storybook": "storybook dev",
+    "storybook-legacy": "NODE_OPTIONS=--openssl-legacy-provider storybook dev",
     "build-storybook": "storybook build -s public",
     "build-dictionary": "./style-dictionary/generate.sh",
     "transpile": "rm -rf dist && NODE_ENV=production babel src/ --extensions '.tsx,.ts' --out-dir dist --copy-files --no-copy-ignored && cp package.json dist/",

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -1,8 +1,8 @@
 import { Checkbox as MUICheckbox, FormControlLabel, Theme, useTheme } from '@mui/material';
 import React, { SyntheticEvent } from 'react';
 
-export const CheckboxStyle = (theme: Theme) => ({
-  padding: theme.spacing(0, 1, 0, 0),
+export const CheckboxStyle = (theme: Theme, paddingRight = 1) => ({
+  padding: theme.spacing(0, paddingRight, 0, 0),
   '& .MuiSvgIcon-root': {
     fill: theme.palette.TwClrBrdrSecondary,
   },

--- a/src/stories/Table.stories.tsx
+++ b/src/stories/Table.stories.tsx
@@ -58,6 +58,7 @@ const Template: Story<TableProps<{ name: string; lastname: string }>> = (args) =
 
 export const Default = Template.bind({});
 export const Selectable = Template.bind({});
+export const IsSelectable = Template.bind({});
 export const Presorted = Template.bind({});
 
 Default.args = {
@@ -110,6 +111,14 @@ Selectable.args = {
   ...Default.args,
   showCheckbox: true,
   controlledOnSelect: true,
+};
+
+IsSelectable.args = {
+  ...Default.args,
+  showCheckbox: true,
+  controlledOnSelect: true,
+  isSelectable: (row) => !!row.name.match('15') ? false : true,
+  checkboxTooltip: (row) => !!row.name.match('15') ? 'This checkbox is not selectable' : undefined,
 };
 
 Presorted.args = {


### PR DESCRIPTION
- added new optional prop func `isSelectable` that returns boolean if a row is selectable
- this can be used to dictate whether a row is selectable or not, the component does the right math to show selected-all logic
- disabled selections will show a disabled checkbox
- also add support for showing tooltips next to a checkbox (if use-case wants to explain why a row is not selectable)
- added a story to capture this
- this will be used to disable selecting certain users in TW People table

<img width="275" alt="Screen Shot 2023-09-21 at 3 38 31 PM" src="https://github.com/terraware/web-components/assets/1865174/086a86a4-1d12-4438-af80-608c5a04970e">

<img width="365" alt="Table - Is Selectable ⋅ Storybook 2023-09-21 15-38-13" src="https://github.com/terraware/web-components/assets/1865174/79756cee-e15f-48e5-b8dd-c7cd06250582">

