### PR TITLE
SW-5973: Remove extraneous asterisk

### DIFF
--- a/src/components/Textfield/Textfield.tsx
+++ b/src/components/Textfield/Textfield.tsx
@@ -156,7 +156,7 @@ export default function TextField(props: Props): JSX.Element {
   return (
     <Box className={`textfield ${className}`} sx={sx}>
       <label htmlFor={id} className='textfield-label'>
-        {required ? `${label} *` : label}
+        {required && label ? `${label} *` : label}
         {tooltipTitle && <IconTooltip placement='top' title={tooltipTitle} />}
       </label>
       {!display &&


### PR DESCRIPTION
This PR includes a fix for an issue causing asterisks to appear on a line by themselves when input fields are `required` with an empty value for `label`.