### PR TITLE
Create separate useXr hook

### DIFF
--- a/src/components/VirtualWalkthrough/SplatControls.tsx
+++ b/src/components/VirtualWalkthrough/SplatControls.tsx
@@ -1,12 +1,11 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 
 import { Fullscreen, FullscreenExit } from '@mui/icons-material';
 import { Box, IconButton, useTheme } from '@mui/material';
-import { useApp } from '@playcanvas/react/hooks';
-import { CameraComponent, XRSPACE_LOCAL, XRTYPE_AR, XRTYPE_VR } from 'playcanvas';
 
 import useBoolean from '../../hooks/useBoolean';
 import { useCameraPosition } from '../../hooks/useCameraPosition';
+import { useXr } from '../../hooks/useXr';
 import { getRgbaFromHex } from '../../utils/color';
 import useDeviceInfo from '../../utils/useDeviceInfo';
 import Button from '../Button/Button';
@@ -97,65 +96,11 @@ const SplatControls = ({
 }: SplatControlsProps) => {
   const theme = useTheme();
   const { isDesktop } = useDeviceInfo();
-  const app = useApp();
   const { setCamera, getCameraState } = useCameraPosition();
-  const [isArAvailable, setIsArAvailable] = useState(false);
-  const [isVrAvailable, setIsVrAvailable] = useState(false);
+  const { isXrAvailable, startXr } = useXr({ onError });
   const [isInfoVisible, setIsInfoVisible] = useBoolean(true);
   const paneRef = useRef<HTMLDivElement>(null);
   const infoButtonRef = useRef<HTMLButtonElement>(null);
-
-  const errorCallback = useCallback(
-    (err: Error | null) => {
-      if (err) {
-        onError?.(err);
-        app.xr?.end();
-      }
-    },
-    [app, onError]
-  );
-
-  const handleAr = useCallback(
-    () =>
-      app.xr?.start(app.root.findComponent('camera') as CameraComponent, XRTYPE_AR, XRSPACE_LOCAL, {
-        callback: errorCallback,
-      }),
-    [app, errorCallback]
-  );
-
-  const handleVr = useCallback(
-    () =>
-      app.xr?.start(app.root.findComponent('camera') as CameraComponent, XRTYPE_VR, XRSPACE_LOCAL, {
-        callback: errorCallback,
-      }),
-    [app, errorCallback]
-  );
-
-  useEffect(() => {
-    // this can't be changed to `useMemo(() => app.xr?.isAvailable(XRTYPE_AR), [app])` because `app` doesn't update when
-    // XR's availability is updated
-    const handleAvailable = (type: string, available: boolean) => {
-      if (type === XRTYPE_VR) {
-        setIsVrAvailable(available);
-      } else if (type === XRTYPE_AR) {
-        setIsArAvailable(available);
-      }
-    };
-
-    // Check current availability state on mount
-    if (app.xr?.isAvailable(XRTYPE_VR)) {
-      setIsVrAvailable(true);
-    }
-    if (app.xr?.isAvailable(XRTYPE_AR)) {
-      setIsArAvailable(true);
-    }
-
-    app.xr?.on('available', handleAvailable);
-
-    return () => {
-      app.xr?.off('available', handleAvailable);
-    };
-  }, [app]);
 
   useEffect(() => {
     const handleKeyPress = (event: KeyboardEvent) => {
@@ -250,8 +195,8 @@ const SplatControls = ({
           pointerEvents: 'auto',
         }}
       >
-        {isArAvailable && !isEdit && <Button label={strings.ar} onClick={handleAr} />}
-        {isVrAvailable && !isEdit && <Button label={strings.vr} onClick={handleVr} />}
+        {isXrAvailable('AR') && !isEdit && <Button label={strings.ar} onClick={() => startXr('AR')} />}
+        {isXrAvailable('VR') && !isEdit && <Button label={strings.vr} onClick={() => startXr('VR')} />}
         {isDesktop && editable && !isEdit && onToggleEdit && <Button label={strings.edit} onClick={handleEdit} />}
         {isDesktop && showFreeFly && !isEdit && onToggleFreeFly && (
           <Button label={isFreeFly ? strings.boundedFly : strings.freeFly} onClick={onToggleFreeFly} />

--- a/src/hooks/useXr.ts
+++ b/src/hooks/useXr.ts
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useApp } from '@playcanvas/react/hooks';
+import { CameraComponent, XRSPACE_LOCAL, XRTYPE_AR, XRTYPE_VR } from 'playcanvas';
+
+export type XrType = 'VR' | 'AR';
+
+interface UseXrOptions {
+  onError?: (error: Error) => void;
+}
+
+const XR_TYPES: Record<XrType, string> = {
+  VR: XRTYPE_VR,
+  AR: XRTYPE_AR,
+};
+
+const XR_SPACES: Record<XrType, string> = {
+  VR: XRSPACE_LOCAL,
+  AR: XRSPACE_LOCAL,
+};
+
+export const useXr = ({ onError }: UseXrOptions = {}) => {
+  const app = useApp();
+  const [available, setAvailable] = useState<Record<XrType, boolean>>({ VR: false, AR: false });
+  const [isCurrentlyInXr, setIsCurrentlyInXr] = useState(app.xr?.active ?? false);
+
+  useEffect(() => {
+    // We subscribe to the manager directly because `app` doesn't update when XR's availability changes.
+    const handleAvailable = (type: string, isAvailable: boolean) => {
+      if (type === XRTYPE_VR) {
+        setAvailable((prev) => ({ ...prev, VR: isAvailable }));
+      } else if (type === XRTYPE_AR) {
+        setAvailable((prev) => ({ ...prev, AR: isAvailable }));
+      }
+    };
+
+    setAvailable({
+      VR: app.xr?.isAvailable(XRTYPE_VR) ?? false,
+      AR: app.xr?.isAvailable(XRTYPE_AR) ?? false,
+    });
+
+    app.xr?.on('available', handleAvailable);
+
+    return () => {
+      app.xr?.off('available', handleAvailable);
+    };
+  }, [app]);
+
+  useEffect(() => {
+    const handleStart = () => setIsCurrentlyInXr(true);
+    const handleEnd = () => setIsCurrentlyInXr(false);
+
+    setIsCurrentlyInXr(app.xr?.active ?? false);
+
+    app.xr?.on('start', handleStart);
+    app.xr?.on('end', handleEnd);
+
+    return () => {
+      app.xr?.off('start', handleStart);
+      app.xr?.off('end', handleEnd);
+    };
+  }, [app]);
+
+  const isXrAvailable = useCallback((type: XrType) => available[type], [available]);
+
+  const startXr = useCallback(
+    (type: XrType) => {
+      const camera = app.root.findComponent('camera') as CameraComponent;
+      app.xr?.start(camera, XR_TYPES[type], XR_SPACES[type], {
+        callback: (err: Error | null) => {
+          if (err) {
+            onError?.(err);
+            app.xr?.end();
+          }
+        },
+      });
+    },
+    [app, onError]
+  );
+
+  const endXr = useCallback(() => {
+    app.xr?.end();
+  }, [app]);
+
+  return useMemo(
+    () => ({ isXrAvailable, startXr, endXr, isCurrentlyInXr }),
+    [isXrAvailable, startXr, endXr, isCurrentlyInXr]
+  );
+};
+
+export default useXr;


### PR DESCRIPTION
Move WebXR availability tracking and AR/VR session start/error handling
out of SplatControls into a reusable useXr hook.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>