### PR TITLE
Add SplatModel and BlockingSpinner

### DIFF
--- a/src/components/VirtualWalkthrough/BlockingSpinner.tsx
+++ b/src/components/VirtualWalkthrough/BlockingSpinner.tsx
@@ -1,0 +1,30 @@
+import React, { type JSX } from 'react';
+
+import { CircularProgress, StyledEngineProvider, useTheme } from '@mui/material';
+
+export default function BlockingSpinner(): JSX.Element {
+  const theme = useTheme();
+
+  return (
+    <StyledEngineProvider injectFirst>
+      <CircularProgress
+        size='193'
+        sx={{
+          height: '200px',
+          width: '200px',
+          position: 'absolute',
+          top: 0,
+          bottom: 0,
+          left: 0,
+          right: 0,
+          margin: 'auto',
+          '& .MuiCircularProgress-svg': {
+            color: theme.palette.TwClrIcnBrand,
+            height: '200px',
+            width: '200px',
+          },
+        }}
+      />
+    </StyledEngineProvider>
+  );
+}

--- a/src/components/VirtualWalkthrough/SplatModel.tsx
+++ b/src/components/VirtualWalkthrough/SplatModel.tsx
@@ -1,0 +1,66 @@
+import React, { memo, useEffect } from 'react';
+
+import { Entity } from '@playcanvas/react';
+import { GSplat } from '@playcanvas/react/components';
+import { useSplat } from '@playcanvas/react/hooks';
+
+import BlockingSpinner from './BlockingSpinner';
+import SplatCrop from './SplatCrop';
+import SplatFadeCrop from './SplatFadeCrop';
+import SplatRevealRain from './SplatRevealRain';
+
+export interface SplatModelProps {
+  splatSrc: string;
+  rotation?: [number, number, number];
+  cropAabbMin?: [number, number, number];
+  cropAabbMax?: [number, number, number];
+  cropEdgeScaleFactor?: number;
+  cropFade?: boolean;
+  cropFadeDistance?: number;
+  revealRain?: boolean;
+  onError?: (error: Error) => void;
+}
+
+const SplatModel = ({
+  splatSrc,
+  rotation,
+  cropAabbMin,
+  cropAabbMax,
+  cropEdgeScaleFactor,
+  cropFade = false,
+  cropFadeDistance = 0.5,
+  revealRain = false,
+  onError,
+}: SplatModelProps) => {
+  // A filename is required for the file props to assist with the asset loading. Otherwise it assumes that the splatSrc is a ply file.
+  const { asset, loading, error } = useSplat(splatSrc, { file: { filename: 'model.sog' } });
+
+  useEffect(() => {
+    if (error) {
+      onError?.(new Error(error));
+    }
+  }, [error, onError]);
+
+  if (loading) {
+    return <BlockingSpinner />;
+  }
+
+  if (!asset) {
+    return null;
+  }
+
+  return (
+    <Entity name='splat' rotation={rotation}>
+      <GSplat asset={asset} />
+      {(cropAabbMin || cropAabbMax) &&
+        (cropFade ? (
+          <SplatFadeCrop aabbMin={cropAabbMin} aabbMax={cropAabbMax} fadeDistance={cropFadeDistance} />
+        ) : (
+          <SplatCrop aabbMin={cropAabbMin} aabbMax={cropAabbMax} edgeScaleFactor={cropEdgeScaleFactor} />
+        ))}
+      <SplatRevealRain enabled={revealRain} />
+    </Entity>
+  );
+};
+
+export default memo(SplatModel);

--- a/src/virtualWalkthrough.ts
+++ b/src/virtualWalkthrough.ts
@@ -10,6 +10,7 @@ import AnnotationEditPane from './components/VirtualWalkthrough/AnnotationEditPa
 import AnnotationPanel from './components/VirtualWalkthrough/AnnotationPanel';
 import Application from './components/VirtualWalkthrough/Application';
 import { AutoRotator } from './components/VirtualWalkthrough/AutoRotator';
+import BlockingSpinner from './components/VirtualWalkthrough/BlockingSpinner';
 import BoundaryRing from './components/VirtualWalkthrough/BoundaryRing';
 import CameraInfo from './components/VirtualWalkthrough/CameraInfo';
 import ControlsInfoPane from './components/VirtualWalkthrough/ControlsInfoPane';
@@ -17,6 +18,7 @@ import GradientSky from './components/VirtualWalkthrough/GradientSky';
 import SplatControls from './components/VirtualWalkthrough/SplatControls';
 import SplatCrop from './components/VirtualWalkthrough/SplatCrop';
 import SplatFadeCrop from './components/VirtualWalkthrough/SplatFadeCrop';
+import SplatModel from './components/VirtualWalkthrough/SplatModel';
 import SplatRevealRain from './components/VirtualWalkthrough/SplatRevealRain';
 import { TfAnnotationManager } from './components/VirtualWalkthrough/TfAnnotationManager';
 import { TfXrNavigation } from './components/VirtualWalkthrough/TfXrNavigation';
@@ -32,6 +34,7 @@ export type { SplatControlsProps, SplatControlsStrings } from './components/Virt
 export type { BoundaryRingGeometry, BoundaryRingGeometryParams } from './components/VirtualWalkthrough/boundary-ring';
 export type { GroundPlane } from './components/VirtualWalkthrough/groundPlane';
 export type { BoundaryRingProps } from './components/VirtualWalkthrough/BoundaryRing';
+export type { SplatModelProps } from './components/VirtualWalkthrough/SplatModel';
 
 export {
   Annotation,
@@ -39,6 +42,7 @@ export {
   AnnotationPanel,
   Application,
   AutoRotator,
+  BlockingSpinner,
   BoundaryRing,
   boundaryRingMesh,
   BoundaryRingScript,
@@ -49,6 +53,7 @@ export {
   SplatControls,
   SplatCrop,
   SplatFadeCrop,
+  SplatModel,
   SplatRevealRain,
   TfAnnotationManager,
   TfXrNavigation,


### PR DESCRIPTION
Migrate SplatModel from terraware-web's GaussianSplat folder. Replace the
app-specific useSnackbar dependency with an onError callback prop and port
the common BlockingSpinner component it depends on for the loading state.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>