### PR TITLE
Fix the ground height for VR

### DIFF
--- a/src/components/VirtualWalkthrough/TfAnnotationManager.ts
+++ b/src/components/VirtualWalkthrough/TfAnnotationManager.ts
@@ -176,6 +176,15 @@ export class TfAnnotationManager extends PcAnnotationManager {
   _registerAnnotation(annotation: any) {
     super._registerAnnotation(annotation);
     this._applyAnnotationIcon(annotation);
+
+    // Keep the hotspot mesh hidden until the first scale pass clamps it. The annotation entity
+    // starts at unit local scale, so under a scaled content-root the plane would render many world
+    // units across for the frames before _updateAnnotationRotationAndScale runs.
+    const resources = (this as any)._annotationResources.get(annotation);
+    if (resources) {
+      resources.baseEntity.enabled = false;
+      resources.overlayEntity.enabled = false;
+    }
   }
 
   /**
@@ -292,6 +301,18 @@ export class TfAnnotationManager extends PcAnnotationManager {
   }
 
   /**
+   * Override to also disable the hotspot mesh (not just the DOM) when the annotation is behind the
+   * camera. The base implementation leaves the mesh enabled, so a not-yet-scaled plane under a
+   * scaled content-root would stay huge in view until the camera moves the anchor in front.
+   * @private
+   */
+  _hideAnnotationElements(annotation: any, resources: any) {
+    super._hideAnnotationElements(annotation, resources);
+    resources.baseEntity.enabled = false;
+    resources.overlayEntity.enabled = false;
+  }
+
+  /**
    * Override the scale update to clamp the world size to a maximum value.
    * Also scales the hotspot DOM element to match.
    * @private
@@ -330,6 +351,12 @@ export class TfAnnotationManager extends PcAnnotationManager {
     // size, so it uses the true _hotspotSize and the clamp ratio only (never the
     // parent scale, which the DOM overlay does not inherit).
     const resources = (this as any)._annotationResources.get(annotation);
+    if (resources) {
+      // This branch only runs for annotations in front of the camera, and the scale above is now
+      // clamped, so it is safe to reveal the mesh (hidden on register / when behind the camera).
+      resources.baseEntity.enabled = true;
+      resources.overlayEntity.enabled = true;
+    }
     if (resources && resources.hotspotDom) {
       const clampRatio = clampedScale / unclampedScale;
       const baseSize = (this as any)._hotspotSize + 5; // Match the +5 from the stylesheet

--- a/src/hooks/useXr.ts
+++ b/src/hooks/useXr.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useApp } from '@playcanvas/react/hooks';
-import { CameraComponent, XRSPACE_LOCAL, XRSPACE_LOCALFLOOR, XRTYPE_AR, XRTYPE_VR } from 'playcanvas';
+import { CameraComponent, XRSPACE_LOCALFLOOR, XRTYPE_AR, XRTYPE_VR } from 'playcanvas';
 
 export type XrType = 'VR' | 'AR';
 
@@ -12,11 +12,6 @@ interface UseXrOptions {
 const XR_TYPES: Record<XrType, string> = {
   VR: XRTYPE_VR,
   AR: XRTYPE_AR,
-};
-
-const XR_SPACES: Record<XrType, string> = {
-  VR: XRSPACE_LOCALFLOOR,
-  AR: XRSPACE_LOCAL,
 };
 
 export const useXr = ({ onError }: UseXrOptions = {}) => {
@@ -66,7 +61,7 @@ export const useXr = ({ onError }: UseXrOptions = {}) => {
   const startXr = useCallback(
     (type: XrType) => {
       const camera = app.root.findComponent('camera') as CameraComponent;
-      app.xr?.start(camera, XR_TYPES[type], XR_SPACES[type], {
+      app.xr?.start(camera, XR_TYPES[type], XRSPACE_LOCALFLOOR, {
         callback: (err: Error | null) => {
           if (err) {
             onError?.(err);

--- a/src/hooks/useXr.ts
+++ b/src/hooks/useXr.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useApp } from '@playcanvas/react/hooks';
-import { CameraComponent, XRSPACE_LOCAL, XRTYPE_AR, XRTYPE_VR } from 'playcanvas';
+import { CameraComponent, XRSPACE_LOCAL, XRSPACE_LOCALFLOOR, XRTYPE_AR, XRTYPE_VR } from 'playcanvas';
 
 export type XrType = 'VR' | 'AR';
 
@@ -15,7 +15,7 @@ const XR_TYPES: Record<XrType, string> = {
 };
 
 const XR_SPACES: Record<XrType, string> = {
-  VR: XRSPACE_LOCAL,
+  VR: XRSPACE_LOCALFLOOR,
   AR: XRSPACE_LOCAL,
 };
 

--- a/src/stories/VirtualWalkthroughViewer.stories.tsx
+++ b/src/stories/VirtualWalkthroughViewer.stories.tsx
@@ -113,7 +113,7 @@ const Template: Story<Partial<VirtualWalkthroughViewerProps>> = (args) => (
         ]}
         sceneBounds={{ x: 0, y: -0.1, z: -0.1, m: 1 }}
         averageCameraHeight={0.2}
-        scaleFactor={7}
+        scaleFactor={15}
         {...args}
       />
     </Application>


### PR DESCRIPTION
The ground height of the model was set close to where the viewer's headset was when inside VR. Set this to LocalFloor so that it feels more natural.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>