### PR TITLE
Add useBoolean hook and getRgbaFromHex color util

### DIFF
--- a/src/hooks/useBoolean.ts
+++ b/src/hooks/useBoolean.ts
@@ -1,0 +1,17 @@
+import { Dispatch, SetStateAction, useCallback, useState } from 'react';
+
+const useBoolean = (initialValue: boolean): [boolean, Dispatch<SetStateAction<boolean>>, () => void, () => void] => {
+  const [value, setValue] = useState(initialValue);
+
+  const setTrue = useCallback(() => {
+    setValue(true);
+  }, []);
+
+  const setFalse = useCallback(() => {
+    setValue(false);
+  }, []);
+
+  return [value, setValue, setTrue, setFalse];
+};
+
+export default useBoolean;

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,0 +1,8 @@
+import hexRgb from 'hex-rgb';
+
+export const getRgbaFromHex = (hex: string, opacity: number) => {
+  const rgba = hexRgb(hex, { alpha: opacity, format: 'object' });
+  const { red, green, blue, alpha } = rgba;
+
+  return `rgba(${red}, ${green}, ${blue}, ${alpha})`;
+};


### PR DESCRIPTION
Migrates the useBoolean hook and the getRgbaFromHex color utility from
terraware-web. These are dependencies of the GaussianSplat controls
components being migrated next.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>