### PR TITLE
Add walkthrough scene utility scripts

### DIFF
--- a/src/components/VirtualWalkthrough/AutoRotator.ts
+++ b/src/components/VirtualWalkthrough/AutoRotator.ts
@@ -1,0 +1,229 @@
+import { Quat, Script, Vec3 } from 'playcanvas';
+
+/**
+ * Auto-rotator script for PlayCanvas CameraControls.
+ * Automatically orbits the camera around its focus point after a period of inactivity.
+ */
+export class AutoRotator extends Script {
+  static scriptName = 'autoRotator';
+
+  /**
+   * Rotation speed in degrees per second when auto-rotating.
+   *
+   * @attribute
+   * @title Speed
+   */
+  speed = 4;
+
+  /**
+   * Delay in seconds before auto-rotation starts after initialization.
+   *
+   * @attribute
+   * @title Start Delay
+   */
+  startDelay = 5;
+
+  /**
+   * Delay in seconds before auto-rotation restarts after the camera stops moving.
+   *
+   * @attribute
+   * @title Restart Delay
+   */
+  restartDelay = 2;
+
+  /**
+   * Duration in seconds to fade in the rotation speed.
+   *
+   * @attribute
+   * @title Start Fade In Time
+   */
+  startFadeInTime = 5;
+
+  /**
+   * Internal timer tracking how long the camera has been idle.
+   * @private
+   */
+  private timer = 0;
+
+  /**
+   * Flag to track if rotation has started at least once.
+   * @private
+   */
+  private hasStartedRotating = false;
+
+  /**
+   * Flag to track if we're currently rotating.
+   * @private
+   */
+  private isCurrentlyRotating = false;
+
+  /**
+   * Last known pitch angle for movement detection.
+   * @private
+   */
+  private pitch: number | null = null;
+
+  /**
+   * Last known yaw angle for movement detection.
+   * @private
+   */
+  private yaw: number | null = null;
+
+  /**
+   * Reference to the camera entity.
+   * @private
+   */
+  private cameraEntity: any = null;
+
+  /**
+   * Reference to the CameraControls script.
+   * @private
+   */
+  private cameraControls: any = null;
+
+  /**
+   * Reference to the WalkthroughCamera script (used when CameraControls is absent).
+   * @private
+   */
+  private walkthroughCamera: any = null;
+
+  /**
+   * Bound event handlers for cleanup.
+   * @private
+   */
+  private onPointerDown?: () => void;
+  private onKeyDown?: () => void;
+
+  /**
+   * Handle user input events.
+   * @private
+   */
+  private handleUserInput() {
+    this.timer = 0;
+    this.isCurrentlyRotating = false;
+    this.hasStartedRotating = true;
+  }
+
+  /**
+   * Initialize the script.
+   */
+  initialize() {
+    this.onPointerDown = this.handleUserInput.bind(this);
+    this.onKeyDown = this.handleUserInput.bind(this);
+
+    if (this.app.graphicsDevice.canvas) {
+      this.app.graphicsDevice.canvas.addEventListener('pointerdown', this.onPointerDown);
+    }
+    window.addEventListener('keydown', this.onKeyDown);
+
+    this.cameraEntity = this.entity.findByName('camera');
+    if (this.cameraEntity) {
+      this.cameraControls = this.cameraEntity.script?.cameraControls ?? null;
+      this.walkthroughCamera = this.cameraEntity.script?.walkthroughCamera ?? null;
+    }
+  }
+
+  /**
+   * Update loop that handles auto-rotation logic.
+   * Runs after CameraControls updates.
+   */
+  postUpdate(dt: number) {
+    const hasControls = this.cameraControls && this.cameraControls._pose;
+    const hasWalkthrough = !!this.walkthroughCamera;
+
+    if (!hasControls && !hasWalkthrough) {
+      return;
+    }
+
+    const currentPitch = hasControls ? this.cameraControls._pose.angles.x : this.walkthroughCamera.currentPitch;
+    const currentYaw = hasControls ? this.cameraControls._pose.angles.y : this.walkthroughCamera.currentYaw;
+
+    // Initialize angles on first frame
+    if (this.pitch === null || this.yaw === null) {
+      this.pitch = currentPitch;
+      this.yaw = currentYaw;
+    }
+
+    // Check for camera movement only after initial rotation has started and while not actively rotating
+    if (this.hasStartedRotating && !this.isCurrentlyRotating && this.pitch !== null && this.yaw !== null) {
+      const pitchDiff = Math.abs(this.pitch - currentPitch);
+      const yawDiff = Math.abs(this.yaw - currentYaw);
+
+      if (pitchDiff > 0.1 || yawDiff > 0.1) {
+        this.pitch = currentPitch;
+        this.yaw = currentYaw;
+        this.timer = 0;
+        this.isCurrentlyRotating = false;
+        this.hasStartedRotating = true;
+
+        return;
+      }
+    }
+
+    this.timer += dt;
+
+    // Determine which delay to use
+    const currentDelay = this.hasStartedRotating ? this.restartDelay : this.startDelay;
+
+    // Start auto-rotation after delay
+    if (this.timer >= currentDelay) {
+      this.isCurrentlyRotating = true;
+
+      const time = this.timer - currentDelay;
+      const fadeIn = this.smoothStep(time / this.startFadeInTime);
+      const yawDelta = dt * fadeIn * this.speed;
+
+      if (hasControls) {
+        const pose = this.cameraControls._pose;
+        const focusPoint = pose.getFocus(new Vec3());
+        const offset = new Vec3().sub2(pose.position.clone(), focusPoint);
+        const rotationQuat = new Quat().setFromAxisAngle(Vec3.UP, yawDelta);
+        const rotatedOffset = new Vec3();
+        rotationQuat.transformVector(offset, rotatedOffset);
+        const newPos = new Vec3().add2(focusPoint, rotatedOffset);
+        pose.look(newPos, focusPoint);
+        if (this.cameraControls._controller?.attach) {
+          this.cameraControls._controller.attach(pose, false);
+        }
+        this.cameraEntity.setPosition(pose.position);
+        this.cameraEntity.setEulerAngles(pose.angles);
+        this.pitch = pose.angles.x;
+        this.yaw = pose.angles.y;
+      } else {
+        this.walkthroughCamera.orbitStep(yawDelta);
+        this.pitch = this.walkthroughCamera.currentPitch;
+        this.yaw = this.walkthroughCamera.currentYaw;
+      }
+    }
+  }
+
+  /**
+   * Smooth step interpolation function.
+   *
+   * @param {number} x - Input value.
+   * @returns {number} - Smoothly interpolated value.
+   * @private
+   */
+  private smoothStep(x: number): number {
+    if (x <= 0) {
+      return 0;
+    }
+    if (x >= 1) {
+      return 1;
+    }
+
+    return Math.sin((x - 0.5) * Math.PI) * 0.5 + 0.5;
+  }
+
+  /**
+   * Clean up event listeners when the script is destroyed.
+   */
+  destroy() {
+    if (this.app.graphicsDevice.canvas && this.onPointerDown) {
+      this.app.graphicsDevice.canvas.removeEventListener('pointerdown', this.onPointerDown);
+    }
+    if (this.onKeyDown) {
+      window.removeEventListener('keydown', this.onKeyDown);
+    }
+  }
+}

