### PR TITLE
Fix sass warning

### DIFF
--- a/src/style-dictionary-dist/terraware.scss
+++ b/src/style-dictionary-dist/terraware.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 $tw-sz-btn-large-height: 48px;
 $tw-sz-btn-large-icon: 28px;
 $tw-sz-btn-large-min-width: 120px;
@@ -131,7 +132,7 @@ $tw-clr-bg-tertiary: #CBC6B7;
 $tw-clr-bg-tertiary-active: #B2AB93;
 $tw-clr-bg-tertiary-hover: linear-gradient(rgba(#B2AB93, 0.5), rgba(#B2AB93, 0.5)), linear-gradient(#CBC6B7, #CBC6B7);
 $tw-clr-brdr: #333025;
-$tw-clr-brdr-active: mix(#4658AA, #6172BE, 50%);
+$tw-clr-brdr-active: color.mix(#4658AA, #6172BE, 50%);
 $tw-clr-brdr-focus: #4658AA;
 $tw-clr-brdr-hover: #6172BE;
 $tw-clr-brdr-secondary: #7F775B;

--- a/style-dictionary-utils/transforms/value_color_mix.js
+++ b/style-dictionary-utils/transforms/value_color_mix.js
@@ -1,0 +1,11 @@
+module.exports = {
+  name: 'value/color-mix',
+  type: 'value',
+  transitive: true,
+  matcher: function (prop) {
+    return typeof prop.value === 'string' && /(^|[^.\w])mix\(/.test(prop.value);
+  },
+  transformer: function (prop) {
+    return prop.value.replace(/(^|[^.\w])mix\(/g, '$1color.mix(');
+  },
+};

--- a/style-dictionary/build.js
+++ b/style-dictionary/build.js
@@ -1,14 +1,15 @@
 function build(source, destination) {
-  const StyleDictionary = require('style-dictionary').extend({
+  const sd = require('style-dictionary');
+  const StyleDictionary = sd.extend({
     source: source,
     platforms: {
       scss: {
         transformGroup: 'scss',
-        transforms: ['name/css_composite', 'value/gradient', 'value/shadow'],
+        transforms: ['name/css_composite', 'value/gradient', 'value/shadow', 'value/color-mix'],
         buildPath: '../src/style-dictionary-dist/',
         files: [
           {
-            format: 'scss/variables',
+            format: 'scss/variables-with-color-module',
             destination: destination,
             options: {
               showFileHeader: false, // this is needed so we can generate output without dirtying git tree if there are no changes
@@ -22,6 +23,24 @@ function build(source, destination) {
   StyleDictionary.registerTransform(require('../style-dictionary-utils/transforms/name_css_composite.js'));
   StyleDictionary.registerTransform(require('../style-dictionary-utils/transforms/value_gradient.js'));
   StyleDictionary.registerTransform(require('../style-dictionary-utils/transforms/value_shadow.js'));
+  StyleDictionary.registerTransform(require('../style-dictionary-utils/transforms/value_color_mix.js'));
+
+  // Same output as the built-in scss/variables format, but prefixed with a
+  // `@use "sass:color"` rule so the generated color.mix() calls resolve.
+  StyleDictionary.registerFormat({
+    name: 'scss/variables-with-color-module',
+    formatter: function ({ dictionary, options }) {
+      return (
+        '@use "sass:color";\n' +
+        sd.formatHelpers.formattedVariables({
+          format: 'sass',
+          dictionary,
+          outputReferences: options.outputReferences,
+        }) +
+        '\n'
+      );
+    },
+  });
 
   StyleDictionary.buildAllPlatforms();
 }


### PR DESCRIPTION
When using web-components with Vite, there are sass warnings from terraware.scss. Fix these using the [sass migrator tool](https://sass-lang.com/documentation/breaking-changes/import/).

Update the style builder script so this doesn't happen again the next time the styles are rebuilt.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>