### PR TITLE
Add scene components (Application, GradientSky, BoundaryRing)

### DIFF
--- a/src/components/VirtualWalkthrough/Application.tsx
+++ b/src/components/VirtualWalkthrough/Application.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import { Application as PcApplication } from '@playcanvas/react';
+
+import './application-styles.css';
+
+interface ApplicationProps {
+  children: React.ReactNode;
+  style?: Record<string, unknown>;
+}
+
+const Application = ({ children, style }: ApplicationProps) => {
+  return (
+    <>
+      <PcApplication
+        style={style as Record<string, unknown>}
+        graphicsDeviceOptions={{ antialias: false, xrCompatible: true }}
+      >
+        {children}
+      </PcApplication>
+      {/* Container for annotation hotspots - positioned to match canvas */}
+      <div
+        data-annotation-container
+        className='annotation-container'
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+          pointerEvents: 'none',
+          zIndex: 1000,
+        }}
+      >
+        {/* Hotspot elements will be appended here by TfAnnotationManager */}
+      </div>
+    </>
+  );
+};
+
+export default Application;

--- a/src/components/VirtualWalkthrough/BoundaryRing.tsx
+++ b/src/components/VirtualWalkthrough/BoundaryRing.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect } from 'react';
+
+import { Entity } from '@playcanvas/react';
+import { Script } from '@playcanvas/react/components';
+import { useApp } from '@playcanvas/react/hooks';
+import { Vec3 } from 'playcanvas';
+
+import { BoundaryRingScript } from './boundary-ring';
+
+export type BoundaryRingProps = {
+  center: Vec3;
+  radius: number;
+  groundPlane: Vec3[];
+};
+
+const BoundaryRing = ({ center, radius, groundPlane }: BoundaryRingProps) => {
+  const app = useApp();
+
+  useEffect(() => {
+    // Set imperatively rather than via reactive Script props. @playcanvas/react wraps Script
+    // in memo() whose shallowEquals returns early on the first prop with a .equals() method
+    // (Vec3), so any prop after a Vec3 is never compared and would not propagate.
+    // @ts-expect-error - scripts are added dynamically to the entity
+    const script = app.root.findByName('boundary-ring')?.script?.boundaryRing;
+    if (script) {
+      script.center = center;
+      script.radius = radius;
+      script.groundPlane = groundPlane;
+      script.rebuild();
+    }
+  }, [app, center, radius, groundPlane]);
+
+  return (
+    <Entity name='boundary-ring'>
+      <Script script={BoundaryRingScript} />
+    </Entity>
+  );
+};
+
+export default BoundaryRing;

