### PR TITLE
SW-5918: Doc producer - Missing section display mode variable popover

### DIFF
--- a/src/components/DialogBox/styles.scss
+++ b/src/components/DialogBox/styles.scss
@@ -125,7 +125,6 @@
   }
 
   &--body-no-footer {
-    color: $tw-clr-base-white;
     padding: $tw-spc-base-medium;
     &.scrolled {
       overflow: auto;


### PR DESCRIPTION
This PR includes a small style change to fix white text on a white background in `DialogBox`s with no footer.

Context:

The display mode of the variable popover renders no action buttons in the footer, and therefore no footer. Currently, the styles for  a`DialogBox` without a footer are defined such that the background & foreground colors are the same (both white). This resulted in the display fields in the variable popover to appear blank/empty.

## Screenshots

Here are screenshots from Terraware with the style change in this PR:

### Before

![localhost_3000_accelerator_documents_9_tab=document](https://github.com/user-attachments/assets/5beef093-b55b-41f2-9280-226b408bbf8e)

### After

![localhost_3000_accelerator_documents_9_tab=document (1)](https://github.com/user-attachments/assets/354f6765-48e8-43fa-8215-214413dfc60f)
