### PR TITLE
SW-8690 Allow VR annotations to be clicked to make active

### DIFF
--- a/src/components/VirtualWalkthrough/Annotation.tsx
+++ b/src/components/VirtualWalkthrough/Annotation.tsx
@@ -120,6 +120,15 @@ const Annotation = (props: AnnotationProps & { index: number }) => {
     [setCamera]
   );
 
+  // VR open path: shows the annotation without moving the camera (roomscale head pose
+  // comes from the XR views, so a camera move would be disorienting or a no-op).
+  const handleVrOpen = useCallback((screenX: number, screenY: number) => {
+    if (isEditRef.current) {
+      return;
+    }
+    onViewRef.current?.(annotationForViewRef.current, screenX, screenY);
+  }, []);
+
   // Stable callback so its identity doesn't churn the underlying script prop each frame.
   const handleScreenPositionUpdate = useCallback(
     (screenX: number, screenY: number, size?: number) => {
@@ -228,6 +237,7 @@ const Annotation = (props: AnnotationProps & { index: number }) => {
         text={bodyText}
         enabled={visible}
         onClickCallback={handleClick}
+        onVrOpenCallback={handleVrOpen}
         onScreenPositionUpdateCallback={isViewed ? handleScreenPositionUpdate : undefined}
       />
     </Entity>

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -19,6 +19,7 @@ import SplatControls, { SplatControlsStrings } from './SplatControls';
 import SplatModel from './SplatModel';
 import { TfAnnotationManager } from './TfAnnotationManager';
 import { TfXrNavigation } from './TfXrNavigation';
+import XrAnnotationInteraction from './XrAnnotationInteraction';
 import XrExitButton from './XrExitButton';
 import { WalkthroughCamera } from './walkthrough-camera';
 
@@ -289,6 +290,7 @@ const VirtualWalkthroughViewer = ({
             transform every frame, so the button drives its own world pose from the XR head pose. */}
         <XrExitButton />
         <Script script={XrControllers} enabled={!isEdit} />
+        <XrAnnotationInteraction />
         {/* Disable teleport for AR as it can be disorienting */}
         <Script script={TfXrNavigation} enabled={!isEdit} enableTeleport={false} />
         {!isCurrentlyInXr && (

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -21,6 +21,7 @@ import { TfAnnotationManager } from './TfAnnotationManager';
 import { TfXrNavigation } from './TfXrNavigation';
 import XrAnnotationInteraction from './XrAnnotationInteraction';
 import XrExitButton from './XrExitButton';
+import XrPointerRay from './XrPointerRay';
 import { WalkthroughCamera } from './walkthrough-camera';
 
 const DEFAULT_FOCUS_POINT: [number, number, number] = [0, 0.1, 0];
@@ -291,6 +292,7 @@ const VirtualWalkthroughViewer = ({
         <XrExitButton />
         <Script script={XrControllers} enabled={!isEdit} />
         <XrAnnotationInteraction />
+        <XrPointerRay />
         {/* Disable teleport for AR as it can be disorienting */}
         <Script script={TfXrNavigation} enabled={!isEdit} enableTeleport={false} />
         {!isCurrentlyInXr && (

--- a/src/components/VirtualWalkthrough/XrAnnotationInteraction.tsx
+++ b/src/components/VirtualWalkthrough/XrAnnotationInteraction.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { Entity } from '@playcanvas/react';
+import { Script } from '@playcanvas/react/components';
+
+import { XrAnnotationInteraction as XrAnnotationInteractionScript } from './xr-annotation-interaction';
+
+const XrAnnotationInteraction = () => (
+  <Entity name='xr-annotation-interaction'>
+    <Script script={XrAnnotationInteractionScript} />
+  </Entity>
+);
+
+export default XrAnnotationInteraction;

--- a/src/components/VirtualWalkthrough/XrPointerRay.tsx
+++ b/src/components/VirtualWalkthrough/XrPointerRay.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { Entity } from '@playcanvas/react';
+import { Script } from '@playcanvas/react/components';
+
+import { XrPointerRay as XrPointerRayScript } from './xr-pointer-ray';
+
+const XrPointerRay = () => (
+  <Entity name='xr-pointer-ray'>
+    <Script script={XrPointerRayScript} />
+  </Entity>
+);
+
+export default XrPointerRay;

--- a/src/components/VirtualWalkthrough/XrPointerRay.tsx
+++ b/src/components/VirtualWalkthrough/XrPointerRay.tsx
@@ -2,12 +2,17 @@ import React from 'react';
 
 import { Entity } from '@playcanvas/react';
 import { Script } from '@playcanvas/react/components';
+import { Color } from 'playcanvas';
 
-import { XrPointerRay as XrPointerRayScript } from './xr-pointer-ray';
+import { DEFAULT_RAY_COLOR, XrPointerRay as XrPointerRayScript } from './xr-pointer-ray';
 
-const XrPointerRay = () => (
+export type XrPointerRayProps = {
+  color?: Color;
+};
+
+const XrPointerRay = ({ color = DEFAULT_RAY_COLOR }: XrPointerRayProps) => (
   <Entity name='xr-pointer-ray'>
-    <Script script={XrPointerRayScript} />
+    <Script script={XrPointerRayScript} color={color} />
   </Entity>
 );
 

--- a/src/components/VirtualWalkthrough/xr-annotation-interaction.test.ts
+++ b/src/components/VirtualWalkthrough/xr-annotation-interaction.test.ts
@@ -1,0 +1,39 @@
+import { Vec3 } from 'playcanvas';
+
+import { nearestAnnotationHit } from './xr-annotation-interaction';
+
+describe('nearestAnnotationHit', () => {
+  const origin = new Vec3(0, 0, 5);
+  const forward = new Vec3(0, 0, -1);
+
+  it('returns null when there are no candidates', () => {
+    expect(nearestAnnotationHit(origin, forward, [])).toBeNull();
+  });
+
+  it('returns null when the ray misses every candidate', () => {
+    const candidates = [{ position: new Vec3(0, 5, 0), radius: 1 }];
+    expect(nearestAnnotationHit(origin, forward, candidates)).toBeNull();
+  });
+
+  it('returns the index of a single hit candidate', () => {
+    const candidates = [{ position: new Vec3(0, 0, 0), radius: 1 }];
+    expect(nearestAnnotationHit(origin, forward, candidates)).toBe(0);
+  });
+
+  it('returns the nearest candidate when several are hit, regardless of order', () => {
+    const far = { position: new Vec3(0, 0, -5), radius: 1 };
+    const near = { position: new Vec3(0, 0, 0), radius: 1 };
+    expect(nearestAnnotationHit(origin, forward, [far, near])).toBe(1);
+  });
+
+  it('treats a ray starting inside a sphere as the nearest hit', () => {
+    const inside = { position: new Vec3(0, 0, 5), radius: 1 };
+    const ahead = { position: new Vec3(0, 0, 0), radius: 1 };
+    expect(nearestAnnotationHit(origin, forward, [ahead, inside])).toBe(1);
+  });
+
+  it('normalizes a non-unit direction', () => {
+    const candidates = [{ position: new Vec3(0, 0, 0), radius: 1 }];
+    expect(nearestAnnotationHit(origin, new Vec3(0, 0, -4), candidates)).toBe(0);
+  });
+});

--- a/src/components/VirtualWalkthrough/xr-annotation-interaction.test.ts
+++ b/src/components/VirtualWalkthrough/xr-annotation-interaction.test.ts
@@ -36,4 +36,14 @@ describe('nearestAnnotationHit', () => {
     const candidates = [{ position: new Vec3(0, 0, 0), radius: 1 }];
     expect(nearestAnnotationHit(origin, new Vec3(0, 0, -4), candidates)).toBe(0);
   });
+
+  it('returns null when the only candidate is behind the ray origin', () => {
+    const candidates = [{ position: new Vec3(0, 0, 0), radius: 1 }];
+    expect(nearestAnnotationHit(origin, new Vec3(0, 0, 1), candidates)).toBeNull();
+  });
+
+  it('registers a tangent graze as a hit', () => {
+    const candidates = [{ position: new Vec3(0, 0, 0), radius: 1 }];
+    expect(nearestAnnotationHit(new Vec3(0, 1, 5), new Vec3(0, 0, -1), candidates)).toBe(0);
+  });
 });

--- a/src/components/VirtualWalkthrough/xr-annotation-interaction.ts
+++ b/src/components/VirtualWalkthrough/xr-annotation-interaction.ts
@@ -1,61 +1,13 @@
 import { Script, Vec3, XRTYPE_VR, XrInputSource } from 'playcanvas';
+import { Annotation as PcAnnotation } from 'playcanvas/scripts/esm/annotations.mjs';
 
-export interface AnnotationHitCandidate {
-  position: Vec3;
-  radius: number;
-}
-
-/**
- * Distance along a (normalized) ray to where it first enters the sphere, or null if it never does.
- * A ray starting inside the sphere returns 0.
- */
-const raySphereEntryDistance = (origin: Vec3, dir: Vec3, center: Vec3, radius: number): number | null => {
-  const m = new Vec3().sub2(origin, center);
-  const b = m.dot(dir);
-  const c = m.dot(m) - radius * radius;
-  if (c > 0 && b > 0) {
-    return null;
-  }
-  const disc = b * b - c;
-  if (disc < 0) {
-    return null;
-  }
-  const t = -b - Math.sqrt(disc);
-
-  return t < 0 ? 0 : t;
-};
-
-/**
- * Index of the closest candidate sphere the ray enters, or null if it hits none.
- */
-export const nearestAnnotationHit = (
-  origin: Vec3,
-  direction: Vec3,
-  candidates: AnnotationHitCandidate[]
-): number | null => {
-  const dir = direction.clone().normalize();
-  let bestIndex: number | null = null;
-  let bestDistance = Infinity;
-
-  candidates.forEach((candidate, index) => {
-    const distance = raySphereEntryDistance(origin, dir, candidate.position, candidate.radius);
-    if (distance !== null && distance < bestDistance) {
-      bestDistance = distance;
-      bestIndex = index;
-    }
-  });
-
-  return bestIndex;
-};
+import { nearestAnnotationHit } from './xr-annotation-targeting';
 
 /** Local half-extent of the unit-plane hotspot quad. */
 const HOTSPOT_HALF_EXTENT = 0.5;
 
 /** Multiplier on the hotspot's world radius to make controller targeting forgiving. */
 const HIT_RADIUS_PAD = 2.5;
-
-/** PlayCanvas annotation script name. */
-const ANNOTATION_SCRIPT_NAME = 'Annotation';
 
 export class XrAnnotationInteraction extends Script {
   static scriptName = 'xrAnnotationInteraction';
@@ -86,7 +38,7 @@ export class XrAnnotationInteraction extends Script {
   private _openAnnotationUnderRay(origin: Vec3, direction: Vec3) {
     const entities = this._collectAnnotationEntities();
     const openable = entities
-      .map((ent: any) => ({ entity: ent, script: ent.script?.get(ANNOTATION_SCRIPT_NAME) }))
+      .map((ent: any) => ({ entity: ent, script: ent.script?.get(PcAnnotation.scriptName) }))
       .filter(({ script: scr }: any) => scr && scr.enabled !== false && typeof scr.onVrOpenCallback === 'function');
 
     const candidates = openable.map(({ entity: ent }: any) => ({

--- a/src/components/VirtualWalkthrough/xr-annotation-interaction.ts
+++ b/src/components/VirtualWalkthrough/xr-annotation-interaction.ts
@@ -1,0 +1,49 @@
+import { Vec3 } from 'playcanvas';
+
+export interface AnnotationHitCandidate {
+  position: Vec3;
+  radius: number;
+}
+
+/**
+ * Distance along a (normalized) ray to where it first enters the sphere, or null if it never does.
+ * A ray starting inside the sphere returns 0.
+ */
+const raySphereEntryDistance = (origin: Vec3, dir: Vec3, center: Vec3, radius: number): number | null => {
+  const m = new Vec3().sub2(origin, center);
+  const b = m.dot(dir);
+  const c = m.dot(m) - radius * radius;
+  if (c > 0 && b > 0) {
+    return null;
+  }
+  const disc = b * b - c;
+  if (disc < 0) {
+    return null;
+  }
+  const t = -b - Math.sqrt(disc);
+
+  return t < 0 ? 0 : t;
+};
+
+/**
+ * Index of the closest candidate sphere the ray enters, or null if it hits none.
+ */
+export const nearestAnnotationHit = (
+  origin: Vec3,
+  direction: Vec3,
+  candidates: AnnotationHitCandidate[]
+): number | null => {
+  const dir = direction.clone().normalize();
+  let bestIndex: number | null = null;
+  let bestDistance = Infinity;
+
+  candidates.forEach((candidate, index) => {
+    const distance = raySphereEntryDistance(origin, dir, candidate.position, candidate.radius);
+    if (distance !== null && distance < bestDistance) {
+      bestDistance = distance;
+      bestIndex = index;
+    }
+  });
+
+  return bestIndex;
+};

--- a/src/components/VirtualWalkthrough/xr-annotation-interaction.ts
+++ b/src/components/VirtualWalkthrough/xr-annotation-interaction.ts
@@ -1,4 +1,4 @@
-import { Vec3 } from 'playcanvas';
+import { Script, Vec3, XRTYPE_VR, XrInputSource } from 'playcanvas';
 
 export interface AnnotationHitCandidate {
   position: Vec3;
@@ -47,3 +47,69 @@ export const nearestAnnotationHit = (
 
   return bestIndex;
 };
+
+/** Local half-extent of the unit-plane hotspot quad. */
+const HOTSPOT_HALF_EXTENT = 0.5;
+
+/** Multiplier on the hotspot's world radius to make controller targeting forgiving. */
+const HIT_RADIUS_PAD = 2.5;
+
+/** PlayCanvas annotation script name. */
+const ANNOTATION_SCRIPT_NAME = 'Annotation';
+
+export class XrAnnotationInteraction extends Script {
+  static scriptName = 'xrAnnotationInteraction';
+
+  private _scratchScale = new Vec3();
+
+  private _isVrActive = () => this.app.xr?.active === true && this.app.xr?.type === XRTYPE_VR;
+
+  private _onSelect = (inputSource: XrInputSource) => {
+    if (!this._isVrActive()) {
+      return;
+    }
+    this._openAnnotationUnderRay(inputSource.getOrigin(), inputSource.getDirection());
+  };
+
+  private _collectAnnotationEntities() {
+    const root = this.app.root.findByName('annotations-root');
+
+    return root ? root.children : [];
+  }
+
+  private _hitRadius(entity: any): number {
+    entity.getWorldTransform().getScale(this._scratchScale);
+
+    return HOTSPOT_HALF_EXTENT * this._scratchScale.x * HIT_RADIUS_PAD;
+  }
+
+  private _openAnnotationUnderRay(origin: Vec3, direction: Vec3) {
+    const entities = this._collectAnnotationEntities();
+    const openable = entities
+      .map((ent: any) => ({ entity: ent, script: ent.script?.get(ANNOTATION_SCRIPT_NAME) }))
+      .filter(({ script: scr }: any) => scr && scr.enabled !== false && typeof scr.onVrOpenCallback === 'function');
+
+    const candidates = openable.map(({ entity: ent }: any) => ({
+      position: ent.getPosition(),
+      radius: this._hitRadius(ent),
+    }));
+
+    const index = nearestAnnotationHit(origin, direction, candidates);
+    if (index === null) {
+      return;
+    }
+
+    const { entity, script } = openable[index];
+    const camera = this.app.root.findByName('camera') as any;
+    const screen = camera?.camera?.worldToScreen(entity.getPosition());
+    script.onVrOpenCallback(screen?.x ?? 0, screen?.y ?? 0);
+  }
+
+  initialize() {
+    this.app.xr?.input?.on('select', this._onSelect);
+  }
+
+  destroy() {
+    this.app.xr?.input?.off('select', this._onSelect);
+  }
+}

--- a/src/components/VirtualWalkthrough/xr-annotation-targeting.test.ts
+++ b/src/components/VirtualWalkthrough/xr-annotation-targeting.test.ts
@@ -1,6 +1,6 @@
 import { Vec3 } from 'playcanvas';
 
-import { nearestAnnotationHit } from './xr-annotation-interaction';
+import { nearestAnnotationHit } from './xr-annotation-targeting';
 
 describe('nearestAnnotationHit', () => {
   const origin = new Vec3(0, 0, 5);

--- a/src/components/VirtualWalkthrough/xr-annotation-targeting.ts
+++ b/src/components/VirtualWalkthrough/xr-annotation-targeting.ts
@@ -1,0 +1,49 @@
+import { Vec3 } from 'playcanvas';
+
+export interface AnnotationHitCandidate {
+  position: Vec3;
+  radius: number;
+}
+
+/**
+ * Distance along a (normalized) ray to where it first enters the sphere, or null if it never does.
+ * A ray starting inside the sphere returns 0.
+ */
+const raySphereEntryDistance = (origin: Vec3, dir: Vec3, center: Vec3, radius: number): number | null => {
+  const m = new Vec3().sub2(origin, center);
+  const b = m.dot(dir);
+  const c = m.dot(m) - radius * radius;
+  if (c > 0 && b > 0) {
+    return null;
+  }
+  const disc = b * b - c;
+  if (disc < 0) {
+    return null;
+  }
+  const t = -b - Math.sqrt(disc);
+
+  return t < 0 ? 0 : t;
+};
+
+/**
+ * Index of the closest candidate sphere the ray enters, or null if it hits none.
+ */
+export const nearestAnnotationHit = (
+  origin: Vec3,
+  direction: Vec3,
+  candidates: AnnotationHitCandidate[]
+): number | null => {
+  const dir = direction.clone().normalize();
+  let bestIndex: number | null = null;
+  let bestDistance = Infinity;
+
+  candidates.forEach((candidate, index) => {
+    const distance = raySphereEntryDistance(origin, dir, candidate.position, candidate.radius);
+    if (distance !== null && distance < bestDistance) {
+      bestDistance = distance;
+      bestIndex = index;
+    }
+  });
+
+  return bestIndex;
+};

--- a/src/components/VirtualWalkthrough/xr-pointer-ray.ts
+++ b/src/components/VirtualWalkthrough/xr-pointer-ray.ts
@@ -1,0 +1,27 @@
+import { Color, Script, Vec3 } from 'playcanvas';
+
+/** Length of the drawn pointer ray, in world meters. */
+const RAY_LENGTH = 5;
+
+/** Ray colour (cyan) — bright enough to read against the scene. */
+const RAY_COLOR = new Color(0.25, 0.8, 1);
+
+export class XrPointerRay extends Script {
+  static scriptName = 'xrPointerRay';
+
+  private _end = new Vec3();
+
+  update() {
+    if (this.app.xr?.active !== true) {
+      return;
+    }
+
+    const sources = this.app.xr?.input?.inputSources ?? [];
+    for (const source of sources) {
+      const origin = source.getOrigin();
+      const direction = source.getDirection();
+      this._end.copy(direction).mulScalar(RAY_LENGTH).add(origin);
+      this.app.drawLine(origin, this._end, RAY_COLOR, false);
+    }
+  }
+}

--- a/src/components/VirtualWalkthrough/xr-pointer-ray.ts
+++ b/src/components/VirtualWalkthrough/xr-pointer-ray.ts
@@ -3,11 +3,13 @@ import { Color, Script, Vec3 } from 'playcanvas';
 /** Length of the drawn pointer ray, in world meters. */
 const RAY_LENGTH = 5;
 
-/** Ray colour (cyan) — bright enough to read against the scene. */
-const RAY_COLOR = new Color(0.25, 0.8, 1);
+/** Default ray colour (cyan) — bright enough to read against the scene. */
+export const DEFAULT_RAY_COLOR = new Color(0.25, 0.8, 1);
 
 export class XrPointerRay extends Script {
   static scriptName = 'xrPointerRay';
+
+  color = DEFAULT_RAY_COLOR.clone();
 
   private _end = new Vec3();
 
@@ -21,7 +23,7 @@ export class XrPointerRay extends Script {
       const origin = source.getOrigin();
       const direction = source.getDirection();
       this._end.copy(direction).mulScalar(RAY_LENGTH).add(origin);
-      this.app.drawLine(origin, this._end, RAY_COLOR, false);
+      this.app.drawLine(origin, this._end, this.color, false);
     }
   }
 }


### PR DESCRIPTION
VR annotations have to be rebuilt from scratch since there is no dom inside VR. 
First up, make annotations clickable.

Also enable controller rays so it's obvious what the user is pointing at.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>