--- a/src/components/VirtualWalkthrough/GradientSky.tsx
+++ b/src/components/VirtualWalkthrough/GradientSky.tsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useMemo } from 'react';
+
+import { Entity } from '@playcanvas/react';
+import { Render } from '@playcanvas/react/components';
+import { useApp } from '@playcanvas/react/hooks';
+import { Color, PIXELFORMAT_RGBA8, StandardMaterial, Texture } from 'playcanvas';
+
+interface GradientSkyProps {
+  topColor?: string;
+  horizonColor?: string;
+  groundColor?: string;
+  resolution?: number;
+}
+
+const GradientSky = ({
+  topColor = '#1e90ff',
+  horizonColor = '#87ceeb',
+  groundColor = '#8b7355',
+  resolution = 512,
+}: GradientSkyProps) => {
+  const app = useApp();
+
+  const material = useMemo(() => {
+    if (!app) {
+      return null;
+    }
+
+    const canvas = document.createElement('canvas');
+    canvas.width = resolution;
+    canvas.height = resolution;
+    const ctx = canvas.getContext('2d');
+
+    if (!ctx) {
+      return null;
+    }
+
+    const gradient = ctx.createLinearGradient(0, 0, 0, resolution);
+    gradient.addColorStop(0, topColor);
+    gradient.addColorStop(0.5, horizonColor);
+    gradient.addColorStop(0.5, groundColor);
+    gradient.addColorStop(1, groundColor);
+
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, resolution, resolution);
+
+    const texture = new Texture(app.graphicsDevice, {
+      width: resolution,
+      height: resolution,
+      format: PIXELFORMAT_RGBA8,
+      mipmaps: false,
+    });
+
+    const pixels = ctx.getImageData(0, 0, resolution, resolution);
+    texture.lock().set(new Uint8Array(pixels.data));
+    texture.unlock();
+
+    const mat = new StandardMaterial();
+    mat.emissiveMap = texture;
+    mat.emissive = new Color(1, 1, 1);
+    mat.useLighting = false;
+    mat.cull = 0;
+    mat.depthWrite = false;
+    mat.update();
+
+    return mat;
+  }, [app, topColor, horizonColor, groundColor, resolution]);
+
+  useEffect(() => {
+    // remove material to avoid memory leak
+    return () => {
+      if (material) {
+        material.destroy();
+      }
+    };
+  }, [material]);
+
+  if (!material) {
+    return null;
+  }
+
+  return (
+    <Entity name='gradient-sky' position={[0, 0, 0]} scale={[500, 500, 500]}>
+      <Render type='sphere' material={material} castShadows={false} receiveShadows={false} />
+    </Entity>
+  );
+};
+
+export default GradientSky;

--- a/src/components/VirtualWalkthrough/application-styles.css
+++ b/src/components/VirtualWalkthrough/application-styles.css
@@ -1,0 +1,4 @@
+/* Allow pointer events on annotation hotspots while container blocks events */
+.annotation-container > * {
+  pointer-events: auto;
+}

--- a/src/virtualWalkthrough.ts
+++ b/src/virtualWalkthrough.ts
@@ -8,9 +8,12 @@
 import Annotation from './components/VirtualWalkthrough/Annotation';
 import AnnotationEditPane from './components/VirtualWalkthrough/AnnotationEditPane';
 import AnnotationPanel from './components/VirtualWalkthrough/AnnotationPanel';
+import Application from './components/VirtualWalkthrough/Application';
 import { AutoRotator } from './components/VirtualWalkthrough/AutoRotator';
+import BoundaryRing from './components/VirtualWalkthrough/BoundaryRing';
 import CameraInfo from './components/VirtualWalkthrough/CameraInfo';
 import ControlsInfoPane from './components/VirtualWalkthrough/ControlsInfoPane';
+import GradientSky from './components/VirtualWalkthrough/GradientSky';
 import SplatControls from './components/VirtualWalkthrough/SplatControls';
 import SplatCrop from './components/VirtualWalkthrough/SplatCrop';
 import SplatFadeCrop from './components/VirtualWalkthrough/SplatFadeCrop';
@@ -28,17 +31,21 @@ export type { ControlsInfoPaneStrings } from './components/VirtualWalkthrough/Co
 export type { SplatControlsProps, SplatControlsStrings } from './components/VirtualWalkthrough/SplatControls';
 export type { BoundaryRingGeometry, BoundaryRingGeometryParams } from './components/VirtualWalkthrough/boundary-ring';
 export type { GroundPlane } from './components/VirtualWalkthrough/groundPlane';
+export type { BoundaryRingProps } from './components/VirtualWalkthrough/BoundaryRing';
 
 export {
   Annotation,
   AnnotationEditPane,
   AnnotationPanel,
+  Application,
   AutoRotator,
+  BoundaryRing,
   boundaryRingMesh,
   BoundaryRingScript,
   CameraInfo,
   computeGroundPlane,
   ControlsInfoPane,
+  GradientSky,
   SplatControls,
   SplatCrop,
   SplatFadeCrop,


### PR DESCRIPTION
Migrate the PlayCanvas scene/environment components from terraware-web's
GaussianSplat folder: the Application wrapper (with annotation-container
styles), GradientSky, and BoundaryRing.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>