--- a/src/components/VirtualWalkthrough/TfXrNavigation.ts
+++ b/src/components/VirtualWalkthrough/TfXrNavigation.ts
@@ -1,0 +1,24 @@
+import { XrNavigation as PcXrNavigation } from 'playcanvas/scripts/esm/xr-navigation.mjs';
+
+/**
+ * Extended XrNavigation that fixes the bug where tryTeleport doesn't respect
+ * the enableTeleport flag setting.
+ */
+export class TfXrNavigation extends PcXrNavigation {
+  static scriptName = 'tfXrNavigation';
+
+  /**
+   * Override tryTeleport to respect the enableTeleport flag.
+   * The base implementation is always called from handleSelectEnd,
+   * but we only want to teleport when enableTeleport is true.
+   */
+  tryTeleport(inputSource: any) {
+    // Only proceed with teleportation if enableTeleport is true
+    if (!this.enableTeleport) {
+      return;
+    }
+
+    // Call the parent implementation
+    super.tryTeleport(inputSource);
+  }
+}

--- a/src/components/VirtualWalkthrough/boundary-ring.test.ts
+++ b/src/components/VirtualWalkthrough/boundary-ring.test.ts
@@ -1,0 +1,76 @@
+import { Vec3 } from 'playcanvas';
+
+import { boundaryRingMesh } from './boundary-ring';
+
+const FLAT = [new Vec3(0, 0, 0), new Vec3(1, 0, 0), new Vec3(0, 0, 1)];
+
+const toVertices = (positions: number[]): [number, number, number][] => {
+  const out: [number, number, number][] = [];
+  for (let i = 0; i < positions.length; i += 3) {
+    out.push([positions[i], positions[i + 1], positions[i + 2]]);
+  }
+
+  return out;
+};
+
+describe('boundaryRingMesh', () => {
+  it('produces four vertices and six indices per dash', () => {
+    const geom = boundaryRingMesh({ center: new Vec3(0, 0, 0), radius: 5, width: 0.1, groundPlane: FLAT, dashCount: 16 });
+    expect(geom.positions).toHaveLength(16 * 4 * 3);
+    expect(geom.indices).toHaveLength(16 * 6);
+  });
+
+  it('places every vertex at the inner or outer radius from center in XZ', () => {
+    const center = new Vec3(2, 0, -3);
+    const radius = 4;
+    const width = 0.2;
+    const inner = radius - width / 2;
+    const outer = radius + width / 2;
+    const geom = boundaryRingMesh({ center, radius, width, groundPlane: FLAT, dashCount: 32 });
+    for (const [x, , z] of toVertices(geom.positions)) {
+      const d = Math.sqrt((x - center.x) ** 2 + (z - center.z) ** 2);
+      const atInner = Math.abs(d - inner) < 1e-6;
+      const atOuter = Math.abs(d - outer) < 1e-6;
+      expect(atInner || atOuter).toBe(true);
+    }
+  });
+
+  it('lifts every vertex onto a tilted ground plane (y = z)', () => {
+    const tilted = [new Vec3(0, 0, 0), new Vec3(1, 0, 0), new Vec3(0, 1, 1)];
+    const geom = boundaryRingMesh({ center: new Vec3(0, 0, 0), radius: 3, width: 0.1, groundPlane: tilted, dashCount: 8 });
+    for (const [, y, z] of toVertices(geom.positions)) {
+      expect(y).toBeCloseTo(z);
+    }
+  });
+
+  it('references only in-range vertices from the index buffer', () => {
+    const geom = boundaryRingMesh({ center: new Vec3(0, 0, 0), radius: 5, width: 0.1, groundPlane: FLAT, dashCount: 8 });
+    const vertexCount = geom.positions.length / 3;
+    for (const idx of geom.indices) {
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(idx).toBeLessThan(vertexCount);
+    }
+  });
+
+  it('returns empty geometry for a non-positive radius', () => {
+    const geom = boundaryRingMesh({ center: new Vec3(0, 0, 0), radius: 0, width: 0.1, groundPlane: FLAT });
+    expect(geom.positions).toHaveLength(0);
+    expect(geom.indices).toHaveLength(0);
+  });
+
+  it('returns empty geometry for a non-positive width', () => {
+    const geom = boundaryRingMesh({ center: new Vec3(0, 0, 0), radius: 5, width: 0, groundPlane: FLAT });
+    expect(geom.positions).toHaveLength(0);
+  });
+
+  it('returns empty geometry for a non-positive dashCount', () => {
+    const geom = boundaryRingMesh({ center: new Vec3(0, 0, 0), radius: 5, width: 0.1, groundPlane: FLAT, dashCount: 0 });
+    expect(geom.positions).toHaveLength(0);
+  });
+
+  it('returns empty geometry for an invalid ground plane', () => {
+    const collinear = [new Vec3(0, 0, 0), new Vec3(1, 0, 0), new Vec3(2, 0, 0)];
+    const geom = boundaryRingMesh({ center: new Vec3(0, 0, 0), radius: 5, width: 0.1, groundPlane: collinear });
+    expect(geom.positions).toHaveLength(0);
+  });
+});

