### PR TITLE
SW-5066 Don't require MIME types in file chooser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.10.3",
+  "version": "2.10.4-rc.0",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/FileChooser/index.tsx
+++ b/src/components/FileChooser/index.tsx
@@ -38,7 +38,8 @@ export type FileTemplate = {
 };
 
 export type FileChooserProps = {
-  acceptFileType: string;
+  /** Optional comma-separated list of MIME types to accept in the chooser. */
+  acceptFileType?: string;
   chooseFileText?: string;
   files?: File[];
   fileSelectedText?: string;


### PR DESCRIPTION
Allow the file chooser to be configured to accept all file types.
