### PR TITLE
Fix sass warnings in terraware-web

### DIFF
--- a/src/style-dictionary-dist/terraware.scss
+++ b/src/style-dictionary-dist/terraware.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 $tw-sz-btn-large-height: 48px;
 $tw-sz-btn-large-icon: 28px;
 $tw-sz-btn-large-min-width: 120px;
@@ -131,7 +133,7 @@ $tw-clr-bg-tertiary: #CBC6B7;
 $tw-clr-bg-tertiary-active: #B2AB93;
 $tw-clr-bg-tertiary-hover: linear-gradient(rgba(#B2AB93, 0.5), rgba(#B2AB93, 0.5)), linear-gradient(#CBC6B7, #CBC6B7);
 $tw-clr-brdr: #333025;
-$tw-clr-brdr-active: mix(#4658AA, #6172BE, 50%);
+$tw-clr-brdr-active: color.mix(#4658AA, #6172BE, 50%);
 $tw-clr-brdr-focus: #4658AA;
 $tw-clr-brdr-hover: #6172BE;
 $tw-clr-brdr-secondary: #7F775B;


### PR DESCRIPTION
After adding rsbuild to `terraware-web`, the `rsbuild/plugin-sass` dependency started complaining at build time that global built in functions are deprecated and will be removed later.

Import `sass:color` and use that for mix.