### PR TITLE
Add splat crop and reveal effect components

### DIFF
--- a/src/components/VirtualWalkthrough/SplatCrop.tsx
+++ b/src/components/VirtualWalkthrough/SplatCrop.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { Script } from '@playcanvas/react/components';
+import { Vec3 } from 'playcanvas';
+import { GsplatCropShaderEffect } from 'playcanvas/scripts/esm/gsplat/shader-effect-crop.mjs';
+
+interface SplatCropProps {
+  aabbMin?: [number, number, number];
+  aabbMax?: [number, number, number];
+  edgeScaleFactor?: number;
+}
+
+const SplatCrop = ({ aabbMin = [-1, -1, -1], aabbMax = [1, 1, 1], edgeScaleFactor = 0.5 }: SplatCropProps) => {
+  return (
+    <Script
+      script={GsplatCropShaderEffect}
+      aabbMin={new Vec3(...aabbMin)}
+      aabbMax={new Vec3(...aabbMax)}
+      edgeScaleFactor={edgeScaleFactor}
+    />
+  );
+};
+
+export default SplatCrop;

--- a/src/components/VirtualWalkthrough/SplatFadeCrop.tsx
+++ b/src/components/VirtualWalkthrough/SplatFadeCrop.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { Script } from '@playcanvas/react/components';
+import { Vec3 } from 'playcanvas';
+
+import { GsplatFadeCropShaderEffect } from './gsplat-fade-crop-effect';
+
+interface SplatFadeCropProps {
+  aabbMin?: [number, number, number];
+  aabbMax?: [number, number, number];
+  fadeDistance?: number;
+}
+
+const SplatFadeCrop = ({ aabbMin = [-1, -1, -1], aabbMax = [1, 1, 1], fadeDistance = 0.5 }: SplatFadeCropProps) => {
+  return (
+    <Script
+      script={GsplatFadeCropShaderEffect}
+      aabbMin={new Vec3(...aabbMin)}
+      aabbMax={new Vec3(...aabbMax)}
+      fadeDistance={fadeDistance}
+    />
+  );
+};
+
+export default SplatFadeCrop;

--- a/src/components/VirtualWalkthrough/SplatRevealRain.tsx
+++ b/src/components/VirtualWalkthrough/SplatRevealRain.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+import { Script } from '@playcanvas/react/components';
+import { Color, Vec3 } from 'playcanvas';
+import { GsplatRevealRain } from 'playcanvas/scripts/esm/gsplat/reveal-rain.mjs';
+
+interface SplatRevealRainProps {
+  enabled?: boolean;
+  center?: [number, number, number];
+  distance?: number;
+  speed?: number;
+  acceleration?: number;
+  flightTime?: number;
+  rainSize?: number;
+  rotation?: number;
+  fallTint?: [number, number, number];
+  fallTintIntensity?: number;
+  hitTint?: [number, number, number];
+  hitDuration?: number;
+  endRadius?: number;
+}
+
+const SplatRevealRain = ({
+  enabled = true,
+  center = [0, 0, 0],
+  distance = 3,
+  speed = 10,
+  acceleration = 5,
+  flightTime = 0.25,
+  rainSize = 0.0,
+  rotation = 0,
+  fallTint = [0, 0, 0],
+  fallTintIntensity = 0,
+  hitTint = [0, 0, 0],
+  hitDuration = 0,
+  endRadius = 5,
+}: SplatRevealRainProps) => {
+  return (
+    <Script
+      script={GsplatRevealRain}
+      enabled={enabled}
+      center={new Vec3(...center)}
+      distance={distance}
+      speed={speed}
+      acceleration={acceleration}
+      flightTime={flightTime}
+      rainSize={rainSize}
+      rotation={rotation}
+      fallTint={new Color(...fallTint)}
+      fallTintIntensity={fallTintIntensity}
+      hitTint={new Color(...hitTint)}
+      hitDuration={hitDuration}
+      endRadius={endRadius}
+    />
+  );
+};
+
+export default SplatRevealRain;

