### PR TITLE
SW-4662 More fixedMenu fixes, handle scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.12.6",
+  "version": "2.12.7-rc.0",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -1,6 +1,6 @@
 import { Story } from '@storybook/react';
 import React from 'react';
-import { Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import Select, { SelectProps } from '../components/Select/Select';
 import SelectT, { SelectTProps } from '../components/Select/SelectT';
 
@@ -28,7 +28,16 @@ const EditableTemplate: Story<SelectProps> = (args) => {
     setOptions((args.options ?? []).filter((opt) => !!opt.match(str)));
   };
 
-  return <Select {...args} onChange={handleChange} selectedValue={value} options={options} />;
+  // the Box hierarchy below is mostly to enable scrolling and test fixedMenu with scrolled content
+  return (
+    <Box border='1px solid black' height='400px' width='500px' marginTop='50px' overflow='auto'>
+      <Box height='1000px'>
+        <Box width='200px' margin='0 auto'>
+          <Select {...args} onChange={handleChange} selectedValue={value} options={options} />
+        </Box>
+      </Box>
+    </Box>
+  );
 };
 
 export const Default = Template.bind({});


### PR DESCRIPTION
- previously the fixedMenu will be fixed during scroll and separated from input component
- added a scroll event handler to reposition menu
- updated story to enable scrolling

#### Before (without scroll handling)
<img width="404" alt="Select - Editable ⋅ Storybook 2024-04-09 11-34-45" src="https://github.com/terraware/web-components/assets/1865174/c61821d8-65ce-4674-948a-66c56757cde0">

#### After (after scroll handling)
<img width="272" alt="Select - Editable ⋅ Storybook 2024-04-09 11-34-01" src="https://github.com/terraware/web-components/assets/1865174/9ab90c2e-c025-4348-9b90-a93d9aac43d4">
