### PR TITLE
Fix react nesting warning

### DIFF
--- a/src/components/TextTruncated/index.tsx
+++ b/src/components/TextTruncated/index.tsx
@@ -61,7 +61,7 @@ export interface Props {
   placeHolder?: React.ReactElement;
 }
 
-export default function TextTruncated(props: Props): JSX.Element {
+export default function TextTruncated(props: Props): JSX.Element | null {
   const { stringList, listSeparator, maxLengthPx, moreSeparator, moreText, textStyle, showAllStyle, placeHolder } =
     props;
   const [showAllOpen, setShowAllOpen] = useState(false);
@@ -156,6 +156,6 @@ export default function TextTruncated(props: Props): JSX.Element {
        ) : null}
     </Typography>
   ) : (
-    placeHolder || <div />
+    placeHolder || null
   );
 }


### PR DESCRIPTION
In development, the following error showed up on several pages, because of `TextTruncated`'s default display if `stringList` was empty and `placeHolder` was undefined:

```
<div> cannot appear as a descendant of <p>
```

This error annoyed me so I decided to create a PR to fix it.