### PR TITLE
Add useDevicePerformance hook

### DIFF
--- a/src/hooks/useDevicePerformance.ts
+++ b/src/hooks/useDevicePerformance.ts
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+
+import useDeviceInfo from '../utils/useDeviceInfo';
+
+interface DevicePerformance {
+  isHighPerformance: boolean;
+  cpuCores: number;
+  deviceMemory?: number;
+  isMobile: boolean;
+}
+
+export const useDevicePerformance = (): DevicePerformance => {
+  const { isMobile } = useDeviceInfo();
+
+  const cpuCores = useMemo(() => navigator.hardwareConcurrency || 4, []);
+
+  const deviceMemory = useMemo(() => (navigator as Navigator & { deviceMemory?: number }).deviceMemory, []);
+
+  const isHighPerformance = useMemo(
+    () => (!isMobile && cpuCores >= 4) || (deviceMemory !== undefined && deviceMemory >= 8) || cpuCores >= 6,
+    [cpuCores, deviceMemory, isMobile]
+  );
+
+  return { isHighPerformance, cpuCores, deviceMemory, isMobile };
+};

--- a/src/virtualWalkthrough.ts
+++ b/src/virtualWalkthrough.ts
@@ -25,6 +25,7 @@ import { TfXrNavigation } from './components/VirtualWalkthrough/TfXrNavigation';
 import { BoundaryRingScript, boundaryRingMesh } from './components/VirtualWalkthrough/boundary-ring';
 import { computeGroundPlane, yOnPlane } from './components/VirtualWalkthrough/groundPlane';
 import { WalkthroughCamera } from './components/VirtualWalkthrough/walkthrough-camera';
+import { useDevicePerformance } from './hooks/useDevicePerformance';
 
 export type { AnnotationProps, AnnotationIconType } from './components/VirtualWalkthrough/Annotation';
 export type { AnnotationEditPaneStrings } from './components/VirtualWalkthrough/AnnotationEditPane';
@@ -57,6 +58,7 @@ export {
   SplatRevealRain,
   TfAnnotationManager,
   TfXrNavigation,
+  useDevicePerformance,
   WalkthroughCamera,
   yOnPlane,
 };


### PR DESCRIPTION
Move useDevicePerformance hook to web-components, since it's not used by anything but the viewer which will be in the next PR.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>