### PR TITLE
Fix generate-assets script

### DIFF
--- a/.svgrrc.cjs
+++ b/.svgrrc.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+  runtimeConfig: false,
+  prettierConfig: {
+    trailingComma: 'es5',
+    semi: true,
+    singleQuote: true,
+    jsxSingleQuote: true,
+    tabWidth: 2,
+    printWidth: 120,
+  },
+};

--- a/src/components/svg/BlobbyGrayIconImage.tsx
+++ b/src/components/svg/BlobbyGrayIconImage.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/BlobbyGrayIconImport.tsx
+++ b/src/components/svg/BlobbyGrayIconImport.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/BlobbyGrayIconUploadToTheCloud.tsx
+++ b/src/components/svg/BlobbyGrayIconUploadToTheCloud.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/BlobbyIconCloudChecked.tsx
+++ b/src/components/svg/BlobbyIconCloudChecked.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/BlobbyIconExportOrUploadPhoto.tsx
+++ b/src/components/svg/BlobbyIconExportOrUploadPhoto.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/BlobbyIconFolder.tsx
+++ b/src/components/svg/BlobbyIconFolder.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/BlobbyIconGraphReport.tsx
+++ b/src/components/svg/BlobbyIconGraphReport.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/BlobbyIconHappy.tsx
+++ b/src/components/svg/BlobbyIconHappy.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/BlobbyIconHeartMonitor.tsx
+++ b/src/components/svg/BlobbyIconHeartMonitor.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/BlobbyIconLeaf.tsx
+++ b/src/components/svg/BlobbyIconLeaf.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/BlobbyIconLibrary.tsx
+++ b/src/components/svg/BlobbyIconLibrary.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/BlobbyIconNursery.tsx
+++ b/src/components/svg/BlobbyIconNursery.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/BlobbyIconOrganization.tsx
+++ b/src/components/svg/BlobbyIconOrganization.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/BlobbyIconParchment.tsx
+++ b/src/components/svg/BlobbyIconParchment.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/BlobbyIconPeople.tsx
+++ b/src/components/svg/BlobbyIconPeople.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/BlobbyIconSeedBank.tsx
+++ b/src/components/svg/BlobbyIconSeedBank.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/BlobbyIconSeedling.tsx
+++ b/src/components/svg/BlobbyIconSeedling.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/BlobbyIconSeeds.tsx
+++ b/src/components/svg/BlobbyIconSeeds.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/BlobbyIconSite.tsx
+++ b/src/components/svg/BlobbyIconSite.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/BlobbyIconSparkles.tsx
+++ b/src/components/svg/BlobbyIconSparkles.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/BlobbyIconWrench.tsx
+++ b/src/components/svg/BlobbyIconWrench.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Bug.tsx
+++ b/src/components/svg/Bug.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Calendar.tsx
+++ b/src/components/svg/Calendar.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/CaretDown.tsx
+++ b/src/components/svg/CaretDown.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/CaretLeft.tsx
+++ b/src/components/svg/CaretLeft.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/CaretRight.tsx
+++ b/src/components/svg/CaretRight.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/CaretUp.tsx
+++ b/src/components/svg/CaretUp.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/ChevronDown.tsx
+++ b/src/components/svg/ChevronDown.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/ChevronUp.tsx
+++ b/src/components/svg/ChevronUp.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Close.tsx
+++ b/src/components/svg/Close.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Critical.tsx
+++ b/src/components/svg/Critical.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Edit.tsx
+++ b/src/components/svg/Edit.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Error.tsx
+++ b/src/components/svg/Error.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Filter.tsx
+++ b/src/components/svg/Filter.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Folder.tsx
+++ b/src/components/svg/Folder.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Help.tsx
+++ b/src/components/svg/Help.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Home.tsx
+++ b/src/components/svg/Home.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconAdd.tsx
+++ b/src/components/svg/IconAdd.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconArrowRight.tsx
+++ b/src/components/svg/IconArrowRight.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconBusinessNetwork.tsx
+++ b/src/components/svg/IconBusinessNetwork.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconCancel.tsx
+++ b/src/components/svg/IconCancel.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconChargingBattery.tsx
+++ b/src/components/svg/IconChargingBattery.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconChecklist.tsx
+++ b/src/components/svg/IconChecklist.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconCheckmark.tsx
+++ b/src/components/svg/IconCheckmark.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconCoinInHand.tsx
+++ b/src/components/svg/IconCoinInHand.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconColumns.tsx
+++ b/src/components/svg/IconColumns.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconComment.tsx
+++ b/src/components/svg/IconComment.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconDashboard.tsx
+++ b/src/components/svg/IconDashboard.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconDataMigration.tsx
+++ b/src/components/svg/IconDataMigration.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconDownloadFromTheCloud.tsx
+++ b/src/components/svg/IconDownloadFromTheCloud.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconEdit.tsx
+++ b/src/components/svg/IconEdit.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconExpand.tsx
+++ b/src/components/svg/IconExpand.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconExport.tsx
+++ b/src/components/svg/IconExport.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconExternalLink.tsx
+++ b/src/components/svg/IconExternalLink.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconEye.tsx
+++ b/src/components/svg/IconEye.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconEyeOff.tsx
+++ b/src/components/svg/IconEyeOff.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconFile.tsx
+++ b/src/components/svg/IconFile.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconFolder.tsx
+++ b/src/components/svg/IconFolder.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconFullScreen.tsx
+++ b/src/components/svg/IconFullScreen.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconFutures.tsx
+++ b/src/components/svg/IconFutures.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconGraphReport.tsx
+++ b/src/components/svg/IconGraphReport.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconHeartMonitor.tsx
+++ b/src/components/svg/IconHeartMonitor.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconHelp.tsx
+++ b/src/components/svg/IconHelp.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconHistory.tsx
+++ b/src/components/svg/IconHistory.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconImport.tsx
+++ b/src/components/svg/IconImport.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconIndex.tsx
+++ b/src/components/svg/IconIndex.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconLayers.tsx
+++ b/src/components/svg/IconLayers.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconLibrary.tsx
+++ b/src/components/svg/IconLibrary.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconList.tsx
+++ b/src/components/svg/IconList.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconLivePlant.tsx
+++ b/src/components/svg/IconLivePlant.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconMail.tsx
+++ b/src/components/svg/IconMail.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconManager.tsx
+++ b/src/components/svg/IconManager.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconMarker.tsx
+++ b/src/components/svg/IconMarker.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconMenu.tsx
+++ b/src/components/svg/IconMenu.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconMenuHorizontal.tsx
+++ b/src/components/svg/IconMenuHorizontal.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconModule.tsx
+++ b/src/components/svg/IconModule.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconMyLocation.tsx
+++ b/src/components/svg/IconMyLocation.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconNote.tsx
+++ b/src/components/svg/IconNote.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconNursery.tsx
+++ b/src/components/svg/IconNursery.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconOrg.tsx
+++ b/src/components/svg/IconOrg.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconParchment.tsx
+++ b/src/components/svg/IconParchment.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconPhoto.tsx
+++ b/src/components/svg/IconPhoto.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconPlantsFilled.tsx
+++ b/src/components/svg/IconPlantsFilled.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconRedo.tsx
+++ b/src/components/svg/IconRedo.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconRestorationSite.tsx
+++ b/src/components/svg/IconRestorationSite.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconSeedBank.tsx
+++ b/src/components/svg/IconSeedBank.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconSeedling.tsx
+++ b/src/components/svg/IconSeedling.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconSettings.tsx
+++ b/src/components/svg/IconSettings.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconSlice.tsx
+++ b/src/components/svg/IconSlice.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconSubmit.tsx
+++ b/src/components/svg/IconSubmit.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconSubtract.tsx
+++ b/src/components/svg/IconSubtract.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconSynced.tsx
+++ b/src/components/svg/IconSynced.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconTrashCan.tsx
+++ b/src/components/svg/IconTrashCan.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconTreasureMap.tsx
+++ b/src/components/svg/IconTreasureMap.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconUnavailable.tsx
+++ b/src/components/svg/IconUnavailable.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconUndo.tsx
+++ b/src/components/svg/IconUndo.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconVariable.tsx
+++ b/src/components/svg/IconVariable.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconVideo.tsx
+++ b/src/components/svg/IconVideo.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/IconWifi.tsx
+++ b/src/components/svg/IconWifi.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Info.tsx
+++ b/src/components/svg/Info.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Key.tsx
+++ b/src/components/svg/Key.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Leaf.tsx
+++ b/src/components/svg/Leaf.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Lock.tsx
+++ b/src/components/svg/Lock.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Logo.tsx
+++ b/src/components/svg/Logo.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/MenuVertical.tsx
+++ b/src/components/svg/MenuVertical.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Notification.tsx
+++ b/src/components/svg/Notification.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Person.tsx
+++ b/src/components/svg/Person.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Plus.tsx
+++ b/src/components/svg/Plus.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/RestorationSite.tsx
+++ b/src/components/svg/RestorationSite.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Search.tsx
+++ b/src/components/svg/Search.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Seeds.tsx
+++ b/src/components/svg/Seeds.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Site.tsx
+++ b/src/components/svg/Site.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Sparkles.tsx
+++ b/src/components/svg/Sparkles.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Species.tsx
+++ b/src/components/svg/Species.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Species2.tsx
+++ b/src/components/svg/Species2.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Spinner.tsx
+++ b/src/components/svg/Spinner.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Star.tsx
+++ b/src/components/svg/Star.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Success.tsx
+++ b/src/components/svg/Success.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/SuccessFilled.tsx
+++ b/src/components/svg/SuccessFilled.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/TerrawareLogoDesktop.tsx
+++ b/src/components/svg/TerrawareLogoDesktop.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/TerrawareLogoMobile.tsx
+++ b/src/components/svg/TerrawareLogoMobile.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Touchscreen.tsx
+++ b/src/components/svg/Touchscreen.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/UploadCloud.tsx
+++ b/src/components/svg/UploadCloud.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/Warning.tsx
+++ b/src/components/svg/Warning.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;

--- a/src/components/svg/WelcomeClipboard.tsx
+++ b/src/components/svg/WelcomeClipboard.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
-
+import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;
   titleId?: string;


### PR DESCRIPTION
- PR #735 bumped @trivago/prettier-plugin-sort-imports from v4 (CJS) to v6 (ESM with top-level await).
- Prettier 2 (used by @svgr/plugin-prettier@8) loads plugins via require(), which on Node 20.19+ throws ERR_REQUIRE_ASYNC_MODULE when asked to require an ESM module with top-level await — so svgr crashes before producing any output

.svgrrc.cjs configures svgr to:
  - runtimeConfig: false — stops svgr's prettier from auto-discovering the repo's .prettierrc. That file declares the trivago plugin in its "plugins" field, so any prettier instance that reads it will then try to require() the plugin (which is the call that crashes inside svgr's bundled prettier 2)
  - prettierConfig: {...} — supply the same formatting options inline so generated files keep the project's single-quote
   style.

