### PR TITLE
Fix MultiSelect-within-Popover functionality

### DIFF
--- a/src/components/MultiSelect/index.tsx
+++ b/src/components/MultiSelect/index.tsx
@@ -15,6 +15,7 @@ export type MultiSelectProps<K, V> = {
   missingValuePlaceholder?: string;
   onAdd: (item: K) => void;
   onBlur?: () => void;
+  onFocus?: () => void;
   onPillClick?: (item: K) => void;
   onRemove: (item: K) => void;
   options: Map<K, V>;
@@ -51,6 +52,10 @@ export default function MultiSelect<K, V>(props: MultiSelectProps<K, V>): JSX.El
 
   const toggleOptions = () => {
     setOpenedOptions((isOpen) => !isOpen && !disabled);
+
+    if (props.onFocus) {
+      props.onFocus();
+    }
   };
 
   useEffect(() => {

--- a/src/stories/MultiSelect.stories.tsx
+++ b/src/stories/MultiSelect.stories.tsx
@@ -56,16 +56,7 @@ const WithParentOptionsVisibilityControlTemplate: Story<MultiSelectProps<number,
   const [selectedOptions, setSelectedOptions] = useState<number[]>([]);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [optionsVisible, setOptionsVisible] = useState(false);
-  /*
-    Admittedly, this is a bit confusing. Because the onBlur event within the MultiSelect bubbles up _before_ the
-    onClose event in the Popover, we need to store, within this component's state, whether or not the options _were_
-    visible before the blur event occurred. I tried many, many configurations where setOptionsVisible was passed into
-    the MultiSelect, but the onBlur would still fire before the child component could tell the parent component that
-    the options were no longer visible (using setOptionsVisible), which resulted in the options being close, the parent
-    component re-rendering, and then the onClose handler would think that the options aren't visible, so the Popover
-    should be closed, which resulted in not achieving the goal.
-   */
-  const [optionsWereVisibleBeforeBlur, setOptionsWereVisibleBeforeblur] = useState(false);
+  const [shouldClose, setShouldClose] = useState(false);
 
   const toggleMultiSelectVisible = (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     if (event) {
@@ -74,16 +65,34 @@ const WithParentOptionsVisibilityControlTemplate: Story<MultiSelectProps<number,
   };
 
   const hideOptionsOrClose = () => {
-    if (optionsWereVisibleBeforeBlur) {
-      setOptionsVisible(false);
-      setOptionsWereVisibleBeforeblur(false);
-    } else {
+    if (shouldClose) {
       setAnchorEl(null);
     }
   };
 
   const onMultiSelectBlur = () => {
-    setOptionsWereVisibleBeforeblur(true);
+    /*
+      I admit this is less than ideal. I was unable to find another solution (and I spent way to long on it already).
+      Because there are two events that fire in immediate succession (and in this order), the MultiSelect onBlur
+      and the Popover onClick, we need to setOptionsVisible(false) and setShouldClose(false) _after_ the
+      Popover's onClickCapture executes. I chose 100 ms arbitrarily based on the desire to still be able to double
+      click away from the popover to close the options and subsequently close the popover. Choosing a number
+      like 1000ms, for example, makes the double click not work unless 1000ms has elapsed between the two clicks.
+     */
+    const delaySet = async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 100);
+      });
+      setShouldClose(false);
+      setOptionsVisible(false);
+    };
+
+    void delaySet();
+  };
+
+  const onMultiSelectFocus = () => {
+    setOptionsVisible(true);
+    setShouldClose(false);
   };
 
   const handleAdd = (id: number) => {
@@ -117,6 +126,7 @@ const WithParentOptionsVisibilityControlTemplate: Story<MultiSelectProps<number,
       valueRenderer={renderString}
       optionsVisible={optionsVisible}
       onBlur={onMultiSelectBlur}
+      onFocus={onMultiSelectFocus}
     />
   );
 
@@ -135,6 +145,17 @@ const WithParentOptionsVisibilityControlTemplate: Story<MultiSelectProps<number,
         open={Boolean(anchorEl)}
         onClose={hideOptionsOrClose}
         anchorEl={anchorEl}
+        onClickCapture={(event) => {
+          // Since two events are fired when the options are opened, the MultiSelect onBlur and
+          // the Popover onClick (of the backdrop, which prompts the onClose event), we need to stop event propagation
+          // if the options are visible. Otherwise, we setShouldClose(true) so that when the onClose handler fires
+          // it knows that it should close
+          if (optionsVisible) {
+            event.stopPropagation();
+          } else {
+            setShouldClose(true);
+          }
+        }}
         anchorOrigin={{
           vertical: 'bottom',
           horizontal: 'left',

--- a/src/stories/MultiSelect.stories.tsx
+++ b/src/stories/MultiSelect.stories.tsx
@@ -146,6 +146,14 @@ const WithParentOptionsVisibilityControlTemplate: Story<MultiSelectProps<number,
         onClose={hideOptionsOrClose}
         anchorEl={anchorEl}
         onClickCapture={(event) => {
+          // If the captured event is not for the backdrop, do nothing
+          const eventIsBackdropClick = Array.from((event.target as HTMLElement).classList.values()).some((targetClass: string) =>
+            targetClass.toLowerCase().includes('backdrop')
+          );
+          if (!eventIsBackdropClick) {
+            return;
+          }
+
           // Since two events are fired when the options are opened, the MultiSelect onBlur and
           // the Popover onClick (of the backdrop, which prompts the onClose event), we need to stop event propagation
           // if the options are visible. Otherwise, we setShouldClose(true) so that when the onClose handler fires


### PR DESCRIPTION
The previous PR that added this functionality did not work as expected, and required the user to double click out of the Popover if they had focused and blurred the MultiSelect _within_ the Popover.

The implementer of this MultiSelect-within-Popover-with-desired-blur/closing-behavior unfortunately needs to implement a cheeky setTimeout for the functionality to work as expected. This is because the state of the component updates from the onBlur event resolution before the onClick event resolves, resulting in an impossible (at least through my many attempts) situation to achieve the desired effect.

![2024-02-08 12.16.34.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/32bb9a37-038a-44a6-ab17-12be3a21b535.gif)

