### PR TITLE
Add labels to Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     ":preserveSemverRanges"
   ],
+  "labels": [ "bot", "renovate" ],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],
@@ -12,7 +13,7 @@
     },
     {
       "matchUpdateTypes": ["major"],
-      "labels": ["UPDATE-MAJOR"],
+      "addLabels": ["UPDATE-MAJOR"],
       "schedule": ["every weekend"],
       "stabilityDays": 3
     }


### PR DESCRIPTION
Add the "bot" and "renovate" labels to PRs generated by Renovate so
we can easily differentiate them in tools that work with GitHub.

In addition, Renovate renamed the preset with the recommended
settings from `base` to `recommended`, so change the config to use
the new name.