### PR TITLE
Align table header label and icons to the right when column is right aligned

### DIFF
--- a/src/components/IconTooltip/index.tsx
+++ b/src/components/IconTooltip/index.tsx
@@ -6,6 +6,10 @@ import Icon from '../Icon/Icon';
 import { IconName } from '../Icon/icons';
 import { useDeviceInfo } from '../../utils';
 
+interface StyleProps {
+  disableRightMargin?: boolean;
+}
+
 const useStyles = makeStyles((theme: Theme) => ({
   arrow: {
     color: theme.palette.TwClrBaseGray800,
@@ -13,7 +17,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   icon: {
     fill: theme.palette.TwClrIcnSecondary,
     marginLeft: '4px',
-    marginRight: '4px',
+    marginRight: (props: StyleProps) => (props.disableRightMargin ? '0px' : '4px'),
     verticalAlign: 'text-top',
   },
   tooltip: {
@@ -30,16 +34,18 @@ export type IconTooltipProps = {
   iconName?: IconName;
   placement?: TooltipProps['placement'];
   title: TooltipProps['title'];
+  disableRightMargin?: boolean;
 };
 
 export default function IconTooltip({
   iconName = 'info',
   placement = 'top-start',
   title,
+  disableRightMargin,
 }: IconTooltipProps): JSX.Element {
   const [open, setOpen] = React.useState(false);
   const { isMobile } = useDeviceInfo();
-  const classes = useStyles();
+  const classes = useStyles({ disableRightMargin });
 
   const handleTooltipClose = () => {
     setOpen(false);

--- a/src/components/table/TableHeaderItem.tsx
+++ b/src/components/table/TableHeaderItem.tsx
@@ -2,15 +2,20 @@ import React from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { DragHandle } from '@mui/icons-material';
-import { TableCell, TableSortLabel, Theme } from '@mui/material';
+import { Box, TableCell, TableSortLabel, Theme } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 
 import { SortOrder } from './sort';
 import IconTooltip from '../IconTooltip';
 import { HeadCell } from '.';
 
+interface StyleProps {
+  rightAligned?: boolean;
+}
+
 const useStyles = makeStyles((theme: Theme) => ({
   dragIcon: {
+    marginLeft: (props: StyleProps) => (props.rightAligned ? '0px' : '-20px'),
     color: theme.palette.common.white,
     '&:hover': {
       color: theme.palette.neutral[600],
@@ -28,7 +33,7 @@ type Props = {
 
 export default function TableHeaderItem(props: Props): JSX.Element {
   const { headCell, order, orderBy, onRequestSort, i } = props;
-  const classes = useStyles();
+  const classes = useStyles({ rightAligned: headCell.alignment === 'right' });
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: headCell.id,
   });
@@ -52,24 +57,27 @@ export default function TableHeaderItem(props: Props): JSX.Element {
       style={style}
       className={headCell.className || ''}
     >
-      {i > 0 && (
-        <DragHandle
-          className={classes.dragIcon}
-          {...attributes}
-          {...listeners}
-          sx={{ marginLeft: 0, verticalAlign: 'middle', display: 'inline-flex' }}
-        />
-      )}
-      {headCell.label && (
-        <TableSortLabel
-          active={orderBy === headCell.id}
-          direction={orderBy === headCell.id ? order : 'asc'}
-          onClick={createSortHandler(headCell.id)}
-        >
-          {headCell.tooltipTitle && <IconTooltip title={headCell.tooltipTitle} disableRightMargin={true} />}
-          {headCell.label}
-        </TableSortLabel>
-      )}
+      <Box display='flex' alignItems='center' flexDirection='row-reverse'>
+        {headCell.label && (
+          <TableSortLabel
+            sx={{ flexDirection: 'row-reverse' }}
+            active={orderBy === headCell.id}
+            direction={orderBy === headCell.id ? order : 'asc'}
+            onClick={createSortHandler(headCell.id)}
+          >
+            {headCell.tooltipTitle && <IconTooltip title={headCell.tooltipTitle} disableRightMargin={true} />}
+            {headCell.label}
+          </TableSortLabel>
+        )}
+        {i > 0 && (
+          <DragHandle
+            className={classes.dragIcon}
+            {...attributes}
+            {...listeners}
+            sx={{ verticalAlign: 'middle', display: 'inline-flex' }}
+          />
+        )}
+      </Box>
     </TableCell>
   ) : (
     <TableCell
@@ -88,7 +96,7 @@ export default function TableHeaderItem(props: Props): JSX.Element {
           direction={orderBy === headCell.id ? order : 'asc'}
           onClick={createSortHandler(headCell.id)}
         >
-          {i > 0 && <DragHandle className={classes.dragIcon} {...attributes} {...listeners} sx={{ marginLeft: -20 }} />}
+          {i > 0 && <DragHandle className={classes.dragIcon} {...attributes} {...listeners} />}
           {headCell.label}
           {headCell.tooltipTitle && <IconTooltip title={headCell.tooltipTitle} />}
         </TableSortLabel>

--- a/src/components/table/TableHeaderItem.tsx
+++ b/src/components/table/TableHeaderItem.tsx
@@ -11,7 +11,6 @@ import { HeadCell } from '.';
 
 const useStyles = makeStyles((theme: Theme) => ({
   dragIcon: {
-    marginLeft: -20,
     color: theme.palette.common.white,
     '&:hover': {
       color: theme.palette.neutral[600],
@@ -89,7 +88,7 @@ export default function TableHeaderItem(props: Props): JSX.Element {
           direction={orderBy === headCell.id ? order : 'asc'}
           onClick={createSortHandler(headCell.id)}
         >
-          {i > 0 && <DragHandle className={classes.dragIcon} {...attributes} {...listeners} />}
+          {i > 0 && <DragHandle className={classes.dragIcon} {...attributes} {...listeners} sx={{ marginLeft: -20 }} />}
           {headCell.label}
           {headCell.tooltipTitle && <IconTooltip title={headCell.tooltipTitle} />}
         </TableSortLabel>

--- a/src/components/table/TableHeaderItem.tsx
+++ b/src/components/table/TableHeaderItem.tsx
@@ -42,7 +42,37 @@ export default function TableHeaderItem(props: Props): JSX.Element {
     onRequestSort(event, property);
   };
 
-  return (
+  return headCell.alignment === 'right' ? (
+    <TableCell
+      ref={setNodeRef}
+      id={`table-header-${headCell.id}`}
+      key={headCell.id}
+      align={'right'}
+      padding={headCell.disablePadding ? 'none' : 'normal'}
+      sortDirection={orderBy === headCell.id ? order : false}
+      style={style}
+      className={headCell.className || ''}
+    >
+      {i > 0 && (
+        <DragHandle
+          className={classes.dragIcon}
+          {...attributes}
+          {...listeners}
+          sx={{ marginLeft: 0, verticalAlign: 'middle', display: 'inline-flex' }}
+        />
+      )}
+      {headCell.label && (
+        <TableSortLabel
+          active={orderBy === headCell.id}
+          direction={orderBy === headCell.id ? order : 'asc'}
+          onClick={createSortHandler(headCell.id)}
+        >
+          {headCell.tooltipTitle && <IconTooltip title={headCell.tooltipTitle} disableRightMargin />}
+          {headCell.label}
+        </TableSortLabel>
+      )}
+    </TableCell>
+  ) : (
     <TableCell
       ref={setNodeRef}
       id={`table-header-${headCell.id}`}
@@ -60,7 +90,7 @@ export default function TableHeaderItem(props: Props): JSX.Element {
           onClick={createSortHandler(headCell.id)}
         >
           {i > 0 && <DragHandle className={classes.dragIcon} {...attributes} {...listeners} />}
-          <span style={{ textAlign: headCell.alignment || 'left', width: '100%' }}>{headCell.label}</span>
+          {headCell.label}
           {headCell.tooltipTitle && <IconTooltip title={headCell.tooltipTitle} />}
         </TableSortLabel>
       )}

--- a/src/components/table/TableHeaderItem.tsx
+++ b/src/components/table/TableHeaderItem.tsx
@@ -67,7 +67,7 @@ export default function TableHeaderItem(props: Props): JSX.Element {
           direction={orderBy === headCell.id ? order : 'asc'}
           onClick={createSortHandler(headCell.id)}
         >
-          {headCell.tooltipTitle && <IconTooltip title={headCell.tooltipTitle} disableRightMargin />}
+          {headCell.tooltipTitle && <IconTooltip title={headCell.tooltipTitle} disableRightMargin={true} />}
           {headCell.label}
         </TableSortLabel>
       )}

--- a/src/stories/Table.stories.tsx
+++ b/src/stories/Table.stories.tsx
@@ -69,6 +69,7 @@ const Template: Story<Omit<TableProps<{ name: string; lastname: string }>, 'rows
             available: true,
             date: '2023-04-27',
             pets: 12,
+            previousStudies: 'natural Sciences, social Sciences',
           };
         }
       });
@@ -124,6 +125,7 @@ Default.args = {
     { key: 'lastname', name: 'Lastname', type: 'string' },
     { key: 'occupation', name: 'Occupation', type: 'string' },
     { key: 'available', name: 'Available', type: 'boolean' },
+    { key: 'previousStudies', name: 'Previous Studies', type: 'string', alignment: 'right' },
     { key: 'date', name: 'Date', type: 'string', tooltipTitle: 'Right aligend with tooltip', alignment: 'right' },
     { key: 'pets', name: 'Pets', type: 'string', alignment: 'right' },
   ],

--- a/src/stories/Table.stories.tsx
+++ b/src/stories/Table.stories.tsx
@@ -124,7 +124,7 @@ Default.args = {
     { key: 'lastname', name: 'Lastname', type: 'string' },
     { key: 'occupation', name: 'Occupation', type: 'string' },
     { key: 'available', name: 'Available', type: 'boolean' },
-    { key: 'date', name: 'Date', type: 'string' },
+    { key: 'date', name: 'Date', type: 'string', tooltipTitle: 'Right aligend with tooltip', alignment: 'right' },
     { key: 'pets', name: 'Pets', type: 'string', alignment: 'right' },
   ],
   rowCount: 150,


### PR DESCRIPTION
Previously the label was aligned to right, but not the drag, sort and tooltip icons. Reorder all icons correctly when column is right-aligned

Sort icon
<img width="456" alt="Screenshot 2024-04-05 at 10 45 14" src="https://github.com/terraware/web-components/assets/5919083/2aa624f5-24ef-4a96-b00c-8306c69bd7b6">

Drag icon
<img width="555" alt="Screenshot 2024-04-05 at 10 57 39" src="https://github.com/terraware/web-components/assets/5919083/d77aae3e-5f90-4560-946d-9e6314847c51">
