### PR TITLE
Expose image props to client of VirtualWalkthroughViewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "4.2.15",
+  "version": "4.2.16-rc.0",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/VirtualWalkthrough/Annotation.tsx
+++ b/src/components/VirtualWalkthrough/Annotation.tsx
@@ -25,6 +25,7 @@ export interface AnnotationProps {
   bodyText?: string;
   label?: string;
   imageUrl?: string;
+  images?: File[];
   icon?: AnnotationIconType;
   cameraPosition?: [number, number, number];
   visible?: boolean;

--- a/src/components/VirtualWalkthrough/SplatControls.tsx
+++ b/src/components/VirtualWalkthrough/SplatControls.tsx
@@ -50,8 +50,11 @@ export interface SplatControlsProps {
   onDeselectAnnotation?: () => void;
   hasSelectedAnnotation?: boolean;
   selectedAnnotation?: AnnotationProps | null;
+  selectedAnnotationIndex?: number;
   onAnnotationUpdate: (updates: Partial<AnnotationProps>) => void;
   onTextFieldFocus?: (isFocused: boolean) => void;
+  maxImagesPerAnnotation?: number;
+  onImagesChange?: (files: File[]) => void;
   canSave?: boolean;
   isFullScreen?: boolean;
   onToggleFullScreen?: () => void;
@@ -79,8 +82,11 @@ const SplatControls = ({
   onDeselectAnnotation,
   hasSelectedAnnotation,
   selectedAnnotation,
+  selectedAnnotationIndex,
   onAnnotationUpdate,
   onTextFieldFocus,
+  maxImagesPerAnnotation,
+  onImagesChange,
   canSave = true,
   isFullScreen = false,
   onToggleFullScreen,
@@ -298,11 +304,14 @@ const SplatControls = ({
         isFullScreen={isFullScreen}
       />
       <AnnotationEditPane
+        key={selectedAnnotationIndex}
         visible={isEdit === true && hasSelectedAnnotation === true}
         annotation={selectedAnnotation ?? null}
         strings={strings.annotationEditPane}
         onUpdate={onAnnotationUpdate}
         onTextFieldFocus={onTextFieldFocus}
+        maxImages={maxImagesPerAnnotation}
+        onImagesChange={onImagesChange}
       />
       {isEdit && <CameraInfo strings={strings.cameraInfo} getCameraState={getCameraState} />}
     </Box>

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -39,6 +39,7 @@ export interface VirtualWalkthroughViewerProps {
   showFreeFly?: boolean;
   isFullScreen?: boolean;
   onToggleFullScreen?: () => void;
+  maxImagesPerAnnotation?: number;
 }
 
 const VirtualWalkthroughViewer = ({
@@ -57,6 +58,7 @@ const VirtualWalkthroughViewer = ({
   showFreeFly = false,
   isFullScreen = false,
   onToggleFullScreen,
+  maxImagesPerAnnotation,
 }: VirtualWalkthroughViewerProps) => {
   const theme = useTheme();
   const { setCamera } = useCameraPosition();
@@ -226,6 +228,11 @@ const VirtualWalkthroughViewer = ({
     [selectedAnnotationIndex]
   );
 
+  const handleImagesChange = useCallback(
+    (files: File[]) => handleAnnotationUpdate({ images: files }),
+    [handleAnnotationUpdate]
+  );
+
   const canSave = useMemo(
     () => localAnnotations.every((annotation) => annotation.title && annotation.title.trim() !== ''),
     [localAnnotations]
@@ -318,7 +325,10 @@ const VirtualWalkthroughViewer = ({
         onDeselectAnnotation={handleDeselectAnnotation}
         hasSelectedAnnotation={selectedAnnotationIndex >= 0}
         selectedAnnotation={selectedAnnotationIndex >= 0 ? localAnnotations[selectedAnnotationIndex] : null}
+        selectedAnnotationIndex={selectedAnnotationIndex}
         onAnnotationUpdate={handleAnnotationUpdate}
+        onImagesChange={handleImagesChange}
+        maxImagesPerAnnotation={maxImagesPerAnnotation}
         onTextFieldFocus={setIsTextFieldFocused}
         canSave={canSave}
         editable={editable}


### PR DESCRIPTION
The previous PR added the ability to upload images in AnnotationEditPane, but didn't expose the props. Add these to `SplatControls` and `VirtualWalkthroughViewer`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>