### PR TITLE
SW-5031: In Participant view, 1c. Parent/Subsidiary information, no upload option after CANCEL

### DIFF
--- a/src/components/FileChooser/index.tsx
+++ b/src/components/FileChooser/index.tsx
@@ -119,6 +119,10 @@ export default function FileChooser(props: FileChooserProps): JSX.Element {
     if (event.currentTarget.files) {
       addFiles(event.currentTarget.files);
     }
+    if (event.currentTarget.value) {
+      // reset the input value to allow the same file(s) to be selected again
+      event.currentTarget.value = '';
+    }
   };
 
   return (

--- a/src/components/FileChooser/index.tsx
+++ b/src/components/FileChooser/index.tsx
@@ -119,9 +119,9 @@ export default function FileChooser(props: FileChooserProps): JSX.Element {
     if (event.currentTarget.files) {
       addFiles(event.currentTarget.files);
     }
-    if (event.currentTarget.value) {
+    if (inputRef?.current?.value) {
       // reset the input value to allow the same file(s) to be selected again
-      event.currentTarget.value = '';
+      inputRef.current.value = '';
     }
   };
 


### PR DESCRIPTION
This PR includes changes to fix an issue that was preventing file uploads for deliverables in some scenarios.

## Example

### Before

https://github.com/terraware/web-components/assets/1474361/e31256af-79df-4999-9a14-075e694f1aa6

### After

https://github.com/terraware/web-components/assets/1474361/1e52eaa4-4ffd-4cf7-a172-ec2c92aff692