--- a/src/components/VirtualWalkthrough/boundary-ring.ts
+++ b/src/components/VirtualWalkthrough/boundary-ring.ts
@@ -1,0 +1,152 @@
+import {
+  CULLFACE_NONE,
+  Color,
+  LAYERID_IMMEDIATE,
+  Mesh,
+  MeshInstance,
+  Script,
+  StandardMaterial,
+  Vec3,
+} from 'playcanvas';
+
+import { computeGroundPlane, yOnPlane } from './groundPlane';
+
+export type BoundaryRingGeometryParams = {
+  center: Vec3;
+  radius: number;
+  groundPlane: Vec3[];
+  /** Band width in world units (the ring spans radius ± width / 2). */
+  width: number;
+  dashCount?: number;
+  dashRatio?: number;
+};
+
+/** Flat-array triangle geometry ready for `Mesh.setPositions` / `Mesh.setIndices`. */
+export type BoundaryRingGeometry = { positions: number[]; indices: number[] };
+
+/**
+ * Triangle geometry for a dashed boundary ring laid flat on the ground plane. Each dash is a
+ * short band (a quad = two triangles) sweeping from `radius - width / 2` to `radius + width / 2`;
+ * every vertex is sampled on the circle in XZ and lifted onto the plane via `yOnPlane`.
+ * Returns empty arrays when radius, width, or dashCount is non-positive, or the plane is invalid.
+ */
+export const boundaryRingMesh = ({
+  center,
+  radius,
+  groundPlane,
+  width,
+  dashCount = 64,
+  dashRatio = 0.5,
+}: BoundaryRingGeometryParams): BoundaryRingGeometry => {
+  const plane = computeGroundPlane(groundPlane);
+  if (radius <= 0 || width <= 0 || dashCount <= 0 || !plane) {
+    return { positions: [], indices: [] };
+  }
+
+  const innerR = radius - width / 2;
+  const outerR = radius + width / 2;
+  const step = (Math.PI * 2) / dashCount;
+  const on = step * dashRatio;
+  const positions: number[] = [];
+  const indices: number[] = [];
+
+  const pushVertex = (r: number, angle: number) => {
+    const x = center.x + r * Math.cos(angle);
+    const z = center.z + r * Math.sin(angle);
+    positions.push(x, yOnPlane(x, z, plane.normal, plane.point, center.y), z);
+  };
+
+  for (let i = 0; i < dashCount; i++) {
+    const a0 = i * step;
+    const a1 = a0 + on;
+    const base = i * 4;
+    // Per dash: v0 inner@a0, v1 outer@a0, v2 inner@a1, v3 outer@a1.
+    pushVertex(innerR, a0);
+    pushVertex(outerR, a0);
+    pushVertex(innerR, a1);
+    pushVertex(outerR, a1);
+    indices.push(base, base + 1, base + 3, base, base + 3, base + 2);
+  }
+
+  return { positions, indices };
+};
+
+/**
+ * Draws a dashed boundary ring as a flat band mesh on the ground plane.
+ *
+ * Rendered as a thin triangle band whose width is a fraction of the radius (`widthRatio`).
+ * center / radius / groundPlane are set imperatively by the BoundaryRing component (see BoundaryRing.tsx for why
+ * they are not reactive Script props), which calls `rebuild()` after updating them.
+ */
+export class BoundaryRingScript extends Script {
+  static scriptName = 'boundaryRing';
+
+  center = new Vec3();
+  radius = 0;
+  groundPlane: Vec3[] = [];
+  color = new Color(1, 1, 1);
+  dashCount = 64;
+  dashRatio = 0.5;
+  /** Band width as a fraction of the radius. */
+  widthRatio = 0.05;
+
+  private _material?: StandardMaterial;
+  private _mesh?: Mesh;
+
+  initialize() {
+    const material = new StandardMaterial();
+    material.useLighting = false;
+    material.emissive = this.color;
+    material.cull = CULLFACE_NONE;
+    material.update();
+    this._material = material;
+    this.rebuild();
+  }
+
+  rebuild() {
+    this._clearMesh();
+
+    const geometry = boundaryRingMesh({
+      center: this.center,
+      radius: this.radius,
+      groundPlane: this.groundPlane,
+      width: this.radius * this.widthRatio,
+      dashCount: this.dashCount,
+      dashRatio: this.dashRatio,
+    });
+    if (geometry.positions.length === 0 || !this._material) {
+      return;
+    }
+
+    const mesh = new Mesh(this.app.graphicsDevice);
+    mesh.setPositions(geometry.positions);
+    mesh.setIndices(geometry.indices);
+    mesh.update();
+    this._mesh = mesh;
+
+    const meshInstance = new MeshInstance(mesh, this._material);
+    if (this.entity.render) {
+      this.entity.render.meshInstances = [meshInstance];
+    } else {
+      // Render on the Immediate layer (drawn after the World layer where the splats render) so
+      // the ring is not composited behind them.
+      this.entity.addComponent('render', { meshInstances: [meshInstance], layers: [LAYERID_IMMEDIATE] });
+    }
+  }
+
+  private _clearMesh() {
+    if (this.entity.render) {
+      this.entity.render.meshInstances = [];
+    }
+    if (this._mesh) {
+      this._mesh.destroy();
+      this._mesh = undefined;
+    }
+  }
+
+  destroy() {
+    this._clearMesh();
+    this._material?.destroy();
+    this._material = undefined;
+  }
+}

