### PR TITLE
Fix custom nav item

### DIFF
--- a/src/components/Navbar/NavItem.tsx
+++ b/src/components/Navbar/NavItem.tsx
@@ -57,7 +57,7 @@ export default function NavItem(props: NavItemProps): JSX.Element {
   return (
     <div
       className={`
-        ${customLabel ? '' : 'nav-item'}
+        nav-item 
         ${selected ? 'nav-item--selected' : ''}
         ${hasChildrenSelected() ? 'nav-item--children-selected' : ''}
         ${isFooter ? 'nav-item--footer' : ''}
@@ -69,9 +69,12 @@ export default function NavItem(props: NavItemProps): JSX.Element {
           ${customLabel ? 'nav-item-custom-content' : 'nav-item-content'}
           ${disabled ? 'nav-item--disabled' : ''}
         `}
-        onClick={onClickHandler} id={id}
+        onClick={onClickHandler}
+        id={id}
       >
-        {icon && <Icon name={icon} className='nav-item--icon' fillColor={iconColor ?? theme.palette.TwClrIcnSecondary} />}
+        {icon && (
+          <Icon name={icon} className='nav-item--icon' fillColor={iconColor ?? theme.palette.TwClrIcnSecondary} />
+        )}
         {!href && <span className='nav-item--label'>{label}</span>}
         {href && (
           <a className='nav-item--label nav-item--anchor' href={href} rel='noopener noreferrer' target='_external'>

--- a/src/components/Navbar/styles.scss
+++ b/src/components/Navbar/styles.scss
@@ -117,7 +117,7 @@
       color: $tw-clr-txt;
       font-family: 'Inter';
       padding-right: $tw-spc-base-small;
-      padding-left: 20px;
+      padding-left: 16px;
     }
 
     &--icon {


### PR DESCRIPTION
For custom label nav items, we need to keep the main 'nav-item' class, to keep hover, active, etc styles 