### PR TITLE
Implemented map drawer for desktop

### DIFF
--- a/src/components/Map/MapDrawer.tsx
+++ b/src/components/Map/MapDrawer.tsx
@@ -2,6 +2,7 @@ import React, { CSSProperties, ReactNode } from 'react';
 import { Box, IconButton, useTheme } from '@mui/material';
 import Icon from '../Icon/Icon';
 import './styles.scss';
+import { useDeviceInfo } from '../../utils';
 
 type MapDrawerSize = 'small' | 'medium';
 
@@ -17,9 +18,14 @@ export type MapDrawerProp = {
 const MapDrawer = (props: MapDrawerProp) => {
   const { children, onClose, open, size, style, title } = props;
   const theme = useTheme();
+  const { isDesktop } = useDeviceInfo();
 
   return open ? (
-    <Box className={`map-drawer map-drawer--${size}`} border={`1px solid ${theme.palette.TwClrBrdrTertiary}`} style={style}>
+    <Box
+      className={`map-drawer map-drawer${isDesktop ? `--${size}` : '--mobile'}`}
+      border={`1px solid ${theme.palette.TwClrBrdrTertiary}`}
+      style={style}
+    >
       <Box className='map-drawer--header'>
         <p className='title'>{title}</p>
         <IconButton onClick={onClose} size='small'>

--- a/src/components/Map/MapDrawer.tsx
+++ b/src/components/Map/MapDrawer.tsx
@@ -1,0 +1,38 @@
+import React, { CSSProperties, ReactNode } from 'react';
+import { Box, IconButton, useTheme } from '@mui/material';
+import Icon from '../Icon/Icon';
+import './styles.scss';
+
+type MapDrawerSize = 'small' | 'medium';
+
+export type MapDrawerProp = {
+  children?: ReactNode;
+  onClose?: () => void;
+  open: boolean;
+  size: MapDrawerSize;
+  style?: CSSProperties;
+  title: string;
+};
+
+const MapDrawer = (props: MapDrawerProp) => {
+  const { children, onClose, open, size, style, title } = props;
+  const theme = useTheme();
+
+  return open ? (
+    <Box className={`map-drawer map-drawer--${size}`} border={`1px solid ${theme.palette.TwClrBrdrTertiary}`} style={style}>
+      <Box className='map-drawer--header'>
+        <p className='title'>{title}</p>
+        <IconButton onClick={onClose} size='small'>
+          <Icon name='close' className='icon-close' />
+        </IconButton>
+      </Box>
+      <Box
+        className={'map-drawer--body'}
+      >
+        {children}
+      </Box>
+    </Box>
+  ) : null;
+};
+
+export default MapDrawer;

--- a/src/components/Map/MapLegend.tsx
+++ b/src/components/Map/MapLegend.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { Box, Tooltip, Typography, useTheme } from '@mui/material';
 import { useDeviceInfo } from '../../utils';
@@ -71,6 +71,14 @@ export type MapLegendProps = {
 const MapLegend = ({ legends }: MapLegendProps): JSX.Element => {
   const theme = useTheme();
   const { isMobile, isDesktop } = useDeviceInfo();
+
+  const borderRadius = useMemo(() => {
+    if (isDesktop) {
+      return '0 8px 8px 0'; // right-side
+    } else {
+      return '0 0 8px 8px'; // bottom-side
+    }
+  }, [isDesktop]);
 
   const legendComponents = legends.map((legend, index) => {
     const isFirst = index === 0;
@@ -274,13 +282,12 @@ const MapLegend = ({ legends }: MapLegendProps): JSX.Element => {
       display='flex'
       justifyItems='flex-start'
       border={`1px solid ${theme.palette.TwClrBrdrTertiary}`}
-      borderRadius='8px'
+      borderRadius={borderRadius}
       padding={theme.spacing(2, 1)}
       flexDirection={'column'}
-      maxWidth={isDesktop ? '184px' : '100%'}
-      width={isDesktop ? 'auto' : '100%'}
-      marginRight={2}
-      marginTop={isDesktop ? 0 : 2}
+      maxWidth={isDesktop ? '184px' : 'fill'}
+      width={isDesktop ? 'auto' : 'fill'}
+      margin={0}
     >
       {legendComponents}
     </Box>

--- a/src/components/Map/styles.scss
+++ b/src/components/Map/styles.scss
@@ -5,7 +5,7 @@
   flex-direction: column;
   background: $tw-clr-base-white;
 
-  &--closed {
+  &--mobile {
     display: none;
   }
 
@@ -30,7 +30,10 @@
       line-height: $tw-fnt-mssg-title-line-height;
       color: $tw-clr-txt;
       text-align: center;
-      margin: 0;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+      margin: 0 $tw-spc-base-xx-small;
       width: 100%;
     }
 

--- a/src/components/Map/styles.scss
+++ b/src/components/Map/styles.scss
@@ -1,0 +1,61 @@
+@import '../../style-dictionary-dist/terraware.scss';
+
+.map-drawer {
+  display: flex;
+  flex-direction: column;
+  background: $tw-clr-base-white;
+
+  &--closed {
+    display: none;
+  }
+
+  &--small {
+    min-width: 280px;
+    width: 280px;
+  }
+  &--medium {
+    min-width: 420px;
+    width: 420px;
+  }
+
+  &--header {
+    padding: $tw-spc-base-x-small $tw-spc-base-xx-small;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    .title {
+      font-family: $tw-fnt-mssg-title-font-family;
+      font-size: $tw-fnt-mssg-title-font-size;
+      font-weight: $tw-fnt-mssg-title-font-weight;
+      line-height: $tw-fnt-mssg-title-line-height;
+      color: $tw-clr-txt;
+      text-align: center;
+      margin: 0;
+      width: 100%;
+    }
+
+    .icon-close {
+      fill: $tw-clr-icn-secondary;
+      height: $tw-sz-base-medium;
+      width: $tw-sz-base-medium;
+    }
+  }
+
+  &--body {
+    background: $tw-clr-base-white;
+    padding: $tw-spc-base-small $tw-spc-base-x-small;
+    text-align: start;
+    overflow: auto;
+    white-space: pre-wrap;
+  }
+
+  &--message {
+    font-family: $tw-fnt-dlg-bx-message-font-family;
+    font-size: $tw-fnt-dlg-bx-message-font-size;
+    font-weight: $tw-fnt-dlg-bx-message-font-weight;
+    line-height: $tw-fnt-dlg-bx-message-line-height;
+    color: $tw-clr-txt;
+    width: 100%;
+    text-align: start;
+  }
+}

--- a/src/stories/MapDrawer.stories.tsx
+++ b/src/stories/MapDrawer.stories.tsx
@@ -4,6 +4,7 @@ import { Story } from '@storybook/react';
 import { Box, useTheme } from '@mui/material';
 import { useDeviceInfo } from '../utils';
 import MapDrawer, { MapDrawerProp } from '../components/Map/MapDrawer';
+import Button from '../components/Button/Button';
 
 export default {
   title: 'MapDrawer',
@@ -41,6 +42,7 @@ const Template: Story<MapDrawerProp> = (args) => {
       <Box display={'flex'} flexDirection={isDesktop ? 'row' : 'column'} maxHeight={'700px'}>
         <Box
           display={'flex'}
+          flexDirection={'column'}
           width={'100%'}
           minHeight={'700px'}
           height={'fill'}
@@ -53,6 +55,7 @@ const Template: Story<MapDrawerProp> = (args) => {
           margin={0}
         >
           Map Placeholder
+          <Button onClick={() => setOpen(true)} label='Open Drawer' />
         </Box>
         <MapDrawer {...args} onClose={onClose} open={open} >
           {args.children}

--- a/src/stories/MapDrawer.stories.tsx
+++ b/src/stories/MapDrawer.stories.tsx
@@ -1,0 +1,103 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { action } from '@storybook/addon-actions';
+import { Story } from '@storybook/react';
+import { Box, useTheme } from '@mui/material';
+import { useDeviceInfo } from '../utils';
+import MapDrawer, { MapDrawerProp } from '../components/Map/MapDrawer';
+
+export default {
+  title: 'MapDrawer',
+  component: MapDrawer,
+};
+
+const Template: Story<MapDrawerProp> = (args) => {
+  const theme = useTheme();
+  const { isDesktop } = useDeviceInfo();
+  const [open, setOpen] = useState(true);
+
+  const mapBorderRadius = useMemo(() => {
+    if (isDesktop) {
+      return '8px 0 0 8px';
+    } else {
+      return '8px 8px 0 0';
+    }
+  }, [isDesktop]);
+
+  const legendBorderRadius = useMemo(() => {
+    if (isDesktop) {
+      return '0 8px 8px 0';
+    } else {
+      return '0 0 8px 8px';
+    }
+  }, [isDesktop]);
+
+  const onClose = useCallback(() => {
+    action('onClose')();
+    setOpen(false);
+  }, [setOpen]);
+
+  return (
+    <Box sx={{ marginTop: '30px' }}>
+      <Box display={'flex'} flexDirection={isDesktop ? 'row' : 'column'} maxHeight={'700px'}>
+        <Box
+          display={'flex'}
+          width={'100%'}
+          minHeight={'700px'}
+          height={'fill'}
+          border={`1px solid ${theme.palette.TwClrBrdrTertiary}`}
+          borderRadius={mapBorderRadius}
+          bgcolor={'#9DC183'}
+          alignItems={'center'}
+          justifyContent={'center'}
+          textAlign={'center'}
+          margin={0}
+        >
+          Map Placeholder
+        </Box>
+        <MapDrawer {...args} onClose={onClose} open={open} >
+          {args.children}
+        </MapDrawer>
+        <Box
+          display={'flex'}
+          minWidth={'184px'}
+          width={isDesktop ? '184px' : 'fill'}
+          minHeight={'700px'}
+          height={'fill'}
+          border={`1px solid ${theme.palette.TwClrBrdrTertiary}`}
+          borderRadius={legendBorderRadius}
+          bgcolor={'#FCF4A3'}
+          alignItems={'center'}
+          justifyContent={'center'}
+          textAlign={'center'}
+        >
+          Legend Placeholder
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export const Default = Template.bind({});
+
+
+Default.args = {
+  title: 'Map Drawer Title',
+  size: 'small',
+  children: `\
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam faucibus, ex in dignissim pulvinar, \
+nunc quam molestie massa, sit amet pulvinar mauris mauris eget enim. Nullam suscipit ultrices turpis \
+id volutpat. Pellentesque accumsan risus ac tortor dictum, et varius augue viverra. Vestibulum \
+lectus mauris, rhoncus vel elit eu, faucibus aliquam enim. Maecenas aliquam pellentesque magna. \
+Etiam quis turpis fermentum, bibendum turpis in, bibendum velit. Nulla facilisi. Nam egestas \
+gravida lorem, sit amet laoreet quam tincidunt vitae. Ut lobortis, massa id sodales faucibus, \
+neque nibh varius massa, eget faucibus purus lorem sed ligula.
+
+Sed eleifend, diam sed malesuada dapibus, nulla enim ultrices diam, non iaculis sem enim id \
+elit. Cras imperdiet urna et libero iaculis, in lacinia metus lacinia. Sed quis leo non lectus \
+tristique scelerisque. Nam at sodales ligula. Etiam congue porttitor odio, non consequat sem \
+molestie at. Sed semper in elit eleifend accumsan. Pellentesque in porttitor enim. Phasellus odio \
+odio, finibus vitae elit et, pharetra viverra justo. Duis eu ligula sit amet dui bibendum tempus. \
+Cras leo purus, lobortis ut leo vel, congue maximus dolor. Aliquam condimentum leo vitae nulla \
+vulputate, pulvinar blandit lorem condimentum. Duis eget leo et arcu rhoncus iaculis vel vel risus. \
+Sed scelerisque, justo quis auctor mollis, eros magna cursus risus, id suscipit lectus massa ac urna.`
+};

--- a/src/stories/MapLegend.stories.tsx
+++ b/src/stories/MapLegend.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { Story } from '@storybook/react';
 import MapLegend, { MapLegendGroup, MapLegendProps } from '../components/Map/MapLegend';
-import { Box } from '@mui/material';
+import { Box, useTheme } from '@mui/material';
 import { useDeviceInfo } from '../utils';
 
 
@@ -11,6 +11,7 @@ export default {
 };
 
 const Template: Story<MapLegendProps> = () => {
+  const theme = useTheme();
   const { isDesktop } = useDeviceInfo();
   const [layer, setLayer] = useState<string>('forest');
 
@@ -164,12 +165,13 @@ const Template: Story<MapLegendProps> = () => {
 
   return (
     <Box sx={{ marginTop: '30px' }}>
-      <Box display={'flex'} flexDirection={isDesktop ? 'row' : 'column'}>
+      <Box display={'flex'} flexDirection={isDesktop ? 'row' : 'column'} maxHeight={'700px'}>
         <Box
           display={'flex'}
           width={'100%'}
-          height={'fill'}
           minHeight={'700px'}
+          height={'fill'}
+          border={`1px solid ${theme.palette.TwClrBrdrTertiary}`}
           borderRadius={mapBorderRadius}
           bgcolor={'#9DC183'}
           alignItems={'center'}

--- a/src/stories/MapLegend.stories.tsx
+++ b/src/stories/MapLegend.stories.tsx
@@ -19,6 +19,14 @@ const Template: Story<MapLegendProps> = () => {
 
   const [rainfallVisible, setRainfallVisible] = useState<boolean>(false);
 
+  const mapBorderRadius = useMemo(() => {
+    if (isDesktop) {
+      return '8px 0 0 8px';
+    } else {
+      return '8px 8px 0 0';
+    }
+  }, [isDesktop]);
+
   const legends = useMemo(() : MapLegendGroup[] => [
       {
         title: 'Boundaries',
@@ -156,16 +164,17 @@ const Template: Story<MapLegendProps> = () => {
 
   return (
     <Box sx={{ marginTop: '30px' }}>
-      <Box display={'flex'} flexDirection={isDesktop ? 'row' : 'column-reverse'}>
+      <Box display={'flex'} flexDirection={isDesktop ? 'row' : 'column'}>
         <Box
           display={'flex'}
           width={'100%'}
           height={'fill'}
-          border={'2px solid black'}
-          borderRadius={'8px'}
+          minHeight={'700px'}
+          borderRadius={mapBorderRadius}
+          bgcolor={'#9DC183'}
           alignItems={'center'}
           justifyContent={'center'}
-          marginX={'4px'}
+          margin={0}
         >
           Map Placeholder
         </Box>


### PR DESCRIPTION

Title Overflow
![Screenshot 2025-07-24 at 4.30.04 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NOxkRPuhAfT4F7nmdXtG/9d7df9b6-1569-4c36-8b3f-1d24fa8fec2d.png)

Bigger size

![Screenshot 2025-07-24 at 4.33.57 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NOxkRPuhAfT4F7nmdXtG/d2d52104-6f74-4bfb-9366-0c5b6880b395.png)

Close and open behavior
[Screen Recording 2025-07-24 at 4.25.22 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/NOxkRPuhAfT4F7nmdXtG/8f4d8993-e88f-4d4b-b353-68f16e6ef481.mov" />](https://app.graphite.dev/media/video/NOxkRPuhAfT4F7nmdXtG/8f4d8993-e88f-4d4b-b353-68f16e6ef481.mov)

This will only show on desktop. Tablet/mobile will not use this component and instead be handled by a different component. The Map Container will handle rendering the correct component.

Content will be implemented separately on the consumer side, on terraware-web. It will leverage tables, images and other components. The drawer itself simply behaves as a container.

