### PR TITLE
SW-5532: Can't click out of native/non-native dropdown without selecting an option first

### DIFF
--- a/src/components/DialogBox/DialogBox.tsx
+++ b/src/components/DialogBox/DialogBox.tsx
@@ -33,15 +33,13 @@ export default function DialogBox(props: Props): JSX.Element | null {
       className={`dialog-box-container${skrim ? '--skrim' : ''} ${open ? 'dialog-box--opened' : 'dialog-box--closed'} ${
         isMobile ? 'mobile' : ''
       }`}
-      onClick={onClose}
+      onClick={(event) => {
+        if (event.target instanceof HTMLElement && event.target.classList.contains('dialog-box--opened')) {
+          onClose?.();
+        }
+      }}
     >
-      <div
-        className={`dialog-box dialog-box--${size}`}
-        onClick={(e) => {
-          // do not close modal if anything inside modal content is clicked
-          e.stopPropagation();
-        }}
-      >
+      <div className={`dialog-box dialog-box--${size}`}>
         <div className='dialog-box--header'>
           <div className='close-icon-spacer' />
           <p className='title'>{title}</p>

--- a/src/stories/DialogBox.stories.tsx
+++ b/src/stories/DialogBox.stories.tsx
@@ -2,6 +2,7 @@ import { Story } from '@storybook/react';
 import React, { useState } from 'react';
 import Button from '../components/Button/Button';
 import DialogBox, { Props as DialogBoxProps } from '../components/DialogBox/DialogBox';
+import Dropdown from '../components/Dropdown';
 
 export default {
   title: 'Dialog Box',
@@ -18,7 +19,19 @@ const WithButtonTemplate: Story<DialogBoxProps> = (args) => {
   return (
     <main>
       <button onClick={() => setOpened(true)}>Click me</button>
-      <DialogBox {...args} open={opened} onClose={() => setOpened(false)} />
+      <DialogBox {...args} open={opened} onClose={() => setOpened(false)}>
+        <Dropdown
+          fullWidth
+          onChange={() => {
+            return;
+          }}
+          options={[
+            { label: 'Item 1', value: 'item1' },
+            { label: 'Item 2', value: 'item2' },
+            { label: 'Item 3', value: 'item3' },
+          ]}
+        />
+      </DialogBox>
     </main>
   );
 };


### PR DESCRIPTION
This PR includes changes to resolve an issue where the `DialogBox` component was stopping click event propagation which was preventing the `Dropdown` component from functioning correctly when rendering within the `DialogBox` component.

Changes include restoring click event propagation and reworking the container click event handler to check if the click event target is the dialog box container before calling `onClose`.