--- a/src/components/VirtualWalkthrough/groundPlane.test.ts
+++ b/src/components/VirtualWalkthrough/groundPlane.test.ts
@@ -1,0 +1,54 @@
+import { Vec3 } from 'playcanvas';
+
+import { computeGroundPlane, yOnPlane } from './groundPlane';
+
+describe('computeGroundPlane', () => {
+  it('returns an up normal for a flat horizontal plane', () => {
+    const plane = computeGroundPlane([new Vec3(0, 5, 0), new Vec3(1, 5, 0), new Vec3(0, 5, 1)]);
+    expect(plane).not.toBeNull();
+    expect(plane!.normal.x).toBeCloseTo(0);
+    expect(plane!.normal.y).toBeCloseTo(1);
+    expect(plane!.normal.z).toBeCloseTo(0);
+    expect(plane!.point.y).toBeCloseTo(5);
+  });
+
+  it('flips a downward-facing normal so normal.y >= 0', () => {
+    const plane = computeGroundPlane([new Vec3(0, 0, 0), new Vec3(0, 0, 1), new Vec3(1, 0, 0)]);
+    expect(plane).not.toBeNull();
+    expect(plane!.normal.y).toBeCloseTo(1);
+  });
+
+  it('computes a unit normal for a plane tilted 45deg about X (y = z)', () => {
+    const plane = computeGroundPlane([new Vec3(0, 0, 0), new Vec3(1, 0, 0), new Vec3(0, 1, 1)]);
+    expect(plane).not.toBeNull();
+    const n = plane!.normal;
+    expect(Math.sqrt(n.x * n.x + n.y * n.y + n.z * n.z)).toBeCloseTo(1);
+    expect(n.x).toBeCloseTo(0);
+    expect(n.y).toBeCloseTo(Math.SQRT1_2);
+    expect(n.z).toBeCloseTo(-Math.SQRT1_2);
+  });
+
+  it('returns null for fewer than 3 points', () => {
+    expect(computeGroundPlane([new Vec3(0, 0, 0), new Vec3(1, 0, 0)])).toBeNull();
+  });
+
+  it('returns null for collinear points', () => {
+    expect(computeGroundPlane([new Vec3(0, 0, 0), new Vec3(1, 0, 0), new Vec3(2, 0, 0)])).toBeNull();
+  });
+});
+
+describe('yOnPlane', () => {
+  it('returns the constant height on a flat plane', () => {
+    expect(yOnPlane(3, 7, new Vec3(0, 1, 0), new Vec3(0, 5, 0), -1)).toBeCloseTo(5);
+  });
+
+  it('interpolates height on a plane where y = z', () => {
+    const n = new Vec3(0, Math.SQRT1_2, -Math.SQRT1_2);
+    expect(yOnPlane(0, 2, n, new Vec3(0, 0, 0), 0)).toBeCloseTo(2);
+    expect(yOnPlane(10, -3, n, new Vec3(0, 0, 0), 0)).toBeCloseTo(-3);
+  });
+
+  it('returns the fallback when the normal is (near) horizontal', () => {
+    expect(yOnPlane(1, 1, new Vec3(1, 0, 0), new Vec3(0, 9, 0), 42)).toBe(42);
+  });
+});

