### PR TITLE
Remove Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-      day: 'sunday'
-    open-pull-requests-limit: 5


### PR DESCRIPTION
We're using Renovate to update dependencies, so no need to
configure Dependabot to do the same thing.