--- a/src/components/VirtualWalkthrough/gsplat-fade-crop-effect.ts
+++ b/src/components/VirtualWalkthrough/gsplat-fade-crop-effect.ts
@@ -1,0 +1,128 @@
+import { Vec3 } from 'playcanvas';
+import { GsplatShaderEffect } from 'playcanvas/scripts/esm/gsplat/gsplat-shader-effect.mjs';
+
+const shaderGLSL = /* glsl */ `
+uniform vec3 uAabbMin;
+uniform vec3 uAabbMax;
+uniform float uFadeDistance;
+
+void modifySplatCenter(inout vec3 center) {
+    // No modifications needed
+}
+
+void modifySplatRotationScale(vec3 originalCenter, vec3 modifiedCenter, inout vec4 rotation, inout vec3 scale) {
+    // Check if splat is inside AABB
+    bool insideAABB = all(greaterThanEqual(modifiedCenter, uAabbMin)) && all(lessThanEqual(modifiedCenter, uAabbMax));
+
+    if (insideAABB) {
+        // Inside the box, no fade needed
+        return;
+    }
+
+    // Calculate distance to AABB for splats outside
+    vec3 distToMin = uAabbMin - modifiedCenter;
+    vec3 distToMax = modifiedCenter - uAabbMax;
+
+    // Get the maximum positive distance on each axis (how far outside we are)
+    vec3 outsideDistance = max(distToMin, distToMax);
+    outsideDistance = max(outsideDistance, vec3(0.0));
+
+    // Use the maximum distance across all axes
+    float maxOutsideDistance = max(max(outsideDistance.x, outsideDistance.y), outsideDistance.z);
+
+    // Calculate fade factor: 1.0 at edge, 0.0 at fadeDistance away
+    float fadeFactor = 1.0 - clamp(maxOutsideDistance / uFadeDistance, 0.0, 1.0);
+
+    // Apply smooth fade using smoothstep for nicer transition
+    fadeFactor = smoothstep(0.0, 1.0, fadeFactor);
+
+    // Scale the splat based on fade factor
+    scale *= fadeFactor;
+}
+
+void modifySplatColor(vec3 center, inout vec4 color) {
+    // No color modification needed
+}
+`;
+
+const shaderWGSL = /* wgsl */ `
+uniform uAabbMin: vec3f;
+uniform uAabbMax: vec3f;
+uniform uFadeDistance: f32;
+
+fn modifySplatCenter(center: ptr<function, vec3f>) {
+    // No modifications needed
+}
+
+fn modifySplatRotationScale(originalCenter: vec3f, modifiedCenter: vec3f, rotation: ptr<function, vec4f>, scale: ptr<function, vec3f>) {
+    // Check if splat is inside AABB
+    let insideAABB = all(modifiedCenter >= uniform.uAabbMin) && all(modifiedCenter <= uniform.uAabbMax);
+
+    if (insideAABB) {
+        // Inside the box, no fade needed
+        return;
+    }
+
+    // Calculate distance to AABB for splats outside
+    let distToMin = uniform.uAabbMin - modifiedCenter;
+    let distToMax = modifiedCenter - uniform.uAabbMax;
+
+    // Get the maximum positive distance on each axis (how far outside we are)
+    var outsideDistance = max(distToMin, distToMax);
+    outsideDistance = max(outsideDistance, vec3f(0.0));
+
+    // Use the maximum distance across all axes
+    let maxOutsideDistance = max(max(outsideDistance.x, outsideDistance.y), outsideDistance.z);
+
+    // Calculate fade factor: 1.0 at edge, 0.0 at fadeDistance away
+    var fadeFactor = 1.0 - clamp(maxOutsideDistance / uniform.uFadeDistance, 0.0, 1.0);
+
+    // Apply smooth fade using smoothstep for nicer transition
+    fadeFactor = smoothstep(0.0, 1.0, fadeFactor);
+
+    // Scale the splat based on fade factor
+    *scale = (*scale) * fadeFactor;
+}
+
+fn modifySplatColor(center: vec3f, color: ptr<function, vec4f>) {
+    // No color modification needed
+}
+`;
+
+/**
+ * Fade crop shader effect for gaussian splats.
+ * Applies a smooth fade to splats outside the AABB based on distance.
+ * Splats at the AABB edge are fully visible, and fade to invisible at fadeDistance away.
+ */
+export class GsplatFadeCropShaderEffect extends GsplatShaderEffect {
+  static scriptName = 'gsplatFadeCropShaderEffect';
+
+  _aabbMinArray = [0, 0, 0];
+  _aabbMaxArray = [0, 0, 0];
+
+  aabbMin = new Vec3(-0.5, -0.5, -0.5);
+  aabbMax = new Vec3(0.5, 0.5, 0.5);
+  fadeDistance = 0.5;
+
+  getShaderGLSL() {
+    return shaderGLSL;
+  }
+
+  getShaderWGSL() {
+    return shaderWGSL;
+  }
+
+  updateEffect() {
+    this._aabbMinArray[0] = this.aabbMin.x;
+    this._aabbMinArray[1] = this.aabbMin.y;
+    this._aabbMinArray[2] = this.aabbMin.z;
+    this.setUniform('uAabbMin', this._aabbMinArray);
+
+    this._aabbMaxArray[0] = this.aabbMax.x;
+    this._aabbMaxArray[1] = this.aabbMax.y;
+    this._aabbMaxArray[2] = this.aabbMax.z;
+    this.setUniform('uAabbMax', this._aabbMaxArray);
+
+    this.setUniform('uFadeDistance', this.fadeDistance);
+  }
+}

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -3,3 +3,6 @@
 declare module 'playcanvas/scripts/esm/camera-controls.mjs';
 declare module 'playcanvas/scripts/esm/annotations.mjs';
 declare module 'playcanvas/scripts/esm/xr-navigation.mjs';
