### PR TITLE
Fix invalid DOM nesting warnings in console

### DIFF
--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -16,15 +16,17 @@ const Badge = (props: BadgeProps): JSX.Element => {
 
   return (
     <Box
+      component='span'
       sx={{
         backgroundColor,
         border: `1px solid ${borderColor}`,
         borderRadius: theme.spacing(1),
+        display: 'inline-block',
         padding: theme.spacing(0.5, 1),
         width: 'fit-content',
       }}
     >
-      <Typography color={labelColor} fontSize='14px' fontWeight={500}>
+      <Typography color={labelColor} component='span' fontSize='14px' fontWeight={500}>
         {props.label}
       </Typography>
     </Box>


### PR DESCRIPTION
This PR includes changes to the `Badge` component to allow nesting within paragraphs.

Currently in `terraware-web` there are two very large warnings that take up most of the console, these changes will resolve those warnings and clean up the console.

## Screenshots

### Warning 1

<img width="2032" alt="Screenshot 2024-06-28 at 11 47 23 AM" src="https://github.com/terraware/web-components/assets/1474361/52cf88a7-f962-41d3-aae9-8bb0bb3a5494">

### Warning 2

<img width="2032" alt="Screenshot 2024-06-28 at 11 47 16 AM" src="https://github.com/terraware/web-components/assets/1474361/f24418da-19ac-4a5c-a134-f22f76b79a73">