--- a/src/components/VirtualWalkthrough/groundPlane.ts
+++ b/src/components/VirtualWalkthrough/groundPlane.ts
@@ -1,0 +1,49 @@
+import { Vec3 } from 'playcanvas';
+
+export type GroundPlane = { normal: Vec3; point: Vec3 };
+
+/** Compute Y on the plane defined by `normal` passing through `point` at world XZ coords (x, z). */
+export const yOnPlane = (x: number, z: number, normal: Vec3, point: Vec3, fallback: number): number => {
+  if (Math.abs(normal.y) < 1e-6) {
+    return fallback;
+  }
+
+  return point.y - (normal.x * (x - point.x) + normal.z * (z - point.z)) / normal.y;
+};
+
+/**
+ * Derive a ground plane from 3 world-space points.
+ * Returns a normalized normal (flipped so normal.y >= 0) and a point on the plane,
+ * or null when fewer than 3 points are supplied or they are degenerate/collinear.
+ */
+export const computeGroundPlane = (points: Vec3[]): GroundPlane | null => {
+  if (points.length < 3) {
+    return null;
+  }
+  const p0 = points[0];
+  const p1 = points[1];
+  const p2 = points[2];
+  const v1x = p1.x - p0.x;
+  const v1y = p1.y - p0.y;
+  const v1z = p1.z - p0.z;
+  const v2x = p2.x - p0.x;
+  const v2y = p2.y - p0.y;
+  const v2z = p2.z - p0.z;
+  let nx = v1y * v2z - v1z * v2y;
+  let ny = v1z * v2x - v1x * v2z;
+  let nz = v1x * v2y - v1y * v2x;
+  const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
+  if (len < 1e-10) {
+    return null;
+  }
+  nx /= len;
+  ny /= len;
+  nz /= len;
+  if (ny < 0) {
+    nx = -nx;
+    ny = -ny;
+    nz = -nz;
+  }
+
+  return { normal: new Vec3(nx, ny, nz), point: new Vec3(p0.x, p0.y, p0.z) };
+};