+declare module 'playcanvas/scripts/esm/gsplat/shader-effect-crop.mjs';
+declare module 'playcanvas/scripts/esm/gsplat/gsplat-shader-effect.mjs';
+declare module 'playcanvas/scripts/esm/gsplat/reveal-rain.mjs';

--- a/src/virtualWalkthrough.ts
+++ b/src/virtualWalkthrough.ts
@@ -12,6 +12,9 @@ import { AutoRotator } from './components/VirtualWalkthrough/AutoRotator';
 import CameraInfo from './components/VirtualWalkthrough/CameraInfo';
 import ControlsInfoPane from './components/VirtualWalkthrough/ControlsInfoPane';
 import SplatControls from './components/VirtualWalkthrough/SplatControls';
+import SplatCrop from './components/VirtualWalkthrough/SplatCrop';
+import SplatFadeCrop from './components/VirtualWalkthrough/SplatFadeCrop';
+import SplatRevealRain from './components/VirtualWalkthrough/SplatRevealRain';
 import { TfAnnotationManager } from './components/VirtualWalkthrough/TfAnnotationManager';
 import { TfXrNavigation } from './components/VirtualWalkthrough/TfXrNavigation';
 import { BoundaryRingScript, boundaryRingMesh } from './components/VirtualWalkthrough/boundary-ring';
@@ -37,6 +40,9 @@ export {
   computeGroundPlane,
   ControlsInfoPane,
   SplatControls,
+  SplatCrop,
+  SplatFadeCrop,
+  SplatRevealRain,
   TfAnnotationManager,
   TfXrNavigation,
   WalkthroughCamera,


### PR DESCRIPTION
Migrate the Gaussian splat effect components from terraware-web's
GaussianSplat folder: SplatCrop, SplatFadeCrop (with its
GsplatFadeCropShaderEffect), and SplatRevealRain.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>