### PR TITLE
SW-4239 Add support for showing tooltips in table topbar buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.3.65",
+  "version": "2.3.66-rc.0",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test-coverage": "cp tsconfig.json tsconfig.json.bak && react-scripts test . --coverage --coverageDirectory='docs/coverage' && mv tsconfig.json.bak tsconfig.json",
     "eject": "react-scripts eject",
     "storybook": "storybook dev",
+    "storybook-legacy": "NODE_OPTIONS=--openssl-legacy-provider storybook dev",
     "build-storybook": "storybook build -s public",
     "build-dictionary": "./style-dictionary/generate.sh",
     "transpile": "rm -rf dist && NODE_ENV=production babel src/ --extensions '.tsx,.ts' --out-dir dist --copy-files --no-copy-ignored && cp package.json dist/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.3.66-rc.0",
+  "version": "2.3.66-rc.1",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/table/EnhancedTableToolbar.tsx
+++ b/src/components/table/EnhancedTableToolbar.tsx
@@ -27,30 +27,24 @@ export default function EnhancedTableToolbar(props: EnhancedTableToolbarProps): 
   const { numSelected, renderNumSelectedText, topBarButtons } = props;
   const classes = styles();
 
-  const getButton = (tbButton: TopBarButton) => (
-    <Button
-      className={classes.buttonSpacing}
-      key={tbButton.buttonText}
-      label={tbButton.buttonText}
-      priority='secondary'
-      type={tbButton.buttonType}
-      onClick={tbButton.onButtonClick}
-      icon={tbButton.icon}
-      disabled={tbButton.disabled}
-     />
-  );
-
   return renderNumSelectedText && numSelected > 0 ? (
     <Toolbar className={classes.toolbar}>
       <Typography color='inherit' variant='subtitle1' component='div' className={classes.flexText}>
         {renderNumSelectedText(numSelected)}
       </Typography>
       {topBarButtons?.map((tbButton) => (
-        tbButton.tooltipTitle ? (
-          <Tooltip title={tbButton.tooltipTitle}>
-            {getButton(tbButton)}
-          </Tooltip>
-        ) : getButton(tbButton)
+        <Tooltip title={tbButton.tooltipTitle}>
+          <Button
+            className={classes.buttonSpacing}
+            key={tbButton.buttonText}
+            label={tbButton.buttonText}
+            priority='secondary'
+            type={tbButton.buttonType}
+            onClick={tbButton.onButtonClick}
+            icon={tbButton.icon}
+            disabled={tbButton.disabled}
+          />
+        </Tooltip>
       ))}
     </Toolbar>
   ) : null;

--- a/src/components/table/EnhancedTableToolbar.tsx
+++ b/src/components/table/EnhancedTableToolbar.tsx
@@ -1,8 +1,9 @@
+import React from 'react';
 import { Theme, Toolbar, Typography } from '@mui/material';
 import { TopBarButton } from '.';
 import Button from '../Button/Button';
 import { makeStyles } from '@mui/styles';
