### PR TITLE
Fix map resetting and not resizing on mobile devices

### DIFF
--- a/src/components/Map/MapBox.tsx
+++ b/src/components/Map/MapBox.tsx
@@ -592,7 +592,7 @@ const MapBox = (props: MapBoxProps): JSX.Element => {
       mapStyle={stylesUrl[mapViewStyle]}
       ref={mapRefCallback}
       scrollZoom={!disableZoom}
-      style={{ width: 'fill', height: isDesktop ? 'fill' : '80vh', flexGrow: isDesktop ? 1 : undefined }}
+      style={{ width: 'auto', height: isDesktop ? 'auto' : '80vh', flexGrow: isDesktop ? 1 : undefined }}
       onClick={onMapClick}
       onMove={onMove}
       onMouseEnter={onMouseEnter}

--- a/src/components/Map/MapBox.tsx
+++ b/src/components/Map/MapBox.tsx
@@ -80,6 +80,7 @@ export type MapBoxProps = {
   cursorMap?: MapCursor;
   disableDoubleClickZoom?: boolean;
   disableZoom?: boolean;
+  drawerOpen?: boolean; // Used to trigger resize
   featureGroups?: MapFeatureGroup[];
   hideFullScreenControl?: boolean;
   hideMapViewStyleControl?: boolean;
@@ -110,6 +111,7 @@ const MapBox = (props: MapBoxProps): JSX.Element => {
     cursorMap,
     disableDoubleClickZoom,
     disableZoom,
+    drawerOpen,
     featureGroups,
     hideFullScreenControl,
     hideMapViewStyleControl,
@@ -536,6 +538,14 @@ const MapBox = (props: MapBoxProps): JSX.Element => {
 
     return () => observer.disconnect();
   }, []);
+
+  useEffect(() => {
+    if (!mapRef.current) {
+      return;
+    }
+
+    mapRef.current.resize();
+  }, [drawerOpen]);
 
   // Hovering interactive layers
   const onMouseEnter = useCallback(

--- a/src/components/Map/MapBox.tsx
+++ b/src/components/Map/MapBox.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ReactMapGL, {
   FullscreenControl,
   Layer,
@@ -523,6 +523,18 @@ const MapBox = (props: MapBoxProps): JSX.Element => {
       }
     }
     setHoverFeatureId(undefined);
+  }, []);
+
+  useEffect(() => {
+    if (!mapRef.current) {
+      return;
+    }
+    const observer = new ResizeObserver(() => {
+      mapRef.current?.resize();
+    });
+    observer.observe(mapRef.current.getContainer());
+
+    return () => observer.disconnect();
   }, []);
 
   // Hovering interactive layers

--- a/src/components/Map/MapContainer.tsx
+++ b/src/components/Map/MapContainer.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useMemo } from 'react';
 
 import { useDeviceInfo } from '../../utils';
 import './styles.scss';
@@ -14,6 +14,9 @@ type MapContainerProps = {
 const MapContainer = (props: MapContainerProps) => {
   const { containerId, drawer, drawerOpen, legend, map } = props;
   const { isDesktop } = useDeviceInfo();
+  const drawerOnly = useMemo(() => {
+    return !isDesktop && drawerOpen;
+  }, [drawerOpen, isDesktop]);
 
   return (
     <div
@@ -22,9 +25,9 @@ const MapContainer = (props: MapContainerProps) => {
         isDesktop ? '--desktop' : `--mobile${drawerOpen ? '-drawer-open' : ''}`
       }`}
     >
-      {(isDesktop || !drawerOpen) && map}
+      <div className={`map-holder${drawerOnly ? ' map-holder--hidden' : ''}`}>{map}</div>
       {drawerOpen && drawer}
-      {(isDesktop || !drawerOpen) && legend}
+      {!drawerOnly && legend}
     </div>
   );
 };

--- a/src/components/Map/MapContainer.tsx
+++ b/src/components/Map/MapContainer.tsx
@@ -14,9 +14,7 @@ type MapContainerProps = {
 const MapContainer = (props: MapContainerProps) => {
   const { containerId, drawer, drawerOpen, legend, map } = props;
   const { isDesktop } = useDeviceInfo();
-  const drawerOnly = useMemo(() => {
-    return !isDesktop && drawerOpen;
-  }, [drawerOpen, isDesktop]);
+  const drawerOnly = useMemo(() => !isDesktop && drawerOpen, [drawerOpen, isDesktop]);
 
   return (
     <div

--- a/src/components/Map/styles.scss
+++ b/src/components/Map/styles.scss
@@ -23,6 +23,17 @@
     border: none;
     border-radius: none;
   }
+
+  .map-holder {
+    display: flex;
+    flex-direction: column;
+    height: auto;
+    width: 100%;
+
+    &--hidden {
+      display: none;
+    }
+  }
 }
 
 .map-drawer {


### PR DESCRIPTION
Opening and closing drawers will remember map placement since it hides the map instead of re-rendering it.

[Screen Recording 2025-08-07 at 5.09.57 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/NOxkRPuhAfT4F7nmdXtG/acb14094-f7b3-4122-81f1-72e37f6f11ae.mov" />](https://app.graphite.dev/media/video/NOxkRPuhAfT4F7nmdXtG/acb14094-f7b3-4122-81f1-72e37f6f11ae.mov)

On screen resizes, a listener is added to properly adjust the map size. Another effect is added to adjust sizes when drawer opens/closes. This is not super efficient but users are not expected to constantly resize their screen.

[Screen Recording 2025-08-07 at 5.25.48 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/NOxkRPuhAfT4F7nmdXtG/3f792a9b-3fc4-4196-a6be-c746a819b850.mov" />](https://app.graphite.dev/media/video/NOxkRPuhAfT4F7nmdXtG/3f792a9b-3fc4-4196-a6be-c746a819b850.mov)


