### PR TITLE
Add exit button always visible in VR

### DIFF
--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -18,6 +18,7 @@ import SplatControls, { SplatControlsStrings } from './SplatControls';
 import SplatModel from './SplatModel';
 import { TfAnnotationManager } from './TfAnnotationManager';
 import { TfXrNavigation } from './TfXrNavigation';
+import XrExitButton from './XrExitButton';
 import { WalkthroughCamera } from './walkthrough-camera';
 
 const DEFAULT_FOCUS_POINT: [number, number, number] = [0, 0.1, 0];
@@ -261,6 +262,7 @@ const VirtualWalkthroughViewer = ({
             enableFly={!isTextFieldFocused}
             averageCameraHeight={averageCameraHeight}
           />
+          <XrExitButton />
         </Entity>
         <Script script={XrControllers} enabled={!isEdit} />
         <Script script={TfXrNavigation} enabled={!isEdit} enableTeleport={false} />

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -262,8 +262,10 @@ const VirtualWalkthroughViewer = ({
             enableFly={!isTextFieldFocused}
             averageCameraHeight={averageCameraHeight}
           />
-          <XrExitButton />
         </Entity>
+        {/* Sibling of the camera (not a child): WalkthroughCamera rewrites the camera entity's
+            transform every frame, so the button drives its own world pose from the XR head pose. */}
+        <XrExitButton />
         <Script script={XrControllers} enabled={!isEdit} />
         <Script script={TfXrNavigation} enabled={!isEdit} enableTeleport={false} />
         <Script

--- a/src/components/VirtualWalkthrough/XrExitButton.tsx
+++ b/src/components/VirtualWalkthrough/XrExitButton.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { Entity } from '@playcanvas/react';
+import { Script } from '@playcanvas/react/components';
+
+import { XrExitButton as XrExitButtonScript } from './xr-exit-button';
+
+const XrExitButton = () => (
+  <Entity name='xr-exit-button'>
+    <Script script={XrExitButtonScript} />
+  </Entity>
+);
+
+export default XrExitButton;

--- a/src/components/VirtualWalkthrough/xr-exit-button.test.ts
+++ b/src/components/VirtualWalkthrough/xr-exit-button.test.ts
@@ -1,0 +1,31 @@
+import { Vec3 } from 'playcanvas';
+
+import { raySphereIntersect } from './xr-exit-button';
+
+describe('raySphereIntersect', () => {
+  const CENTER = new Vec3(0, 0, 0);
+
+  it('hits a sphere straight ahead of the ray', () => {
+    expect(raySphereIntersect(new Vec3(0, 0, 5), new Vec3(0, 0, -1), CENTER, 1)).toBe(true);
+  });
+
+  it('misses a sphere off to the side', () => {
+    expect(raySphereIntersect(new Vec3(0, 5, 5), new Vec3(0, 0, -1), CENTER, 1)).toBe(false);
+  });
+
+  it('misses when the sphere is behind the ray origin', () => {
+    expect(raySphereIntersect(new Vec3(0, 0, 5), new Vec3(0, 0, 1), CENTER, 1)).toBe(false);
+  });
+
+  it('hits when the ray origin is inside the sphere', () => {
+    expect(raySphereIntersect(new Vec3(0, 0, 0), new Vec3(1, 0, 0), CENTER, 1)).toBe(true);
+  });
+
+  it('normalizes a non-unit direction', () => {
+    expect(raySphereIntersect(new Vec3(0, 0, 5), new Vec3(0, 0, -3), CENTER, 1)).toBe(true);
+  });
+
+  it('grazes a tangent sphere', () => {
+    expect(raySphereIntersect(new Vec3(0, 1, 5), new Vec3(0, 0, -1), CENTER, 1)).toBe(true);
+  });
+});

--- a/src/components/VirtualWalkthrough/xr-exit-button.ts
+++ b/src/components/VirtualWalkthrough/xr-exit-button.ts
@@ -7,10 +7,12 @@ import {
   LAYERID_IMMEDIATE,
   Mesh,
   MeshInstance,
+  Quat,
   Script,
   StandardMaterial,
   Texture,
   Vec3,
+  XRTYPE_VR,
   XrInputSource,
 } from 'playcanvas';
 
@@ -35,7 +37,7 @@ const TEXTURE_SIZE = 256;
 export class XrExitButton extends Script {
   static scriptName = 'xrExitButton';
 
-  /** Local offset from the camera: right, up, and forward (-z) into the upper-right of the view. */
+  /** Offset from the head, in head space: right, up, and forward (-z) into the upper-right of the view. */
   offset = new Vec3(0.45, 0.35, -1.2);
 
   /** Half-extent of the square button quad, in world units at the offset distance. */
@@ -49,8 +51,14 @@ export class XrExitButton extends Script {
   private _mesh?: Mesh;
   private _hovered = false;
 
+  private _headPosition = new Vec3();
+  private _headRotation = new Quat();
+  private _worldOffset = new Vec3();
+
+  private _isVrActive = () => this.app.xr?.active === true && this.app.xr?.type === XRTYPE_VR;
+
   private _onXrStart = () => {
-    this.entity.enabled = true;
+    this.entity.enabled = this._isVrActive();
   };
 
   private _onXrEnd = () => {
@@ -156,9 +164,8 @@ export class XrExitButton extends Script {
     // Immediate layer draws after the World layer (where the splats render) so the button is never
     // composited behind them; depthTest:false keeps it on top within the layer.
     this.entity.addComponent('render', { meshInstances: [meshInstance], layers: [LAYERID_IMMEDIATE] });
-    this.entity.setLocalPosition(this.offset.x, this.offset.y, this.offset.z);
 
-    this.entity.enabled = !!this.app.xr?.active;
+    this.entity.enabled = this._isVrActive();
     this.app.xr?.on('start', this._onXrStart);
     this.app.xr?.on('end', this._onXrEnd);
     this.app.xr?.input?.on('select', this._onSelect);
@@ -168,6 +175,8 @@ export class XrExitButton extends Script {
     if (!this.entity.enabled) {
       return;
     }
+
+    this._trackHead();
 
     const sources = this.app.xr?.input?.inputSources ?? [];
     const hovered = sources.some((source) => this._rayHitsButton(source));
@@ -181,6 +190,35 @@ export class XrExitButton extends Script {
         this._material.update();
       }
     }
+  }
+
+  /**
+   * Pin the button to the upper-right of the headset view. The camera entity's transform is
+   * overwritten every frame by WalkthroughCamera and is not the rendered head pose, so the head
+   * pose is read from the XR views (each view's inverse-view matrix is that eye's world transform)
+   * and the button places itself in world space, offset in head space.
+   */
+  private _trackHead() {
+    const views = this.app.xr?.views?.list;
+    if (!views || views.length === 0) {
+      return;
+    }
+
+    this._headPosition.set(0, 0, 0);
+    for (const view of views) {
+      view.viewInvOffMat.getTranslation(this._worldOffset);
+      this._headPosition.add(this._worldOffset);
+    }
+    this._headPosition.mulScalar(1 / views.length);
+    this._headRotation.setFromMat4(views[0].viewInvOffMat);
+
+    this._headRotation.transformVector(this.offset, this._worldOffset);
+    this.entity.setPosition(
+      this._headPosition.x + this._worldOffset.x,
+      this._headPosition.y + this._worldOffset.y,
+      this._headPosition.z + this._worldOffset.z
+    );
+    this.entity.setRotation(this._headRotation);
   }
 
   destroy() {

--- a/src/components/VirtualWalkthrough/xr-exit-button.ts
+++ b/src/components/VirtualWalkthrough/xr-exit-button.ts
@@ -11,6 +11,7 @@ import {
   StandardMaterial,
   Texture,
   Vec3,
+  XrInputSource,
 } from 'playcanvas';
 
 /**
@@ -56,6 +57,24 @@ export class XrExitButton extends Script {
     this.entity.enabled = false;
     this._hovered = false;
   };
+
+  private _onSelect = (inputSource: XrInputSource) => {
+    if (!this.entity.enabled) {
+      return;
+    }
+    if (this._rayHitsButton(inputSource)) {
+      this.app.xr?.end();
+    }
+  };
+
+  private _rayHitsButton(inputSource: XrInputSource): boolean {
+    return raySphereIntersect(
+      inputSource.getOrigin(),
+      inputSource.getDirection(),
+      this.entity.getPosition(),
+      this.hitRadius
+    );
+  }
 
   private _createTexture(): Texture {
     const canvas = document.createElement('canvas');
@@ -137,11 +156,32 @@ export class XrExitButton extends Script {
     this.entity.enabled = !!this.app.xr?.active;
     this.app.xr?.on('start', this._onXrStart);
     this.app.xr?.on('end', this._onXrEnd);
+    this.app.xr?.input?.on('select', this._onSelect);
+  }
+
+  update() {
+    if (!this.entity.enabled) {
+      return;
+    }
+
+    const sources = this.app.xr?.input?.inputSources ?? [];
+    const hovered = sources.some((source) => this._rayHitsButton(source));
+
+    if (hovered !== this._hovered) {
+      this._hovered = hovered;
+      const scale = hovered ? 1.15 : 1;
+      this.entity.setLocalScale(scale, scale, scale);
+      if (this._material) {
+        this._material.opacity = hovered ? 1 : 0.9;
+        this._material.update();
+      }
+    }
   }
 
   destroy() {
     this.app.xr?.off('start', this._onXrStart);
     this.app.xr?.off('end', this._onXrEnd);
+    this.app.xr?.input?.off('select', this._onSelect);
     if (this.entity.render) {
       this.entity.render.meshInstances = [];
     }

--- a/src/components/VirtualWalkthrough/xr-exit-button.ts
+++ b/src/components/VirtualWalkthrough/xr-exit-button.ts
@@ -56,6 +56,11 @@ export class XrExitButton extends Script {
   private _onXrEnd = () => {
     this.entity.enabled = false;
     this._hovered = false;
+    this.entity.setLocalScale(1, 1, 1);
+    if (this._material) {
+      this._material.opacity = 0.9;
+      this._material.update();
+    }
   };
 
   private _onSelect = (inputSource: XrInputSource) => {

--- a/src/components/VirtualWalkthrough/xr-exit-button.ts
+++ b/src/components/VirtualWalkthrough/xr-exit-button.ts
@@ -1,0 +1,16 @@
+import { Vec3 } from 'playcanvas';
+
+/**
+ * Boolean ray-sphere hit test. Treats the ray as a half-line (t >= 0) and returns true when it
+ * intersects the sphere or starts inside it. `direction` is normalized internally.
+ */
+export const raySphereIntersect = (origin: Vec3, direction: Vec3, center: Vec3, radius: number): boolean => {
+  const dir = direction.clone().normalize();
+  const m = new Vec3().sub2(origin, center);
+  const b = m.dot(dir);
+  const c = m.dot(m) - radius * radius;
+  if (c > 0 && b > 0) {
+    return false;
+  }
+  return b * b - c >= 0;
+};

--- a/src/components/VirtualWalkthrough/xr-exit-button.ts
+++ b/src/components/VirtualWalkthrough/xr-exit-button.ts
@@ -34,6 +34,9 @@ export const raySphereIntersect = (origin: Vec3, direction: Vec3, center: Vec3, 
 
 const TEXTURE_SIZE = 256;
 
+/** xr-standard gamepad button indices for the face buttons: A/X (4) and B/Y (5). */
+const FACE_BUTTON_INDICES = [4, 5];
+
 export class XrExitButton extends Script {
   static scriptName = 'xrExitButton';
 
@@ -54,6 +57,7 @@ export class XrExitButton extends Script {
   private _headPosition = new Vec3();
   private _headRotation = new Quat();
   private _worldOffset = new Vec3();
+  private _faceButtonDown = new WeakMap<XrInputSource, boolean>();
 
   private _isVrActive = () => this.app.xr?.active === true && this.app.xr?.type === XRTYPE_VR;
 
@@ -87,6 +91,12 @@ export class XrExitButton extends Script {
       this.entity.getPosition(),
       this.hitRadius
     );
+  }
+
+  private _faceButtonPressed(inputSource: XrInputSource): boolean {
+    const buttons = inputSource.gamepad?.buttons;
+
+    return buttons ? FACE_BUTTON_INDICES.some((index) => buttons[index]?.pressed === true) : false;
   }
 
   private _createTexture(): Texture {
@@ -179,7 +189,23 @@ export class XrExitButton extends Script {
     this._trackHead();
 
     const sources = this.app.xr?.input?.inputSources ?? [];
-    const hovered = sources.some((source) => this._rayHitsButton(source));
+    let hovered = false;
+    for (const source of sources) {
+      const sourceHovers = this._rayHitsButton(source);
+      hovered = hovered || sourceHovers;
+
+      // A face-button press exits only while that controller is aimed at the button, matching the
+      // trigger. Edge-detected so holding a button and then aiming onto it doesn't fire.
+      const facePressed = this._faceButtonPressed(source);
+      const faceWasDown = this._faceButtonDown.get(source) ?? false;
+      this._faceButtonDown.set(source, facePressed);
+
+      if (sourceHovers && facePressed && !faceWasDown) {
+        this.app.xr?.end();
+
+        return;
+      }
+    }
 
     if (hovered !== this._hovered) {
       this._hovered = hovered;

--- a/src/components/VirtualWalkthrough/xr-exit-button.ts
+++ b/src/components/VirtualWalkthrough/xr-exit-button.ts
@@ -1,4 +1,17 @@
-import { Vec3 } from 'playcanvas';
+import {
+  ADDRESS_CLAMP_TO_EDGE,
+  BLEND_NORMAL,
+  CULLFACE_NONE,
+  Color,
+  FILTER_LINEAR,
+  LAYERID_IMMEDIATE,
+  Mesh,
+  MeshInstance,
+  Script,
+  StandardMaterial,
+  Texture,
+  Vec3,
+} from 'playcanvas';
 
 /**
  * Boolean ray-sphere hit test. Treats the ray as a half-line (t >= 0) and returns true when it
@@ -12,5 +25,131 @@ export const raySphereIntersect = (origin: Vec3, direction: Vec3, center: Vec3, 
   if (c > 0 && b > 0) {
     return false;
   }
+
   return b * b - c >= 0;
 };
+
+const TEXTURE_SIZE = 256;
+
+export class XrExitButton extends Script {
+  static scriptName = 'xrExitButton';
+
+  /** Local offset from the camera: right, up, and forward (-z) into the upper-right of the view. */
+  offset = new Vec3(0.45, 0.35, -1.2);
+
+  /** Half-extent of the square button quad, in world units at the offset distance. */
+  halfSize = 0.12;
+
+  /** World-space radius of the hover/hit sphere. Slightly larger than halfSize for easier targeting. */
+  hitRadius = 0.15;
+
+  private _material?: StandardMaterial;
+  private _texture?: Texture;
+  private _mesh?: Mesh;
+  private _hovered = false;
+
+  private _onXrStart = () => {
+    this.entity.enabled = true;
+  };
+
+  private _onXrEnd = () => {
+    this.entity.enabled = false;
+    this._hovered = false;
+  };
+
+  private _createTexture(): Texture {
+    const canvas = document.createElement('canvas');
+    canvas.width = TEXTURE_SIZE;
+    canvas.height = TEXTURE_SIZE;
+    const ctx = canvas.getContext('2d');
+    const c = TEXTURE_SIZE / 2;
+
+    if (ctx) {
+      ctx.clearRect(0, 0, TEXTURE_SIZE, TEXTURE_SIZE);
+      ctx.fillStyle = 'rgba(20, 20, 20, 0.75)';
+      ctx.beginPath();
+      ctx.arc(c, c, c * 0.92, 0, Math.PI * 2);
+      ctx.fill();
+
+      const arm = TEXTURE_SIZE * 0.24;
+      ctx.strokeStyle = '#ffffff';
+      ctx.lineWidth = TEXTURE_SIZE * 0.09;
+      ctx.lineCap = 'round';
+      ctx.beginPath();
+      ctx.moveTo(c - arm, c - arm);
+      ctx.lineTo(c + arm, c + arm);
+      ctx.moveTo(c + arm, c - arm);
+      ctx.lineTo(c - arm, c + arm);
+      ctx.stroke();
+    }
+
+    const texture = new Texture(this.app.graphicsDevice, {
+      name: 'xr-exit-button',
+      width: TEXTURE_SIZE,
+      height: TEXTURE_SIZE,
+      addressU: ADDRESS_CLAMP_TO_EDGE,
+      addressV: ADDRESS_CLAMP_TO_EDGE,
+      minFilter: FILTER_LINEAR,
+      magFilter: FILTER_LINEAR,
+      mipmaps: true,
+    });
+    texture.setSource(canvas);
+
+    return texture;
+  }
+
+  private _createMesh(): Mesh {
+    const h = this.halfSize;
+    const mesh = new Mesh(this.app.graphicsDevice);
+    mesh.setPositions([-h, -h, 0, h, -h, 0, h, h, 0, -h, h, 0]);
+    mesh.setNormals([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1]);
+    mesh.setUvs(0, [0, 1, 1, 1, 1, 0, 0, 0]);
+    mesh.setIndices([0, 1, 2, 0, 2, 3]);
+    mesh.update();
+
+    return mesh;
+  }
+
+  initialize() {
+    this._texture = this._createTexture();
+
+    const material = new StandardMaterial();
+    material.useLighting = false;
+    material.emissive = new Color(1, 1, 1);
+    material.emissiveMap = this._texture;
+    material.opacityMap = this._texture;
+    material.opacityMapChannel = 'a';
+    material.blendType = BLEND_NORMAL;
+    material.depthTest = false;
+    material.depthWrite = false;
+    material.cull = CULLFACE_NONE;
+    material.update();
+    this._material = material;
+
+    this._mesh = this._createMesh();
+    const meshInstance = new MeshInstance(this._mesh, material);
+
+    // Immediate layer draws after the World layer (where the splats render) so the button is never
+    // composited behind them; depthTest:false keeps it on top within the layer.
+    this.entity.addComponent('render', { meshInstances: [meshInstance], layers: [LAYERID_IMMEDIATE] });
+    this.entity.setLocalPosition(this.offset.x, this.offset.y, this.offset.z);
+
+    this.entity.enabled = !!this.app.xr?.active;
+    this.app.xr?.on('start', this._onXrStart);
+    this.app.xr?.on('end', this._onXrEnd);
+  }
+
+  destroy() {
+    this.app.xr?.off('start', this._onXrStart);
+    this.app.xr?.off('end', this._onXrEnd);
+    if (this.entity.render) {
+      this.entity.render.meshInstances = [];
+    }
+    this._mesh?.destroy();
+    this._material?.destroy();
+    this._texture?.destroy();
+    this._mesh = undefined;
+    this._material = undefined;
+    this._texture = undefined;
+  }
+}


### PR DESCRIPTION
Inside VR it can be disorienting and confusing on how to exit a model. Add an exit button that is always visible to make it easier to exit.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>