### PR TITLE
SW-4795 Apply "font-variant-numeric: tabular-nums" to all table columns

### DIFF
--- a/src/components/table/TableCellRenderer.tsx
+++ b/src/components/table/TableCellRenderer.tsx
@@ -21,6 +21,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       paddingTop: '0px',
       paddingBottom: '0px',
       borderBottom: `1px solid ${theme.palette.TwClrBrdrSecondary}`,
+      fontVariantNumeric: 'tabular-nums',
     },
   },
 }));


### PR DESCRIPTION
Adding this style with the basic styles for the table cells, because we want it to apply it in every cell