### PR TITLE
SW-4969 Generic confirm dialog component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.11.0",
+  "version": "2.11.1-rc.0",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.11.1-rc.0",
+  "version": "2.11.1-rc.1",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -14,11 +14,14 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
+export type ButtonPriority = 'primary' | 'secondary' | 'ghost';
+export type ButtonType = 'productive' | 'passive' | 'destructive';
+
 export interface Props {
   onClick: (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   label?: string;
-  type?: 'productive' | 'passive' | 'destructive';
-  priority?: 'primary' | 'secondary' | 'ghost';
+  type?: ButtonType;
+  priority?: ButtonPriority;
   size?: Size;
   disabled?: boolean;
   icon?: IconName;

--- a/src/components/Confirm/index.tsx
+++ b/src/components/Confirm/index.tsx
@@ -105,7 +105,7 @@ export default function Confirm({
             ...(textStyle || {})
           }}
         >{str}</Typography>
-      )
+      );
     };
     if (typeof message === 'string') {
       return text(message);

--- a/src/components/Confirm/index.tsx
+++ b/src/components/Confirm/index.tsx
@@ -1,0 +1,134 @@
+import React, { useMemo } from 'react';
+import { Typography, useTheme } from '@mui/material';
+import DialogBox, { DialogBoxSize } from '../DialogBox/DialogBox';
+import Button, { ButtonPriority, ButtonType } from '../Button/Button';
+import { IconName } from '../Icon/icons';
+
+/**
+ * A generic confirm modal built on top of DialogBox.
+ * Most properties are optional with default values.
+ * Required properties are commented as such.
+ */
+export type ConfirmProps = {
+  confirmButtonDisabled?: boolean; // optional disabled state for confirm button
+  confirmButtonIcon?: IconName; // optional icon for confirm button
+  confirmButtonId?: string; // defaults to 'confirm-submit'
+  confirmButtonPriority?: ButtonPriority; // defaults to 'primary'
+  confirmButtonText: string; // required, text of confirm button
+  confirmButtonType?: ButtonType; // defaults to 'productive'
+  closeButtonId?: string; // defaults to 'confirm-close'
+  closeButtonText?: string; // absence of close text will hide the close button
+  message: string | string[] | React.ReactNode; // required, the message content
+  onClose?: () => void; // absence of onClose will hide the close button
+  onConfirm: () => void; // required, callback on confirm button
+  open?: boolean; // defaults to true, whether confirm modal is open
+  size?: DialogBoxSize; // optional defaults to 'medium'
+  textStyle?: Record<string, any>; // option style override for message text
+  title: string; // required, title of confirm modal
+};
+
+export default function Confirm({
+  confirmButtonDisabled,
+  confirmButtonIcon,
+  confirmButtonId,
+  confirmButtonPriority,
+  confirmButtonText,
+  confirmButtonType,
+  closeButtonId,
+  closeButtonText,
+  message,
+  onClose,
+  onConfirm,
+  open,
+  size,
+  textStyle,
+  title,
+}: ConfirmProps): JSX.Element {
+  const theme = useTheme();
+
+  const middleButtons = useMemo(() => {
+    const buttons = [
+      <Button
+        disabled={confirmButtonDisabled}
+        icon={confirmButtonIcon}
+        id={confirmButtonId || 'confirm-submit'}
+        key='button-2'
+        label={confirmButtonText}
+        onClick={onConfirm}
+        priority={confirmButtonPriority || 'primary'}
+        type={confirmButtonType || 'productive'}
+      />
+    ];
+
+    if (onClose && closeButtonText) {
+      buttons.unshift(
+        <Button
+          id={closeButtonId || 'confirm-close'}
+          key='button-1'
+          label={closeButtonText}
+          onClick={onClose}
+          priority='secondary'
+          type='passive'
+        />,
+      );
+    }
+
+    return buttons;
+  }, [
+    confirmButtonDisabled,
+    confirmButtonIcon,
+    confirmButtonId,
+    confirmButtonPriority,
+    confirmButtonText,
+    confirmButtonType,
+    closeButtonId,
+    closeButtonText,
+    onClose,
+    onConfirm,
+  ]);
+
+  const content = useMemo(() => {
+    const text = (str: string, key?: string) => {
+      return (
+        <Typography
+          color={theme.palette.TwClrTxt}
+          fontSize='16px'
+          fontWeight={400}
+          key={key}
+          lineHeight='24px'
+          textAlign='center'
+          sx={{
+            marginBottom: theme.spacing(1),
+            '&:last-child': {
+              marginBottom: 0,
+            },
+            ...(textStyle || {})
+          }}
+        >{str}</Typography>
+      )
+    };
+    if (typeof message === 'string') {
+      return text(message);
+    } else if (Array.isArray(message)) {
+      return (
+        <>
+          {message.map((str, i) => text(str, `${str}_${i}`))}
+        </>
+      );
+    } else {
+      return message;
+    }
+  }, [message, textStyle, theme]);
+
+  return (
+    <DialogBox
+      onClose={onClose}
+      open={open ?? true}
+      title={title}
+      size={size || 'medium'}
+      middleButtons={middleButtons}
+    >
+      {content}
+    </DialogBox>
+  );
+}

--- a/src/components/DialogBox/DialogBox.tsx
+++ b/src/components/DialogBox/DialogBox.tsx
@@ -4,9 +4,11 @@ import Icon from '../Icon/Icon';
 import { IconButton } from '@mui/material';
 import { useDeviceInfo } from '../../utils';
 
+export type DialogBoxSize = 'small' | 'medium' | 'large' | 'x-large';
+
 export interface Props {
   title: string;
-  size: 'small' | 'medium' | 'large' | 'x-large';
+  size: DialogBoxSize;
   message?: string | string[];
   children?: ReactNode;
   leftButton?: ReactNode;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import Badge from './components/Badge';
 import BusySpinner from './components/BusySpinner';
 import Button from './components/Button/Button';
 import Checkbox from './components/Checkbox';
+import Confirm from './components/Confirm';
 import DatePicker from './components/DatePicker/DatePicker';
 import DialogBox from './components/DialogBox/DialogBox';
 import Divisor from './components/Divisor';
@@ -61,6 +62,7 @@ export type { FileChooserProps } from './components/FileChooser';
 export type { PhotoItem } from './components/ViewPhotosDialog';
 export type { SliderMark } from './components/Slider';
 export type { Tab, TabsProps } from './components/Tabs';
+export type { ConfirmProps } from './components/Confirm';
 
 export {
   Autocomplete,
@@ -70,6 +72,7 @@ export {
   CellRenderer,
   CellDateRenderer,
   Checkbox,
+  Confirm,
   DatePicker,
   descendingComparator,
   DialogBox,

--- a/src/stories/Confirm.stories.tsx
+++ b/src/stories/Confirm.stories.tsx
@@ -1,0 +1,71 @@
+import { Story } from '@storybook/react';
+import React from 'react';
+import { Box } from '@mui/material';
+import Confirm, { ConfirmProps } from '../components/Confirm';
+
+export default {
+  title: 'Confirm',
+  component: Confirm,
+};
+
+const Template: Story<ConfirmProps> = (args) => {
+  return <Confirm {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  confirmButtonText: 'Ok',
+  closeButtonText: 'Cancel',
+  message: 'Hello World',
+  onClose: () => window.alert('closed'),
+  onConfirm: () => window.alert('confirmed'),
+  open: true,
+  size: 'large',
+  textStyle: { color: 'blue' },
+  title: 'Confirm This!',
+};
+
+export const DestructiveNoCancel = Template.bind({});
+DestructiveNoCancel.args = {
+  confirmButtonIcon: 'iconTrashCan',
+  confirmButtonPriority: 'primary',
+  confirmButtonText: 'Destroy',
+  confirmButtonType: 'destructive',
+  message: ['Nukem', 'Are you sure??'],
+  onConfirm: () => window.alert('gone'),
+  title: 'Delete all the things!',
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  confirmButtonDisabled: true,
+  confirmButtonPriority: 'secondary',
+  confirmButtonText: 'Ok',
+  confirmButtonType: 'passive',
+  message: 'Hello World',
+  onConfirm: () => window.alert('confirmed'),
+  title: 'Disabled Confirm',
+};
+
+export const Hidden = Template.bind({});
+Hidden.args = {
+  confirmButtonText: 'Ok',
+  message: 'Hello World',
+  onConfirm: () => window.alert('confirmed'),
+  open: false,
+  title: 'Hidden Confirm',
+};
+
+export const CustomContent = Template.bind({});
+CustomContent.args = {
+  confirmButtonText: 'Ok',
+  message: (
+    <Box display='flex' flexDirection='column' textAlign='left'>
+      <h2>Welcome</h2>
+      <h3>to wherever</h3>
+      <h4>you are</h4>
+    </Box>
+  ),
+  onConfirm: () => window.alert('confirmed'),
+  title: 'Custom Confirm',
+};


### PR DESCRIPTION
- to simplify a confirm modal creation
- supports various configurations

<img width="647" alt="Confirm - Custom Content ⋅ Storybook 2024-03-21 10-43-24" src="https://github.com/terraware/web-components/assets/1865174/5a0d20cd-c9aa-4bd9-8474-a1be20f95284">
<img width="639" alt="Confirm - Disabled ⋅ Storybook 2024-03-21 10-43-05" src="https://github.com/terraware/web-components/assets/1865174/e30e615f-0965-4cc0-b5a0-8bb199262d9e">
<img width="645" alt="Confirm - Destructive No Cancel ⋅ Storybook 2024-03-21 10-42-54" src="https://github.com/terraware/web-components/assets/1865174/9eef2962-6c8f-4e14-8b09-8fa1a16f4228">
<img width="695" alt="Confirm - Default ⋅ Storybook 2024-03-21 10-41-44" src="https://github.com/terraware/web-components/assets/1865174/ae5dddb4-b62d-48ca-b13d-583409005c9e">
