### PR TITLE
Fix Separator color

### DIFF
--- a/src/components/Separator/index.tsx
+++ b/src/components/Separator/index.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { Box } from '@mui/material';
 import theme from '../../theme';
 
-const Separator = (props: { height?: string }) => {
+const Separator = (props: { height?: string; color?: string }) => {
   return (
     <Box
       sx={{
         margin: theme.spacing(0, 2),
         width: '1px',
         height: props.height || '32px',
-        backgroundColor: theme.palette.TwClrBgTertiary,
+        backgroundColor: props.color || theme.palette.TwClrBrdrTertiary,
       }}
     />
   );


### PR DESCRIPTION
- Update the default separator color to `tw-clr-brdr-tertiary`
- Allow for consumer to pass in a different color (deliverable view uses `tw-clr-dvdr-fill`