### PR TITLE
SW-5846: [Visual Bug] Icon in Application progress nav is the wrong size

### DIFF
--- a/src/components/Navbar/styles.scss
+++ b/src/components/Navbar/styles.scss
@@ -124,6 +124,7 @@
       margin-right: $tw-spc-base-x-small;
       line-height: $tw-sz-icon-small;
       height: $tw-sz-icon-small;
+      min-width: $tw-sz-icon-small;
       width: $tw-sz-icon-small;
     }
 


### PR DESCRIPTION
This PR includes applies a `min-width` to the optional `icon` in `NavItem`, to prevent the icon from rendering at smaller size when the label text wraps multiple lines.

## Screenshots

### Before

![localhost_3000_applications_19_review_organizationId=141](https://github.com/user-attachments/assets/94ded6e4-a2c2-4a71-9e4a-ed87e8ad87bd)

### After

![localhost_3000_applications_19_review_organizationId=141 (1)](https://github.com/user-attachments/assets/dc5863cd-5f0a-49c1-a86b-f9d277021522)
