### PR TITLE
SW-4662 Avoid flash of dropdown menu before it's position is calculated/repositioned

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.12.5",
+  "version": "2.12.6-rc.0",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/Select/SelectT.tsx
+++ b/src/components/Select/SelectT.tsx
@@ -76,6 +76,7 @@ export default function SelectT<T>(props: SelectTProps<T>): JSX.Element {
   });
 
   const [openedOptions, setOpenedOptions] = useState(false);
+  const [fixedMenuPositioned, setFixedMenuPositioned] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState<number>(-1);
   const inputRef = useRef<HTMLDivElement>(null);
   const dropdownRef = useRef<HTMLUListElement>(null);
@@ -141,7 +142,10 @@ export default function SelectT<T>(props: SelectTProps<T>): JSX.Element {
             dropdownRef.current.clientHeight - (dropdownBottom - windowHeightThreshold)
           }px`;
         }
+        setFixedMenuPositioned(true);
       }
+    } else if (fixedMenu) {
+      setFixedMenuPositioned(false);
     }
   }, [fixedMenu, openedOptions, hasOptions]);
 
@@ -227,7 +231,7 @@ export default function SelectT<T>(props: SelectTProps<T>): JSX.Element {
         {options && options.length > 0 && openedOptions && (
           <>
             {fixedMenu && <div className='scroll-block' />}
-            <ul className={'options-container' + (fixedMenu ? ' fixed-menu' : '')} ref={dropdownRef}>
+            <ul className={'options-container' + (fixedMenu ? ' fixed-menu' : '') + (fixedMenuPositioned ? ' positioned': '')} ref={dropdownRef}>
               {options.map((option, index) => {
                 return (
                   <li

--- a/src/components/Select/styles.scss
+++ b/src/components/Select/styles.scss
@@ -253,8 +253,12 @@
     overflow-y: auto;
 
     &.fixed-menu {
-      position: fixed;
-      z-index: 11;
+      visibility: 'hidden';
+      &.positioned {
+        visibility: 'visible';
+        position: fixed;
+        z-index: 11;
+      }
     }
 
     .select-value {

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -48,6 +48,15 @@ Default.args = {
 
 export const Editable = EditableTemplate.bind({});
 
+const editableValues = () => {
+  const values = [];
+  for (let i = 0; i < 300; i++) {
+    values.push(`test ${i+1}`);
+  }
+
+  return values;
+};
+
 Editable.args = {
   disabled: false,
   editable: true,
@@ -55,7 +64,7 @@ Editable.args = {
   fixedMenu: true,
   helperText: 'Help text.',
   label: 'Field Label',
-  options: ['test 1', 'test 2', 'test 3'],
+  options: editableValues(),
   placeholder: 'Placeholder...',
   readonly: false,
   selectedValue: 'test 2',


### PR DESCRIPTION
- use state + css to avoid showing the dropdown until it is positioned