### PR TITLE
SW-4918 Don't title case acronyms

### DIFF
--- a/src/utils/text.test.ts
+++ b/src/utils/text.test.ts
@@ -1,0 +1,24 @@
+import { titleCase } from './text';
+
+test('titleCase for a single word', () => {
+  const lowerCaseWord = titleCase('species');
+  expect(lowerCaseWord === 'Species').toBe(true);
+  const capitalizedWord = titleCase('Species');
+  expect(capitalizedWord === 'Species').toBe(true);
+  const allCapsWord = titleCase('SPECIES');
+  expect(allCapsWord === 'SPECIES').toBe(true);
+  const reverseCapWord = titleCase('sPECIES');
+  expect(reverseCapWord === 'Species').toBe(true);
+});
+
+test('titleCase for multiple words', () => {
+  const lowerCaseString = titleCase('common name');
+  expect(lowerCaseString === 'Common Name').toBe(true);
+  const capitalizedString = titleCase('Common Name');
+  expect(capitalizedString === 'Common Name').toBe(true);
+  const allCapsString = titleCase('common NAME');
+  expect(allCapsString === 'Common NAME').toBe(true);
+  const reverseCapString = titleCase('cOMMON nAME');
+  expect(reverseCapString === 'Common Name').toBe(true);
+});
+

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -1,8 +1,14 @@
 const isWhitespaces = (str: string) => str.match(/^\s+$/);
 
 export const titleCase = (str: string) =>
-        str.toLowerCase().split(' ')
-        .map((word) => word.replace(word.charAt(0), word.charAt(0).toUpperCase()))
-        .join(' ');
+        str.split(' ').map((word) => {
+                if(word !== word.toUpperCase()){
+                        let lowerCaseWord = word.toLowerCase();
+                        return(lowerCaseWord.replace(lowerCaseWord.charAt(0), lowerCaseWord.charAt(0).toUpperCase()));
+                }
+                else{
+                        return(word);
+                }
+        }).join(' ');
 
 export default isWhitespaces;

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -3,10 +3,10 @@ const isWhitespaces = (str: string) => str.match(/^\s+$/);
 export const titleCase = (str: string) =>
         str.split(' ').map((word) => {
                 if(word !== word.toUpperCase()){
-                        let lowerCaseWord = word.toLowerCase();
+                        const lowerCaseWord = word.toLowerCase();
+
                         return(lowerCaseWord.replace(lowerCaseWord.charAt(0), lowerCaseWord.charAt(0).toUpperCase()));
-                }
-                else{
+                } else{
                         return(word);
                 }
         }).join(' ');


### PR DESCRIPTION
Recently table column headers were converted to title case.  But we have at least one acronym that should not be title cased (IUCN)