### PR TITLE
SW-6955: Browser back button doesn't work on some pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "3.4.25-rc.1",
+  "version": "3.4.25-rc.2",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "3.4.24",
+  "version": "3.4.25-rc.0",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -99,16 +99,11 @@ const Tabs = ({
     (tab: string) => {
       if (onTabChange) {
         onTabChange(tab);
-
-        return;
-      }
-
-      setSelectedTab(tab);
-      if (sessionViewId) {
-        writeTabToSession(sessionViewId, tab);
+      } else {
+        setSelectedTab(tab);
       }
     },
-    [onTabChange, sessionViewId, setSelectedTab]
+    [onTabChange, setSelectedTab]
   );
 
   // get previous session tab, if sessionViewId is provided

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -1,10 +1,28 @@
 import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { Box, Tab as MuiTab, SxProps, Theme, useTheme } from '@mui/material';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useDeviceInfo } from '../../utils';
 import Icon from '../Icon/Icon';
 import { IconName } from '../Icon/icons';
+
+const makeTabSessionKey = (viewIdentifier: string) => `tab-${viewIdentifier}`;
+
+const getTabFromSession = (viewIdentifier: string): string => {
+  try {
+    return sessionStorage.getItem(makeTabSessionKey(viewIdentifier)) || '';
+  } catch (e) {
+    return '';
+  }
+};
+
+const writeTabToSession = (viewIdentifier: string, tab: string): void => {
+  try {
+    sessionStorage.setItem(makeTabSessionKey(viewIdentifier), tab);
+  } catch (e) {
+    /* empty */
+  }
+};
 
 export type Tab = {
   children: React.ReactNode;
@@ -16,13 +34,21 @@ export type Tab = {
 
 export type TabsProps = {
   activeTab?: string;
+  headerBorder?: boolean;
   onTabChange?: (tab: string) => void;
+  sessionViewId?: string;
   tabs: Tab[];
   tabStyle?: SxProps<Theme>;
-  headerBorder?: boolean;
 };
 
-const Tabs = ({ activeTab, onTabChange, tabs, tabStyle, headerBorder = false }: TabsProps): JSX.Element => {
+const Tabs = ({
+  activeTab,
+  headerBorder = false,
+  onTabChange,
+  sessionViewId,
+  tabs,
+  tabStyle,
+}: TabsProps): JSX.Element => {
   const [selectedTab, setSelectedTab] = useState<string>(activeTab ?? tabs[0]?.id ?? '');
   const theme = useTheme();
   const { isMobile } = useDeviceInfo();
@@ -69,13 +95,38 @@ const Tabs = ({ activeTab, onTabChange, tabs, tabStyle, headerBorder = false }: 
     padding: 0,
   };
 
-  const setTab = (tab: string) => {
-    if (onTabChange) {
-      onTabChange(tab);
-    } else {
+  const setTab = useCallback(
+    (tab: string) => {
+      if (onTabChange) {
+        onTabChange(tab);
+
+        return;
+      }
+
       setSelectedTab(tab);
+      if (sessionViewId) {
+        writeTabToSession(sessionViewId, tab);
+      }
+    },
+    [onTabChange, sessionViewId, setSelectedTab]
+  );
+
+  // get previous session tab, if sessionViewId is provided
+  const prevSessionTab = useMemo(() => (sessionViewId ? getTabFromSession(sessionViewId) : undefined), [sessionViewId]);
+
+  // restore previous session tab, if available
+  useEffect(() => {
+    if (prevSessionTab) {
+      setSelectedTab(prevSessionTab);
     }
-  };
+  }, [prevSessionTab]);
+
+  // write tab to session when selectedTab changes
+  useEffect(() => {
+    if (sessionViewId && selectedTab && selectedTab !== prevSessionTab) {
+      writeTabToSession(sessionViewId, selectedTab);
+    }
+  }, [prevSessionTab, selectedTab, sessionViewId]);
 
   useEffect(() => {
     if (activeTab !== undefined) {

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -99,11 +99,16 @@ const Tabs = ({
     (tab: string) => {
       if (onTabChange) {
         onTabChange(tab);
-      } else {
-        setSelectedTab(tab);
+
+        return;
+      }
+
+      setSelectedTab(tab);
+      if (sessionViewId) {
+        writeTabToSession(sessionViewId, tab);
       }
     },
-    [onTabChange, setSelectedTab]
+    [onTabChange, sessionViewId, setSelectedTab]
   );
 
   // get previous session tab, if sessionViewId is provided

--- a/src/stories/Tabs.stories.tsx
+++ b/src/stories/Tabs.stories.tsx
@@ -41,3 +41,13 @@ OverrideActiveTab.args = {
     { id: 'tab3', label: 'Tab3', children: 'tab3 contents', disabled: false },
   ],
 };
+
+export const StickyTabs = Template.bind({});
+
+StickyTabs.args = {
+  sessionViewId: 'storybook-sticky-tabs',
+  tabs: [
+    { id: 'tab1', label: 'Tab1', children: 'tab1 contents', disabled: false },
+    { id: 'tab2', label: 'Tab2', children: 'tab2 contents', disabled: false },
+  ],
+};


### PR DESCRIPTION
This PR modifies the `Tabs` component to support "sticky tabs" functionality internally, rather than requiring the `useStickyTabs` custom hook and passing in external state as props.