### PR TITLE
SW-5218 Fix datepicker adapter for luxon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.16.2",
+  "version": "2.16.2-rc.0",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "2.16.2-rc.0",
+  "version": "2.16.2-rc.1",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -1,7 +1,7 @@
 import React, { useState, KeyboardEventHandler } from 'react';
 import { TextField, TextFieldProps } from '@mui/material';
 import { LocalizationProvider, DesktopDatePicker } from '@mui/x-date-pickers';
-import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
+import AdapterLuxon from '@date-io/luxon';
 import { DateTime, Settings } from 'luxon';
 import Icon from '../Icon/Icon';
 import './styles.scss';
@@ -56,18 +56,28 @@ const initializeDate = (value?: DatePickerDateType, timeZoneId?: string): DateTi
 
 export default function DatePicker(props: Props): JSX.Element {
   const [temporalValue, setTemporalValue] = useState<DateTime | null>(initializeDate(props.value, props.defaultTimeZone));
+  const [minDateTime, setMinDateTime] = useState<DateTime | null>(initializeDate(props.minDate, props.defaultTimeZone));
+  const [maxDateTime, setMaxDateTime] = useState<DateTime | null>(initializeDate(props.maxDate, props.defaultTimeZone));
   const locale = props.locale ?? 'en';
   Settings.defaultZone = tz(props.defaultTimeZone);
 
   React.useEffect(() => {
     setTemporalValue((prev) => {
-      if (props.value !== prev) {
+      if (props.value !== prev && props.value) {
         return initializeDate(props.value, props.defaultTimeZone);
       } else {
         return prev;
       }
     });
   }, [props.defaultTimeZone, props.value]);
+
+  React.useEffect(() => {
+    setMinDateTime(initializeDate(props.minDate, props.defaultTimeZone));
+  }, [props.defaultTimeZone, props.minDate]);
+
+  React.useEffect(() => {
+    setMaxDateTime(initializeDate(props.maxDate, props.defaultTimeZone));
+  }, [props.defaultTimeZone, props.maxDate]);
 
   /**
    * Note: the inputProps override for placeholder is needed
@@ -111,8 +121,8 @@ export default function DatePicker(props: Props): JSX.Element {
         <DesktopDatePicker
           disabled={props.disabled}
           inputFormat='yyyy-MM-dd'
-          minDate={initializeDate(props.minDate, props.defaultTimeZone) || undefined}
-          maxDate={initializeDate(props.maxDate, props.defaultTimeZone) || undefined}
+          minDate={minDateTime && minDateTime.isValid ? minDateTime : undefined}
+          maxDate={maxDateTime && maxDateTime.isValid ? maxDateTime : undefined}
           onChange={(newValue: DateTime | null) => {
             setTemporalValue(newValue);
             // TODO: remove onChange and make onDateChange required
@@ -125,7 +135,7 @@ export default function DatePicker(props: Props): JSX.Element {
           }}
           onError={props.onError}
           renderInput={renderInput}
-          value={temporalValue ? temporalValue.toISO() : temporalValue}
+          value={temporalValue}
         />
       </LocalizationProvider>
     </div>


### PR DESCRIPTION
- the x-date-pickers luxon adapter is off mui5.x which has bugs
- specifically uses `instanceof DateTime` to check for a luxon dates, instanceof does not work across namespaces (npm package scope vs root terraware-web scope)
- this was preventing min/max date props from working across namespaces
- same for setting the value of DatePicker without a toISO conversion
- moved to @date-io/luxon which uses luxon's isDateTime function to compare dates
- this fixes all the issues previously observed (cannot delete characters, min/max dates not working)