### PR TITLE
Fix table header padding

### DIFF
--- a/src/components/table/TableHeader.tsx
+++ b/src/components/table/TableHeader.tsx
@@ -41,7 +41,7 @@ export default function EnhancedTableHead(props: Props): JSX.Element {
   function columnsToHeadCells(columns: TableColumnType[]): HeadCell[] {
     return columns.map((c) => ({
       id: c.key,
-      disablePadding: true,
+      disablePadding: false,
       className: c.className,
       label: typeof c.name === 'string' && c.name.length > 0 ? titleCase(c.name) : c.name,
       tooltipTitle: c.tooltipTitle,

--- a/src/components/table/TableHeaderItem.tsx
+++ b/src/components/table/TableHeaderItem.tsx
@@ -23,8 +23,6 @@ export default function TableHeaderItem(props: Props): JSX.Element {
   });
   const theme = useTheme();
   const style = {
-    paddingLeft: theme.spacing(1.5),
-    paddingRight: theme.spacing(1.5),
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.5 : 1,


### PR DESCRIPTION
When adding the "Density settings" the padding of the headers were disabled, but this was not necessary. Revert it to have the padding back and remove the styles added after for fixing that issue