### PR TITLE
Truncate table cell

### DIFF
--- a/src/components/table/TableCellRenderer.tsx
+++ b/src/components/table/TableCellRenderer.tsx
@@ -136,7 +136,7 @@ export function CellTextRenderer({
       className={className}
       sx={[defaultStyles(theme), style, ...(Array.isArray(sx) ? sx : [sx])]}
     >
-      <Typography component='p' variant='body1' noWrap={true} fontSize='16px' sx={{ root: { maxWidth: 400 } }}>
+      <Typography component='p' variant='body1' noWrap={true} fontSize='16px' sx={{ maxWidth: 400 }}>
         {value}
       </Typography>
     </TableCell>


### PR DESCRIPTION
The root in the classes object for typography meant that the style should be applied to the MUI root class. With MUI 5 we don't need to do that, just set the max-width to the sx object