### PR TITLE
Add renderOption prop to autocomplete

### DIFF
--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -24,6 +24,7 @@ export interface Props {
   tooltipTitle?: TooltipProps['title'];
   required?: boolean;
   sx?: SxProps;
+  renderOption?: (props: React.HTMLAttributes<HTMLLIElement>, option: ValueType) => React.ReactNode;
 }
 
 const isEmpty = (value: unknown) => ['', undefined].includes(value as string | undefined);
@@ -44,6 +45,7 @@ export default function Autocomplete({
   tooltipTitle,
   required,
   sx,
+  renderOption,
 }: Props): JSX.Element {
   const onChangeHandler = (event: ChangeEvent<any>, value: string | null) => {
     if (event) {
@@ -131,6 +133,7 @@ export default function Autocomplete({
         },
       }}
       {...optionalArgs}
+      renderOption={renderOption}
     />
   );
 }


### PR DESCRIPTION
Autocomplete renders a < ul > with < li > children. By default those < li > children have the label of the option as key, and sometimes labels could be the same, so it generates this error:

`Encountered two children with the same key, ``. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.`

MUI Autocomplete has a renderOption prop to change that default behaviour, so we need to add it to our Autocomplete component to allow using it