### PR TITLE
SW-6963 Remove tabs border, make it optional

### DIFF
--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -19,9 +19,10 @@ export type TabsProps = {
   onTabChange?: (tab: string) => void;
   tabs: Tab[];
   tabStyle?: SxProps<Theme>;
+  headerBorder?: boolean;
 };
 
-const Tabs = ({ activeTab, onTabChange, tabs, tabStyle }: TabsProps): JSX.Element => {
+const Tabs = ({ activeTab, onTabChange, tabs, tabStyle, headerBorder = false }: TabsProps): JSX.Element => {
   const [selectedTab, setSelectedTab] = useState<string>(activeTab ?? tabs[0]?.id ?? '');
   const theme = useTheme();
   const { isMobile } = useDeviceInfo();
@@ -59,7 +60,7 @@ const Tabs = ({ activeTab, onTabChange, tabs, tabStyle }: TabsProps): JSX.Elemen
   ];
 
   const tabHeaderProps = {
-    borderBottom: 1,
+    borderBottom: headerBorder ? 1 : 0,
     borderColor: 'divider',
     margin: isMobile ? 0 : theme.spacing(0, 4),
   };
@@ -95,7 +96,7 @@ const Tabs = ({ activeTab, onTabChange, tabs, tabStyle }: TabsProps): JSX.Elemen
                 height: '4px',
               },
             }}
-            variant='scrollable'
+            variant={'scrollable'}
           >
             {tabs.map((tab, index) => (
               <MuiTab

--- a/src/stories/Tabs.stories.tsx
+++ b/src/stories/Tabs.stories.tsx
@@ -8,9 +8,7 @@ export default {
 };
 
 const Template: Story<TabsProps> = (args) => {
-  const { tabs } = args;
-
-  return <Tabs tabs={tabs} />;
+  return <Tabs {...args} />;
 };
 
 const OverrideTemplate: Story<TabsProps> = (args) => {


### PR DESCRIPTION
Design and Product decided they no longer want the border on the bottom of our tabs component, so make it optional but make the default false.

Before:
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Gd93CNnCsYqInZuuYUOX/30f7acc6-1c36-47ed-b5f7-630c2f74013c.png)

After:
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Gd93CNnCsYqInZuuYUOX/528ed488-2222-4bd2-935f-083e8dffc3d1.png)

