### PR TITLE
SW-4662 Fix bug where 'fixedMenu' dropdowns were being shown above the anchor

### DIFF
--- a/src/components/Select/SelectT.tsx
+++ b/src/components/Select/SelectT.tsx
@@ -126,7 +126,7 @@ export default function SelectT<T>(props: SelectTProps<T>): JSX.Element {
   };
 
   useEffect(() => {
-    if (openedOptions) {
+    if (openedOptions && options?.length) {
       scrollToSelectedElement();
       if (fixedMenu && inputRef.current && dropdownRef.current) {
         dropdownRef.current.style.width = `${inputRef.current.offsetWidth}px`;
@@ -141,7 +141,7 @@ export default function SelectT<T>(props: SelectTProps<T>): JSX.Element {
         }
       }
     }
-  }, [fixedMenu, openedOptions]);
+  }, [fixedMenu, openedOptions, options?.length]);
 
   const toggleOptions = () => {
     setOpenedOptions((isOpen) => !isOpen);

--- a/src/components/Select/SelectT.tsx
+++ b/src/components/Select/SelectT.tsx
@@ -1,6 +1,6 @@
 import { TooltipProps } from '@mui/material';
 import classNames from 'classnames';
-import React, { ChangeEvent, KeyboardEvent, useEffect, useRef, useState } from 'react';
+import React, { ChangeEvent, KeyboardEvent, useEffect, useMemo, useRef, useState } from 'react';
 
 import './styles.scss';
 import Icon from '../Icon/Icon';
@@ -125,8 +125,10 @@ export default function SelectT<T>(props: SelectTProps<T>): JSX.Element {
     setOpenedOptions(false);
   };
 
+  const hasOptions = useMemo<boolean>(() => options !== undefined &&  options.length > 0, [options]);
+
   useEffect(() => {
-    if (openedOptions && options?.length) {
+    if (openedOptions && hasOptions) {
       scrollToSelectedElement();
       if (fixedMenu && inputRef.current && dropdownRef.current) {
         dropdownRef.current.style.width = `${inputRef.current.offsetWidth}px`;
@@ -141,7 +143,7 @@ export default function SelectT<T>(props: SelectTProps<T>): JSX.Element {
         }
       }
     }
-  }, [fixedMenu, openedOptions, options?.length]);
+  }, [fixedMenu, openedOptions, hasOptions]);
 
   const toggleOptions = () => {
     setOpenedOptions((isOpen) => !isOpen);

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -19,18 +19,47 @@ const Template: Story<SelectProps> = (args) => {
   return <Select {...args} onChange={handleChange} selectedValue={value} />;
 };
 
+const EditableTemplate: Story<SelectProps> = (args) => {
+  // tslint:disable-next-line:no-unused-vars
+  const [value, setValue] = React.useState('');
+  const [options, setOptions] = React.useState(args.options);
+  const handleChange = (str: string) => {
+    setValue(str);
+    setOptions((args.options ?? []).filter((opt) => !!opt.match(str)));
+  };
+
+  return <Select {...args} onChange={handleChange} selectedValue={value} options={options} />;
+};
+
 export const Default = Template.bind({});
 
 Default.args = {
-  label: 'Field Label',
   disabled: false,
-  helperText: 'Help text.',
-  placeholder: 'Placeholder...',
   errorText: '',
-  warningText: '',
-  readonly: false,
+  fixedMenu: true,
+  helperText: 'Help text.',
+  label: 'Field Label',
   options: ['test 1', 'test 2', 'test 3'],
+  placeholder: 'Placeholder...',
+  readonly: false,
   selectedValue: 'test 2',
+  warningText: '',
+};
+
+export const Editable = EditableTemplate.bind({});
+
+Editable.args = {
+  disabled: false,
+  editable: true,
+  errorText: '',
+  fixedMenu: true,
+  helperText: 'Help text.',
+  label: 'Field Label',
+  options: ['test 1', 'test 2', 'test 3'],
+  placeholder: 'Placeholder...',
+  readonly: false,
+  selectedValue: 'test 2',
+  warningText: '',
 };
 
 type Value = {


### PR DESCRIPTION
- for editable dropdowns with dynamic options that are set based on user typed input, the dropdown transitions between being-shown and not-being-shown and back to being-shown
- when the dropdown is first shown, we calculate the position of the dropdown based on anchor element, this works fine
- if user continues typing and we no longer have options to show, the dropdown is hidden away at the top of the page
- if user continus typing and we have options again, the dropdown is visible again but the position is now at the top of the page
- the code that calculates position of dropdown was not triggered when dropdown transitions from not-being-shown to being-shown
- fixed that by making sure we calculate dropdown position if we transition from not having results to having results
- added tests to capture the fix

#### Before
<img width="835" alt="Select - Editable ⋅ Storybook 2024-03-27 08-19-05" src="https://github.com/terraware/web-components/assets/1865174/cdc3ee89-06eb-4e8b-a905-89d6c80b6091">

#### After
<img width="839" alt="Select - Editable ⋅ Storybook 2024-03-27 08-19-35" src="https://github.com/terraware/web-components/assets/1865174/880567ef-d4a0-4713-bda8-c6cc5ad78279">
