### PR TITLE
SW-5091 Truncated multi line text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.10.6-rc.0",
+  "version": "2.10.6-rc.1",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.10.5",
+  "version": "2.10.6-rc.0",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/Textfield/Textfield.tsx
+++ b/src/components/Textfield/Textfield.tsx
@@ -1,15 +1,24 @@
 import classNames from 'classnames';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { TooltipProps } from '@mui/material';
 import Icon from '../Icon/Icon';
 import { IconName } from '../Icon/icons';
 import './styles.scss';
 import { isWhitespaces } from '../../utils';
 import IconTooltip from '../IconTooltip';
+import TruncatedTextArea from './TruncatedTextArea';
 
 type TextfieldType = 'text' | 'textarea' | 'number';
 
 type Handler = (value: unknown) => void;
+
+export interface TruncateConfig {
+  maxHeight: number;
+  showMoreText: string;
+  showLessText: string;
+  showTextStyle?: Record<string, any>;
+  valueTextStyle?: Record<string, any>;
+}
 
 export interface Props {
   autoFocus?: boolean;
@@ -37,6 +46,7 @@ export interface Props {
   disabledCharacters?: string[];
   preserveNewlines?: boolean;
   required?: boolean;
+  truncateConfig?: TruncateConfig;
 }
 
 export default function TextField(props: Props): JSX.Element {
@@ -66,6 +76,7 @@ export default function TextField(props: Props): JSX.Element {
     disabledCharacters,
     preserveNewlines,
     required,
+    truncateConfig,
   } = props;
 
   const textfieldClass = classNames({
@@ -122,6 +133,18 @@ export default function TextField(props: Props): JSX.Element {
     }
   }
 
+  const displayComponent = useMemo(() => {
+    if (!display) {
+      return null;
+    }
+
+    if (type === 'textarea' && truncateConfig) {
+      return <TruncatedTextArea preserveNewlines={preserveNewlines} truncateConfig={truncateConfig} value={value} />;
+    }
+
+    return <p className={`textfield-value--display${preserveNewlines ? ' preserve-newlines' : ''}`}>{value}</p>;
+  }, [display, preserveNewlines, truncateConfig, type, value]);
+
   return (
     <div className={`textfield ${className}`}>
       <label htmlFor={id} className='textfield-label'>
@@ -158,7 +181,7 @@ export default function TextField(props: Props): JSX.Element {
             required={required}
           />
         ))}
-      {display && <p className={`textfield-value--display${preserveNewlines ? ' preserve-newlines' : ''}`}>{value}</p>}
+      {displayComponent}
       {errorText && (
         <div className='textfield-label-container'>
           <Icon name='error' className='textfield-error-text--icon' />

--- a/src/components/Textfield/TruncatedTextArea.tsx
+++ b/src/components/Textfield/TruncatedTextArea.tsx
@@ -35,7 +35,7 @@ const TruncatedTextArea = ({ preserveNewlines, truncateConfig, value }: Truncate
     width: '100%',
   };
 
-  if (!showAll) {
+  if (needsTruncating && !showAll) {
     textStyle.maxHeight = `${maxHeight}px`;
   }
 
@@ -54,7 +54,7 @@ const TruncatedTextArea = ({ preserveNewlines, truncateConfig, value }: Truncate
           <Link
             component='button'
             onClick={toggleShowAll}
-            onBlur={toggleShowAll}
+            onBlur={() => setShowAll(false)}
             sx={{ color: theme.palette.TwClrTxtBrand, textDecorationColor: `${theme.palette.TwClrTxtBrand}80` }}
           >
             <Typography sx={{ ...showTextStyle, marginTop: '-3px' }}>

--- a/src/components/Textfield/TruncatedTextArea.tsx
+++ b/src/components/Textfield/TruncatedTextArea.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { TruncateConfig } from './Textfield';
+import { Link, Typography, useTheme } from '@mui/material';
+
+interface TruncatedTextAreaProps {
+  preserveNewlines?: boolean;
+  truncateConfig: TruncateConfig;
+  value?: string | number;
+}
+
+const TruncatedTextArea = ({ preserveNewlines, truncateConfig, value }: TruncatedTextAreaProps) => {
+  const { maxHeight, showLessText, showMoreText, showTextStyle, valueTextStyle } = truncateConfig;
+
+  const theme = useTheme();
+  const [showAll, setShowAll] = useState(false);
+  const [needsTruncating, setNeedsTruncating] = useState(false);
+  const [totalHeight, setTotalHeight] = useState(0);
+  const ref = useRef<HTMLParagraphElement>(null);
+
+  useEffect(() => {
+    if (ref && ref.current && !totalHeight) {
+      const height = ref.current.clientHeight;
+      setTotalHeight(height);
+      setNeedsTruncating(height > maxHeight);
+    }
+  }, [maxHeight, ref, totalHeight]);
+
+  const toggleShowAll = () => setShowAll((prev) => !prev);
+
+  const textStyle: Record<string, any> = {
+    ...valueTextStyle,
+    margin: '8px 0',
+    padding: 0,
+    overflow: 'hidden',
+    width: '100%',
+  };
+
+  if (!showAll) {
+    textStyle.maxHeight = `${maxHeight}px`;
+  }
+
+  return (
+    <>
+      <p
+        ref={ref}
+        className={`textfield-value--display${preserveNewlines ? ' preserve-newlines' : ''}`}
+        style={textStyle}
+      >
+        {value}
+      </p>
+
+      {needsTruncating && (
+        <div>
+          <Link
+            component='button'
+            onClick={toggleShowAll}
+            onBlur={toggleShowAll}
+            sx={{ color: theme.palette.TwClrTxtBrand, textDecorationColor: `${theme.palette.TwClrTxtBrand}80` }}
+          >
+            <Typography sx={{ ...showTextStyle, marginTop: '-3px' }}>
+              {showAll ? showLessText : showMoreText}
+            </Typography>
+          </Link>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default TruncatedTextArea;

--- a/src/stories/TextfieldNew.stories.tsx
+++ b/src/stories/TextfieldNew.stories.tsx
@@ -54,6 +54,8 @@ export const WithTooltip = Template.bind({});
 
 export const TextArea = Template.bind({});
 
+export const TextAreaWithTruncate = Template.bind({});
+
 export const NumberField = NumberTemplate.bind({});
 
 Default.args = {
@@ -97,6 +99,29 @@ TextArea.args = {
   type: 'textarea',
   autoFocus: false,
   preserveNewlines: true,
+};
+
+TextAreaWithTruncate.args = {
+  label: 'Field Label',
+  disabled: false,
+  helperText: 'Help text.',
+  placeholder: 'Placeholder...',
+  errorText: '',
+  warningText: '',
+  readonly: false,
+  display: false,
+  type: 'textarea',
+  autoFocus: false,
+  preserveNewlines: true,
+  truncateConfig: {
+    valueTextStyle: {
+      fontSize: '12px',
+      lineHeight: '16px'
+    },
+    maxHeight: 48,
+    showLessText: 'Show less',
+    showMoreText: 'Show more',
+  },
 };
 
 NumberField.args = {


### PR DESCRIPTION
- Add `TruncatedTextArea` component which renders conditionally within the `Textfield` if we are using `type='textarea'` and a truncation config is passed in

- Since we can't predict how the text will wrap on the page, we need to measure it on the page, as a result, the truncation config needs to have a `maxHeight` which is cleanly divisible by the line height for the value text, otherwise you will see things get cut off.
- I decided this was more simple than measuring and then figuring out what the number of lines is, and then slicing the value. Hopefully it is OK.

![2024-03-20 11 08 40](https://github.com/terraware/web-components/assets/9541815/8ab83f57-40bb-4245-94ff-6a2e58978c32)
