### PR TITLE
SW-5221 Click out of dialog boxes to close

### DIFF
--- a/src/components/DialogBox/DialogBox.tsx
+++ b/src/components/DialogBox/DialogBox.tsx
@@ -33,8 +33,15 @@ export default function DialogBox(props: Props): JSX.Element | null {
       className={`dialog-box-container${skrim ? '--skrim' : ''} ${open ? 'dialog-box--opened' : 'dialog-box--closed'} ${
         isMobile ? 'mobile' : ''
       }`}
+      onClick={onClose}
     >
-      <div className={`dialog-box dialog-box--${size}`}>
+      <div
+        className={`dialog-box dialog-box--${size}`}
+        onClick={(e) => {
+          // do not close modal if anything inside modal content is clicked
+          e.stopPropagation();
+        }}
+      >
         <div className='dialog-box--header'>
           <div className='close-icon-spacer' />
           <p className='title'>{title}</p>

--- a/src/stories/DialogBox.stories.tsx
+++ b/src/stories/DialogBox.stories.tsx
@@ -1,5 +1,5 @@
 import { Story } from '@storybook/react';
-import React from 'react';
+import React, { useState } from 'react';
 import Button from '../components/Button/Button';
 import DialogBox, { Props as DialogBoxProps } from '../components/DialogBox/DialogBox';
 
@@ -10,6 +10,16 @@ export default {
 
 const Template: Story<DialogBoxProps> = (args) => {
   return <DialogBox {...args} open={true} />;
+};
+
+const WithButtonTemplate: Story<DialogBoxProps> = (args) => {
+  const [opened, setOpened] = useState(false);
+  return (
+    <main>
+      <button onClick={() => setOpened(true)}>Click me</button>
+      <DialogBox {...args} open={opened} onClose={() => setOpened(false)} />
+    </main>
+  );
 };
 
 export const Small = Template.bind({});
@@ -74,4 +84,15 @@ noFooter.args = {
   title: 'Title',
   message: 'Message',
   size: 'small',
+};
+
+export const CloseOutside = WithButtonTemplate.bind({});
+CloseOutside.args = {
+  title: 'Title',
+  message: 'Message',
+  size: 'small',
+  middleButtons: [
+    <Button id='new-species' label='Test' onClick={() => true} size='small' key={'1'} />,
+    <Button id='new-species' label='Test' onClick={() => true} size='small' key={'2'} />,
+  ],
 };

--- a/src/stories/DialogBox.stories.tsx
+++ b/src/stories/DialogBox.stories.tsx
@@ -14,6 +14,7 @@ const Template: Story<DialogBoxProps> = (args) => {
 
 const WithButtonTemplate: Story<DialogBoxProps> = (args) => {
   const [opened, setOpened] = useState(false);
+
   return (
     <main>
       <button onClick={() => setOpened(true)}>Click me</button>


### PR DESCRIPTION
With this change all dialog boxes will be closed when clicking outside.

Added a new story where the dialog box can be opened/closed to show the new behavior.