-import React from 'react';
+import Tooltip from '../Tooltip/Tooltip';
 
 const styles = makeStyles((theme: Theme) => ({
   toolbar: {
@@ -26,25 +27,31 @@ export default function EnhancedTableToolbar(props: EnhancedTableToolbarProps): 
   const { numSelected, renderNumSelectedText, topBarButtons } = props;
   const classes = styles();
 
+  const getButton = (tbButton: TopBarButton) => (
+    <Button
+      className={classes.buttonSpacing}
+      key={tbButton.buttonText}
+      label={tbButton.buttonText}
+      priority='secondary'
+      type={tbButton.buttonType}
+      onClick={tbButton.onButtonClick}
+      icon={tbButton.icon}
+      disabled={tbButton.disabled}
+     />
+  );
+
   return renderNumSelectedText && numSelected > 0 ? (
     <Toolbar className={classes.toolbar}>
       <Typography color='inherit' variant='subtitle1' component='div' className={classes.flexText}>
         {renderNumSelectedText(numSelected)}
       </Typography>
-      {topBarButtons?.map((tbButton) => {
-        return (
-          <Button
-            className={classes.buttonSpacing}
-            key={tbButton.buttonText}
-            label={tbButton.buttonText}
-            priority='secondary'
-            type={tbButton.buttonType}
-            onClick={tbButton.onButtonClick}
-            icon={tbButton.icon}
-            disabled={tbButton.disabled}
-          />
-        );
-      })}
+      {topBarButtons?.map((tbButton) => (
+        tbButton.tooltipTitle ? (
+          <Tooltip title={tbButton.tooltipTitle}>
+            {getButton(tbButton)}
+          </Tooltip>
+        ) : getButton(tbButton)
+      ))}
     </Toolbar>
   ) : null;
 }

--- a/src/components/table/EnhancedTableToolbar.tsx
+++ b/src/components/table/EnhancedTableToolbar.tsx
@@ -32,8 +32,8 @@ export default function EnhancedTableToolbar(props: EnhancedTableToolbarProps): 
       <Typography color='inherit' variant='subtitle1' component='div' className={classes.flexText}>
         {renderNumSelectedText(numSelected)}
       </Typography>
-      {topBarButtons?.map((tbButton) => (
-        <Tooltip title={tbButton.tooltipTitle}>
+      {topBarButtons?.map((tbButton, index) => (
+        <Tooltip title={tbButton.tooltipTitle} key={index}>
           <Button
             className={classes.buttonSpacing}
             key={tbButton.buttonText}

--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -88,6 +88,7 @@ export type TopBarButton = {
   onButtonClick: () => void;
   icon?: IconName;
   disabled?: boolean;
+  tooltipTitle?: TooltipProps['title'];
 };
 
 export default function EnhancedTable<T extends TableRowType>({

--- a/src/stories/Table.stories.tsx
+++ b/src/stories/Table.stories.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import Table, { Props as TableProps } from '../components/table/index';
 import CellRenderer from '..//components/table/TableCellRenderer';
 import { RendererProps } from '../components/table/types';
-
+import { Box } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 
 const useStyles = makeStyles(() => ({
@@ -29,36 +29,47 @@ function Renderer(props: RendererProps<any>): JSX.Element {
 }
 
 const Template: Story<TableProps<{ name: string; lastname: string }>> = (args) => {
+  const classes = useStyles();
   const [selectedRows, setSelectedRows] = useState<any>([]);
   const styles = useStyles();
   args.columns[1].className = styles.italic;
 
   return (
-    <Table
-      {...args}
-      Renderer={Renderer}
-      selectedRows={selectedRows}
-      setSelectedRows={setSelectedRows}
-      topBarButtons={[
-        {
-          buttonType: 'productive',
-          buttonText: 'Click',
-          onButtonClick: () => window.alert('click'),
-        },
-        {
-          buttonType: 'passive',
-          buttonText: 'Disabled',
-          onButtonClick: () => window.alert('you should not see this'),
-          disabled: true,
-        },
-      ]}
-    />
+    <Box paddingTop={args.showTopBar ? '50px' : 0} display='flex' flexGrow={1} flexDirection='column'>
+      <Table
+        {...args}
+        Renderer={Renderer}
+        selectedRows={selectedRows}
+        setSelectedRows={setSelectedRows}
+        topBarButtons={[
+          {
+            buttonType: 'productive',
+            buttonText: 'Click',
+            onButtonClick: () => window.alert('click'),
+          },
+          {
+            buttonType: 'passive',
+            buttonText: 'Disabled',
+            onButtonClick: () => window.alert('you should not see this'),
+            disabled: true,
+          },
+          {
+            buttonType: 'passive',
+            buttonText: 'Tooltip',
+            onButtonClick: () => window.alert('you should not see this either'),
+            disabled: true,
+            tooltipTitle: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+          },
+        ]}
+      />
+    </Box>
   );
 };
 
 export const Default = Template.bind({});
 export const Selectable = Template.bind({});
 export const Presorted = Template.bind({});
+export const ShowTopBar = Template.bind({});
 
 Default.args = {
   orderBy: 'name',
@@ -115,4 +126,11 @@ Selectable.args = {
 Presorted.args = {
   ...Default.args,
   isPresorted: true,
+};
+
+ShowTopBar.args = {
+  ...Default.args,
+  showCheckbox: true,
+  controlledOnSelect: true,
+  showTopBar: true,
 };


### PR DESCRIPTION
- to be used in TF Contact selection

<img width="1481" alt="Screen Shot 2023-09-25 at 10 03 10 AM" src="https://github.com/terraware/web-components/assets/1865174/b4147395-62a1-4afc-aa0a-740860f01173">