--- a/src/components/VirtualWalkthrough/walkthrough-camera.ts
+++ b/src/components/VirtualWalkthrough/walkthrough-camera.ts
@@ -1,0 +1,369 @@
+import { Quat, Script, Vec3, math } from 'playcanvas';
+
+import { computeGroundPlane, yOnPlane } from './groundPlane';
+
+/**
+ * First-person walkthrough camera for Gaussian Splat scenes.
+ *
+ * - Pointer drag (mouse or touch) rotates the camera (pitch + yaw) with damping
+ *   matching PlayCanvas CameraControls' rotateDamping=0.98.
+ * - WASD / arrow keys move along the XZ plane using yaw-only direction, so
+ *   movement is always horizontal regardless of where the camera is pointing.
+ * - Mouse wheel moves forward/backward along the XZ plane.
+ * - Y position is clamped between boundsMin.y and boundsMax.y; set them equal
+ *   to lock vertical position entirely.
+ * - Exposes reset() and focusPoint to stay compatible with useCameraPosition.
+ */
+
+const _quat = new Quat();
+const _flatForward = new Vec3();
+const _flatRight = new Vec3();
+
+/** Frame-rate-independent damping lerp rate — matches PlayCanvas CameraControls. */
+const dampRate = (damping: number, dt: number) => 1 - Math.pow(damping, dt * 1000);
+
+/** Below this angular delta (degrees) the damped lerp snaps to its target and stops writing. */
+const ANGLE_EPSILON = 1e-3;
+
+/** Below this positional delta (world units) an idle frame skips the transform write. */
+const POSITION_EPSILON = 1e-5;
+
+export class WalkthroughCamera extends Script {
+  static scriptName = 'walkthroughCamera';
+
+  /** @attribute */
+  moveSpeed = 0.3;
+
+  /** @attribute */
+  moveFastSpeed = 0.5;
+
+  /** @attribute */
+  moveSlowSpeed = 0.15;
+
+  /** @attribute */
+  lookSensitivity = 0.1;
+
+  /** @attribute */
+  rotateDamping = 0.98;
+
+  /** @attribute */
+  pitchMin = -85;
+
+  /** @attribute */
+  pitchMax = 85;
+
+  /** @attribute */
+  scrollSpeed = 0.001;
+
+  /** @attribute */
+  boundsCenter = new Vec3(0, 0, 0);
+
+  /** @attribute */
+  boundsRadius = 10;
+
+  /** @attribute */
+  freeFly = false;
+
+  /** @attribute */
+  enableFly = true;
+
+  /** @attribute */
+  averageCameraHeight = 0;
+
+  /**
+   * Three world-space points defining the ground plane.
+   * When provided, the camera Y position is derived from this plane during non-freeFly movement.
+   *
+   * Not a React prop — must be set directly on the script instance via useEffect. The @playcanvas/react
+   * Script component is wrapped in memo() whose shallowEquals comparator returns early on the first prop
+   * with a .equals() method (Vec3), so any prop listed after boundsCenter is never compared and the
+   * component won't re-render when it changes. Set via:
+   *   app.root.findByName('camera')?.script?.walkthroughCamera.groundPlane = points
+   * Should be updated if shallowEquals is fixed (see https://github.com/playcanvas/react/pull/298)
+   */
+  groundPlane: Vec3[] = [];
+
+  // Current (damped) angles applied to the entity each frame.
+  private _pitch = 0;
+  private _yaw = 0;
+
+  // Target angles — updated immediately on pointer move, entity lerps toward them.
+  private _targetPitch = 0;
+  private _targetYaw = 0;
+
+  private _isDragging = false;
+  private _lastX = 0;
+  private _lastY = 0;
+  private _scrollDelta = 0;
+  private _keys: Partial<Record<string, boolean>> = {};
+  private _removeListeners: (() => void)[] = [];
+
+  // Cached plane derived from groundPlane attribute. Computed once when 3 points become available.
+  private _planeNormal = new Vec3(0, 1, 0);
+  private _planePoint = new Vec3(0, 0, 0);
+  private _hasGroundPlane = false;
+
+  private _syncGroundPlane() {
+    if (this._hasGroundPlane || this.groundPlane.length < 3) {
+      return;
+    }
+    const plane = computeGroundPlane(this.groundPlane);
+    if (!plane) {
+      return;
+    }
+    this._planeNormal.copy(plane.normal);
+    this._planePoint.copy(plane.point);
+    this._hasGroundPlane = true;
+  }
+
+  initialize() {
+    // Start horizontal; reset() will set the correct pose once splat data loads.
+    this._pitch = 0;
+    this._yaw = 0;
+    this._targetPitch = 0;
+    this._targetYaw = 0;
+
+    const canvas = this.app.graphicsDevice.canvas;
+
+    const onPointerDown = (e: PointerEvent) => {
+      this._isDragging = true;
+      this._lastX = e.clientX;
+      this._lastY = e.clientY;
+      try {
+        canvas.setPointerCapture(e.pointerId);
+      } catch {
+        // ignore — canvas may not be focusable yet
+      }
+    };
+
+    const onPointerMove = (e: PointerEvent) => {
+      if (!this._isDragging) {
+        return;
+      }
+      const dx = e.clientX - this._lastX;
+      const dy = e.clientY - this._lastY;
+      this._lastX = e.clientX;
+      this._lastY = e.clientY;
+      this._targetYaw -= dx * this.lookSensitivity;
+      this._targetPitch = math.clamp(this._targetPitch - dy * this.lookSensitivity, this.pitchMin, this.pitchMax);
+    };
+
+    const onPointerUp = (e: PointerEvent) => {
+      this._isDragging = false;
+      try {
+        canvas.releasePointerCapture(e.pointerId);
+      } catch {
+        // ignore
+      }
+    };
+
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      this._scrollDelta += e.deltaY;
+    };
+
+    const onContextMenu = (e: Event) => e.preventDefault();
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      this._keys[e.code] = true;
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      this._keys[e.code] = false;
+    };
+    const onBlur = () => {
+      this._keys = {};
+      this._isDragging = false;
+    };
+
+    canvas.addEventListener('pointerdown', onPointerDown);
+    canvas.addEventListener('pointermove', onPointerMove);
+    canvas.addEventListener('pointerup', onPointerUp);
+    canvas.addEventListener('pointercancel', onPointerUp);
+    canvas.addEventListener('wheel', onWheel, { passive: false });
+    canvas.addEventListener('contextmenu', onContextMenu);
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    window.addEventListener('blur', onBlur);
+
+    this._removeListeners = [
+      () => canvas.removeEventListener('pointerdown', onPointerDown),
+      () => canvas.removeEventListener('pointermove', onPointerMove),
+      () => canvas.removeEventListener('pointerup', onPointerUp),
+      () => canvas.removeEventListener('pointercancel', onPointerUp),
+      () => canvas.removeEventListener('wheel', onWheel),
+      () => canvas.removeEventListener('contextmenu', onContextMenu),
+      () => window.removeEventListener('keydown', onKeyDown),
+      () => window.removeEventListener('keyup', onKeyUp),
+      () => window.removeEventListener('blur', onBlur),
+    ];
+  }
+
+  /**
+   * Position the camera at `position` looking toward `focus`.
+   * Compatible with the useCameraPosition hook's reset() call.
+   */
+  reset(focus: Vec3, position: Vec3) {
+    this.entity.setPosition(position);
+
+    const dx = focus.x - position.x;
+    const dy = focus.y - position.y;
+    const dz = focus.z - position.z;
+    const len = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    if (len > 0) {
+      // PlayCanvas uses right-handed CCW Y rotation: forward = (-sinθ, 0, -cosθ),
+      // so to look toward (dx, 0, dz): θ = atan2(-dx, -dz).
+      this._yaw = Math.atan2(-dx, -dz) * (180 / Math.PI);
+      this._pitch = Math.atan2(-dy, Math.sqrt(dx * dx + dz * dz)) * (180 / Math.PI);
+      this._pitch = math.clamp(this._pitch, this.pitchMin, this.pitchMax);
+    }
+
+    // Snap targets so there's no damped drift from the previous pose.
+    this._targetPitch = this._pitch;
+    this._targetYaw = this._yaw;
+
+    this.entity.setEulerAngles(this._pitch, this._yaw, 0);
+  }
+
+  get currentYaw(): number {
+    return this._targetYaw;
+  }
+
+  get currentPitch(): number {
+    return this._targetPitch;
+  }
+
+  /**
+   * Orbit the camera by `yawDelta` degrees around `boundsCenter`.
+   * Called by AutoRotator
+   */
+  orbitStep(yawDelta: number) {
+    this._syncGroundPlane();
+    const pos = this.entity.getPosition();
+    const dx = pos.x - this.boundsCenter.x;
+    const dz = pos.z - this.boundsCenter.z;
+    const radius = Math.sqrt(dx * dx + dz * dz) || this.boundsRadius * 0.5;
+    const currentAngle = Math.atan2(dz, dx);
+    const newAngle = currentAngle + (yawDelta * Math.PI) / 180;
+    const nx = this.boundsCenter.x + radius * Math.cos(newAngle);
+    const nz = this.boundsCenter.z + radius * Math.sin(newAngle);
+    const ny = this._hasGroundPlane
+      ? yOnPlane(nx, nz, this._planeNormal, this._planePoint, this.boundsCenter.y) + this.averageCameraHeight
+      : this.boundsCenter.y;
+    this.entity.setPosition(nx, ny, nz);
+
+    const faceDx = this.boundsCenter.x - nx;
+    const faceDz = this.boundsCenter.z - nz;
+    this._yaw = Math.atan2(-faceDx, -faceDz) * (180 / Math.PI);
+    this._targetYaw = this._yaw;
+    this.entity.setEulerAngles(this._pitch, this._yaw, 0);
+  }
+
+  /**
+   * Returns the point directly in front of the camera.
+   * Compatible with the useCameraPosition hook's focusPoint read.
+   */
+  get focusPoint(): Vec3 {
+    const pos = this.entity.getPosition();
+    _quat.setFromEulerAngles(this._pitch, this._yaw, 0);
+    _quat.transformVector(Vec3.FORWARD, _flatForward);
+
+    return new Vec3(pos.x + _flatForward.x, pos.y + _flatForward.y, pos.z + _flatForward.z);
+  }
+
+  update(dt: number) {
+    this._syncGroundPlane();
+
+    // Lerp current angles toward targets using the same damping as CameraControls.
+    // Snap to the target once within ANGLE_EPSILON so the asymptotic lerp actually
+    // settles instead of emitting ever-smaller micro-rotations for ~0.4s after each
+    // drag. The gsplat sorter guards its own re-sorts with an epsilon, so this mainly
+    // trims that sort tail; it does not affect per-frame rendering (autoRender does).
+    const r = dampRate(this.rotateDamping, dt);
+    let nextPitch = this._pitch + (this._targetPitch - this._pitch) * r;
+    let nextYaw = this._yaw + (this._targetYaw - this._yaw) * r;
+    if (Math.abs(this._targetPitch - nextPitch) < ANGLE_EPSILON) {
+      nextPitch = this._targetPitch;
+    }
+    if (Math.abs(this._targetYaw - nextYaw) < ANGLE_EPSILON) {
+      nextYaw = this._targetYaw;
+    }
+    nextPitch = math.clamp(nextPitch, this.pitchMin, this.pitchMax);
+
+    // Only write the rotation when it actually changed, to avoid needlessly dirtying
+    // the scene node once the angles have settled.
+    const anglesChanged = nextPitch !== this._pitch || nextYaw !== this._yaw;
+    this._pitch = nextPitch;
+    this._yaw = nextYaw;
+    if (anglesChanged) {
+      this.entity.setEulerAngles(this._pitch, this._yaw, 0);
+    }
+
+    const pos = this.entity.getPosition();
+    let nx = pos.x;
+    let ny = pos.y;
+    let nz = pos.z;
+
+    if (this.enableFly) {
+      const fast = this._keys.ShiftLeft || this._keys.ShiftRight;
+      const slow = this._keys.ControlLeft || this._keys.ControlRight;
+      const speed = (fast ? this.moveFastSpeed : slow ? this.moveSlowSpeed : this.moveSpeed) * dt;
+
+      const fwd = (this._keys.KeyW || this._keys.ArrowUp ? 1 : 0) - (this._keys.KeyS || this._keys.ArrowDown ? 1 : 0);
+      const strafe =
+        (this._keys.KeyD || this._keys.ArrowRight ? 1 : 0) - (this._keys.KeyA || this._keys.ArrowLeft ? 1 : 0);
+
+      const scrollFwd = -this._scrollDelta * this.scrollSpeed;
+
+      if (fwd !== 0 || strafe !== 0 || scrollFwd !== 0) {
+        // Use yaw-only rotation so movement is always horizontal.
+        _quat.setFromEulerAngles(0, this._yaw, 0);
+        _quat.transformVector(Vec3.FORWARD, _flatForward);
+        _quat.transformVector(Vec3.RIGHT, _flatRight);
+
+        nx += _flatForward.x * (fwd * speed + scrollFwd) + _flatRight.x * strafe * speed;
+        nz += _flatForward.z * (fwd * speed + scrollFwd) + _flatRight.z * strafe * speed;
+      }
+
+      if (this.freeFly) {
+        const up = (this._keys.KeyE ? 1 : 0) - (this._keys.KeyQ ? 1 : 0);
+        if (up !== 0) {
+          ny += up * speed;
+        }
+      }
+    }
+
+    this._scrollDelta = 0;
+
+    if (!this.freeFly) {
+      // Circular XZ clamp: project back onto the circle edge if outside.
+      const cdx = nx - this.boundsCenter.x;
+      const cdz = nz - this.boundsCenter.z;
+      const dist = Math.sqrt(cdx * cdx + cdz * cdz);
+      if (dist > this.boundsRadius) {
+        const scale = this.boundsRadius / dist;
+        nx = this.boundsCenter.x + cdx * scale;
+        nz = this.boundsCenter.z + cdz * scale;
+      }
+    }
+
+    const groundY = this._hasGroundPlane
+      ? yOnPlane(nx, nz, this._planeNormal, this._planePoint, this.boundsCenter.y) + this.averageCameraHeight
+      : this.boundsCenter.y;
+    const targetY = this.freeFly ? ny : groundY;
+    // Only write the position when it actually moved. This keeps the scene node clean on
+    // idle frames; note it does not stop per-frame rasterization — while autoRender is on
+    // the app renders every frame regardless of whether the transform changed.
+    if (
+      Math.abs(nx - pos.x) > POSITION_EPSILON ||
+      Math.abs(targetY - pos.y) > POSITION_EPSILON ||
+      Math.abs(nz - pos.z) > POSITION_EPSILON
+    ) {
+      this.entity.setPosition(nx, targetY, nz);
+    }
+  }
+
+  destroy() {
+    this._removeListeners.forEach((fn) => fn());
+    this._removeListeners = [];
+  }
+}

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -2,3 +2,4 @@
 
 declare module 'playcanvas/scripts/esm/camera-controls.mjs';
 declare module 'playcanvas/scripts/esm/annotations.mjs';
+declare module 'playcanvas/scripts/esm/xr-navigation.mjs';

--- a/src/virtualWalkthrough.ts
+++ b/src/virtualWalkthrough.ts
@@ -8,23 +8,37 @@
 import Annotation from './components/VirtualWalkthrough/Annotation';
 import AnnotationEditPane from './components/VirtualWalkthrough/AnnotationEditPane';
 import AnnotationPanel from './components/VirtualWalkthrough/AnnotationPanel';
+import { AutoRotator } from './components/VirtualWalkthrough/AutoRotator';
 import CameraInfo from './components/VirtualWalkthrough/CameraInfo';
 import ControlsInfoPane from './components/VirtualWalkthrough/ControlsInfoPane';
 import SplatControls from './components/VirtualWalkthrough/SplatControls';
 import { TfAnnotationManager } from './components/VirtualWalkthrough/TfAnnotationManager';
+import { TfXrNavigation } from './components/VirtualWalkthrough/TfXrNavigation';
+import { BoundaryRingScript, boundaryRingMesh } from './components/VirtualWalkthrough/boundary-ring';
+import { computeGroundPlane, yOnPlane } from './components/VirtualWalkthrough/groundPlane';
+import { WalkthroughCamera } from './components/VirtualWalkthrough/walkthrough-camera';
 
 export type { AnnotationProps, AnnotationIconType } from './components/VirtualWalkthrough/Annotation';
 export type { AnnotationEditPaneStrings } from './components/VirtualWalkthrough/AnnotationEditPane';
 export type { CameraInfoStrings, CameraState } from './components/VirtualWalkthrough/CameraInfo';
 export type { ControlsInfoPaneStrings } from './components/VirtualWalkthrough/ControlsInfoPane';
 export type { SplatControlsProps, SplatControlsStrings } from './components/VirtualWalkthrough/SplatControls';
+export type { BoundaryRingGeometry, BoundaryRingGeometryParams } from './components/VirtualWalkthrough/boundary-ring';
+export type { GroundPlane } from './components/VirtualWalkthrough/groundPlane';
 
 export {
   Annotation,
   AnnotationEditPane,
   AnnotationPanel,
+  AutoRotator,
+  boundaryRingMesh,
+  BoundaryRingScript,
   CameraInfo,
+  computeGroundPlane,
   ControlsInfoPane,
   SplatControls,
   TfAnnotationManager,
+  TfXrNavigation,
+  WalkthroughCamera,
+  yOnPlane,
 };


### PR DESCRIPTION
Migrate the non-React PlayCanvas helper modules from terraware-web's
GaussianSplat folder: groundPlane geometry helpers, WalkthroughCamera,
BoundaryRingScript, AutoRotator, and TfXrNavigation, with their unit tests.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>