### PR TITLE
SW-8690 Add gaze dwelling for opening annotations in VR

### DIFF
--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -22,6 +22,7 @@ import { TfXrNavigation } from './TfXrNavigation';
 import VrAnnotationPanel from './VrAnnotationPanel';
 import XrAnnotationInteraction from './XrAnnotationInteraction';
 import XrExitButton from './XrExitButton';
+import XrGazeDwell from './XrGazeDwell';
 import XrPointerRay from './XrPointerRay';
 import { WalkthroughCamera } from './walkthrough-camera';
 
@@ -312,6 +313,7 @@ const VirtualWalkthroughViewer = ({
             scaleFactor={scaleFactor}
           />
         )}
+        {isCurrentlyInXr && !viewingAnnotation && <XrGazeDwell />}
         {/* Disable teleport for AR as it can be disorienting */}
         <Script script={TfXrNavigation} enabled={!isEdit} enableTeleport={false} />
         {!isCurrentlyInXr && (

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -313,7 +313,7 @@ const VirtualWalkthroughViewer = ({
             scaleFactor={scaleFactor}
           />
         )}
-        {isCurrentlyInXr && !viewingAnnotation && <XrGazeDwell />}
+        {isCurrentlyInXr && <XrGazeDwell activeIndex={viewingAnnotationIndex} />}
         {/* Disable teleport for AR as it can be disorienting */}
         <Script script={TfXrNavigation} enabled={!isEdit} enableTeleport={false} />
         {!isCurrentlyInXr && (

--- a/src/components/VirtualWalkthrough/XrGazeDwell.tsx
+++ b/src/components/VirtualWalkthrough/XrGazeDwell.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { Entity } from '@playcanvas/react';
+import { Script } from '@playcanvas/react/components';
+
+import { XrGazeDwell as XrGazeDwellScript } from './xr-gaze-dwell';
+
+const XrGazeDwell = () => (
+  <Entity name='xr-gaze-dwell'>
+    <Script script={XrGazeDwellScript} />
+  </Entity>
+);
+
+export default XrGazeDwell;

--- a/src/components/VirtualWalkthrough/XrGazeDwell.tsx
+++ b/src/components/VirtualWalkthrough/XrGazeDwell.tsx
@@ -5,9 +5,13 @@ import { Script } from '@playcanvas/react/components';
 
 import { XrGazeDwell as XrGazeDwellScript } from './xr-gaze-dwell';
 
-const XrGazeDwell = () => (
+interface XrGazeDwellProps {
+  activeIndex: number;
+}
+
+const XrGazeDwell = ({ activeIndex }: XrGazeDwellProps) => (
   <Entity name='xr-gaze-dwell'>
-    <Script script={XrGazeDwellScript} />
+    <Script script={XrGazeDwellScript} activeIndex={activeIndex} />
   </Entity>
 );
 

--- a/src/components/VirtualWalkthrough/xr-annotation-candidates.ts
+++ b/src/components/VirtualWalkthrough/xr-annotation-candidates.ts
@@ -1,0 +1,40 @@
+import { Vec3 } from 'playcanvas';
+import { Annotation as PcAnnotation } from 'playcanvas/scripts/esm/annotations.mjs';
+
+/** Local half-extent of the unit-plane hotspot quad. */
+export const HOTSPOT_HALF_EXTENT = 0.5;
+
+export interface AnnotationCandidate {
+  entity: any;
+  script: any;
+  position: Vec3;
+  radius: number;
+}
+
+const scratchScale = new Vec3();
+
+/**
+ * World-space hit candidates for every openable annotation hotspot: its entity, its stock
+ * annotation script (which carries `onVrOpenCallback`), its world position, and a hit-sphere
+ * radius derived from the hotspot's rendered world size, padded by `radiusPad` for easier aiming.
+ */
+export const collectAnnotationHitCandidates = (app: any, radiusPad: number): AnnotationCandidate[] => {
+  const root = app.root.findByName('annotations-root');
+  if (!root) {
+    return [];
+  }
+
+  return root.children
+    .map((entity: any) => ({ entity, script: entity.script?.get(PcAnnotation.scriptName) }))
+    .filter(({ script }: any) => script && script.enabled !== false && typeof script.onVrOpenCallback === 'function')
+    .map(({ entity, script }: any) => {
+      entity.getWorldTransform().getScale(scratchScale);
+
+      return {
+        entity,
+        script,
+        position: entity.getPosition(),
+        radius: HOTSPOT_HALF_EXTENT * scratchScale.x * radiusPad,
+      };
+    });
+};

--- a/src/components/VirtualWalkthrough/xr-annotation-interaction.ts
+++ b/src/components/VirtualWalkthrough/xr-annotation-interaction.ts
@@ -1,11 +1,8 @@
 import { Script, Vec3, XRTYPE_VR, XrInputSource } from 'playcanvas';
-import { Annotation as PcAnnotation } from 'playcanvas/scripts/esm/annotations.mjs';
 
 import { VrAnnotationPanel } from './vr-annotation-panel';
+import { collectAnnotationHitCandidates } from './xr-annotation-candidates';
 import { nearestAnnotationHit } from './xr-annotation-targeting';
-
-/** Local half-extent of the unit-plane hotspot quad. */
-const HOTSPOT_HALF_EXTENT = 0.5;
 
 /** Multiplier on the hotspot's world radius to make controller targeting forgiving. */
 const HIT_RADIUS_PAD = 2.5;
@@ -15,8 +12,6 @@ export class XrAnnotationInteraction extends Script {
 
   onEmptySelectCallback?: () => void;
 
-  private _scratchScale = new Vec3();
-
   private _isVrActive = () => this.app.xr?.active === true && this.app.xr?.type === XRTYPE_VR;
 
   private _onSelect = (inputSource: XrInputSource) => {
@@ -25,18 +20,6 @@ export class XrAnnotationInteraction extends Script {
     }
     this._openAnnotationUnderRay(inputSource.getOrigin(), inputSource.getDirection());
   };
-
-  private _collectAnnotationEntities() {
-    const root = this.app.root.findByName('annotations-root');
-
-    return root ? root.children : [];
-  }
-
-  private _hitRadius(entity: any): number {
-    entity.getWorldTransform().getScale(this._scratchScale);
-
-    return HOTSPOT_HALF_EXTENT * this._scratchScale.x * HIT_RADIUS_PAD;
-  }
 
   /** True when an open panel is under the ray; it draws in front of everything, so it wins. */
   private _rayHitsOpenPanel(origin: Vec3, direction: Vec3): boolean {
@@ -53,16 +36,7 @@ export class XrAnnotationInteraction extends Script {
       return;
     }
 
-    const entities = this._collectAnnotationEntities();
-    const openable = entities
-      .map((ent: any) => ({ entity: ent, script: ent.script?.get(PcAnnotation.scriptName) }))
-      .filter(({ script: scr }: any) => scr && scr.enabled !== false && typeof scr.onVrOpenCallback === 'function');
-
-    const candidates = openable.map(({ entity: ent }: any) => ({
-      position: ent.getPosition(),
-      radius: this._hitRadius(ent),
-    }));
-
+    const candidates = collectAnnotationHitCandidates(this.app, HIT_RADIUS_PAD);
     const index = nearestAnnotationHit(origin, direction, candidates);
     if (index === null) {
       if (typeof this.onEmptySelectCallback === 'function') {
@@ -72,7 +46,7 @@ export class XrAnnotationInteraction extends Script {
       return;
     }
 
-    const { entity, script } = openable[index];
+    const { entity, script } = candidates[index];
     const camera = this.app.root.findByName('camera') as any;
     const screen = camera?.camera?.worldToScreen(entity.getPosition());
     script.onVrOpenCallback(screen?.x ?? 0, screen?.y ?? 0);

--- a/src/components/VirtualWalkthrough/xr-gaze-dwell-state.test.ts
+++ b/src/components/VirtualWalkthrough/xr-gaze-dwell-state.test.ts
@@ -1,0 +1,40 @@
+import { INITIAL_DWELL_STATE, advanceDwell } from './xr-gaze-dwell-state';
+
+const THRESHOLD = 1.5;
+
+describe('advanceDwell', () => {
+  it('stays reset when there is no gaze target', () => {
+    const r = advanceDwell({ targetIndex: 2, elapsed: 1.0 }, null, 0.1, THRESHOLD);
+    expect(r.state).toEqual(INITIAL_DWELL_STATE);
+    expect(r.progress).toBe(0);
+    expect(r.justOpened).toBe(false);
+  });
+
+  it('resets to zero when the target changes', () => {
+    const r = advanceDwell({ targetIndex: 0, elapsed: 1.0 }, 1, 0.1, THRESHOLD);
+    expect(r.state).toEqual({ targetIndex: 1, elapsed: 0 });
+    expect(r.progress).toBe(0);
+    expect(r.justOpened).toBe(false);
+  });
+
+  it('accumulates dwell time while the same target is held', () => {
+    const r = advanceDwell({ targetIndex: 3, elapsed: 0.5 }, 3, 0.25, THRESHOLD);
+    expect(r.state).toEqual({ targetIndex: 3, elapsed: 0.75 });
+    expect(r.progress).toBeCloseTo(0.5, 5);
+    expect(r.justOpened).toBe(false);
+  });
+
+  it('fires justOpened once when crossing the threshold and clamps elapsed', () => {
+    const r = advanceDwell({ targetIndex: 3, elapsed: 1.4 }, 3, 0.5, THRESHOLD);
+    expect(r.justOpened).toBe(true);
+    expect(r.progress).toBe(1);
+    expect(r.state).toEqual({ targetIndex: 3, elapsed: THRESHOLD });
+  });
+
+  it('does not re-fire while the target stays held past the threshold', () => {
+    const r = advanceDwell({ targetIndex: 3, elapsed: THRESHOLD }, 3, 0.5, THRESHOLD);
+    expect(r.justOpened).toBe(false);
+    expect(r.progress).toBe(1);
+    expect(r.state).toEqual({ targetIndex: 3, elapsed: THRESHOLD });
+  });
+});

--- a/src/components/VirtualWalkthrough/xr-gaze-dwell-state.ts
+++ b/src/components/VirtualWalkthrough/xr-gaze-dwell-state.ts
@@ -1,0 +1,31 @@
+export interface DwellState {
+  targetIndex: number | null;
+  elapsed: number;
+}
+
+export interface DwellUpdate {
+  state: DwellState;
+  progress: number;
+  justOpened: boolean;
+}
+
+export const INITIAL_DWELL_STATE: DwellState = { targetIndex: null, elapsed: 0 };
+
+/**
+ * Advances gaze-dwell timing for one frame. `target` is the annotation index currently under the
+ * gaze ray, or null. Dwell time accumulates while the same target is held and resets when it
+ * changes or is lost. `justOpened` is true only on the frame the dwell first reaches `threshold`.
+ */
+export const advanceDwell = (prev: DwellState, target: number | null, dt: number, threshold: number): DwellUpdate => {
+  if (target === null) {
+    return { state: INITIAL_DWELL_STATE, progress: 0, justOpened: false };
+  }
+  if (target !== prev.targetIndex) {
+    return { state: { targetIndex: target, elapsed: 0 }, progress: 0, justOpened: false };
+  }
+
+  const elapsed = Math.min(prev.elapsed + dt, threshold);
+  const justOpened = prev.elapsed < threshold && elapsed >= threshold;
+
+  return { state: { targetIndex: target, elapsed }, progress: elapsed / threshold, justOpened };
+};

--- a/src/components/VirtualWalkthrough/xr-gaze-dwell.ts
+++ b/src/components/VirtualWalkthrough/xr-gaze-dwell.ts
@@ -43,6 +43,10 @@ const LOCAL_FORWARD = new Vec3(0, 0, -1);
 export class XrGazeDwell extends Script {
   static scriptName = 'xrGazeDwell';
 
+  /** Index of the annotation whose panel is currently open, or -1. Excluded from gaze targets so
+   * dwell opens OTHER annotations while one is open (and never re-dwells the open one). */
+  activeIndex = -1;
+
   private _dwell: DwellState = INITIAL_DWELL_STATE;
 
   private _pieEntity?: Entity;
@@ -165,7 +169,10 @@ export class XrGazeDwell extends Script {
       return;
     }
 
-    const candidates = collectAnnotationHitCandidates(this.app, GAZE_HIT_RADIUS_PAD);
+    const activeName = `annotation-${this.activeIndex}`;
+    const candidates = collectAnnotationHitCandidates(this.app, GAZE_HIT_RADIUS_PAD).filter(
+      (candidate) => candidate.entity.name !== activeName
+    );
     this._headRot.transformVector(LOCAL_FORWARD, this._forward);
     const target = nearestAnnotationHit(this._headPos, this._forward, candidates);
 

--- a/src/components/VirtualWalkthrough/xr-gaze-dwell.ts
+++ b/src/components/VirtualWalkthrough/xr-gaze-dwell.ts
@@ -1,11 +1,27 @@
-import { Color, Quat, Script, Vec3, XRTYPE_VR } from 'playcanvas';
+import {
+  ADDRESS_CLAMP_TO_EDGE,
+  BLEND_NORMAL,
+  CULLFACE_NONE,
+  Color,
+  Entity,
+  FILTER_LINEAR,
+  LAYERID_IMMEDIATE,
+  Mesh,
+  MeshInstance,
+  Quat,
+  Script,
+  StandardMaterial,
+  Texture,
+  Vec3,
+  XRTYPE_VR,
+} from 'playcanvas';
 
 import { collectAnnotationHitCandidates } from './xr-annotation-candidates';
 import { nearestAnnotationHit } from './xr-annotation-targeting';
 import { DwellState, INITIAL_DWELL_STATE, advanceDwell } from './xr-gaze-dwell-state';
 
 /** Multiplier on the hotspot's world radius for gaze targeting. */
-const GAZE_HIT_RADIUS_PAD = 2.5;
+const GAZE_HIT_RADIUS_PAD = 5;
 
 /** Seconds of continuous gaze required to open an annotation. */
 const DWELL_SECONDS = 1.5;
@@ -13,34 +29,114 @@ const DWELL_SECONDS = 1.5;
 /** Local half-extent of the unit-plane hotspot quad. */
 const HOTSPOT_HALF_EXTENT = 0.5;
 
-/** Ring radius as a multiple of the hotspot's rendered half-extent (just outside the hotspot). */
-const RING_RADIUS_SCALE = 1.4;
+/** Progress-pie quad radius as a multiple of the hotspot's rendered half-extent (covers the hotspot). */
+const PIE_RADIUS_SCALE = 1.25;
 
-/** Segments in a full (100%) ring. */
-const RING_SEGMENTS = 48;
+/** Progress-pie texture resolution. */
+const PIE_TEXTURE_SIZE = 128;
 
-const RING_COLOR = new Color(0.25, 0.8, 1);
+/** Sweep starts at 12 o'clock. */
+const PIE_START_ANGLE = -Math.PI / 2;
 
 const LOCAL_FORWARD = new Vec3(0, 0, -1);
-const LOCAL_RIGHT = new Vec3(1, 0, 0);
-const LOCAL_UP = new Vec3(0, 1, 0);
 
 export class XrGazeDwell extends Script {
   static scriptName = 'xrGazeDwell';
 
   private _dwell: DwellState = INITIAL_DWELL_STATE;
 
+  private _pieEntity?: Entity;
+  private _pieCanvas?: HTMLCanvasElement;
+  private _pieTexture?: Texture;
+  private _pieMaterial?: StandardMaterial;
+  private _pieMesh?: Mesh;
+  private _drawnProgress = -1;
+
   private _headPos = new Vec3();
   private _headRot = new Quat();
   private _viewOffset = new Vec3();
   private _forward = new Vec3();
-  private _right = new Vec3();
-  private _up = new Vec3();
   private _scratchScale = new Vec3();
-  private _p0 = new Vec3();
-  private _p1 = new Vec3();
 
   private _isVrActive = () => this.app.xr?.active === true && this.app.xr?.type === XRTYPE_VR;
+
+  initialize() {
+    this._pieCanvas = document.createElement('canvas');
+    this._pieCanvas.width = PIE_TEXTURE_SIZE;
+    this._pieCanvas.height = PIE_TEXTURE_SIZE;
+
+    this._pieTexture = new Texture(this.app.graphicsDevice, {
+      name: 'xr-gaze-dwell-pie',
+      width: PIE_TEXTURE_SIZE,
+      height: PIE_TEXTURE_SIZE,
+      addressU: ADDRESS_CLAMP_TO_EDGE,
+      addressV: ADDRESS_CLAMP_TO_EDGE,
+      minFilter: FILTER_LINEAR,
+      magFilter: FILTER_LINEAR,
+      mipmaps: true,
+    });
+    this._pieTexture.setSource(this._pieCanvas);
+
+    const material = new StandardMaterial();
+    material.useLighting = false;
+    material.emissive = new Color(1, 1, 1);
+    material.emissiveMap = this._pieTexture;
+    material.opacityMap = this._pieTexture;
+    material.opacityMapChannel = 'a';
+    material.blendType = BLEND_NORMAL;
+    material.depthTest = false;
+    material.depthWrite = false;
+    material.cull = CULLFACE_NONE;
+    material.update();
+    this._pieMaterial = material;
+
+    this._pieMesh = this._createQuad();
+    const meshInstance = new MeshInstance(this._pieMesh, material);
+
+    this._pieEntity = new Entity('xr-gaze-dwell-pie');
+    this._pieEntity.addComponent('render', { meshInstances: [meshInstance], layers: [LAYERID_IMMEDIATE] });
+    this._pieEntity.enabled = false;
+    this.entity.addChild(this._pieEntity);
+  }
+
+  private _createQuad(): Mesh {
+    const h = HOTSPOT_HALF_EXTENT;
+    const mesh = new Mesh(this.app.graphicsDevice);
+    mesh.setPositions([-h, -h, 0, h, -h, 0, h, h, 0, -h, h, 0]);
+    mesh.setNormals([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1]);
+    mesh.setUvs(0, [0, 1, 1, 1, 1, 0, 0, 0]);
+    mesh.setIndices([0, 1, 2, 0, 2, 3]);
+    mesh.update();
+
+    return mesh;
+  }
+
+  /** Redraws the pie fill for the given dwell progress (0..1) onto the texture canvas. */
+  private _drawPie(progress: number) {
+    const ctx = this._pieCanvas?.getContext('2d');
+    if (!ctx) {
+      return;
+    }
+    const c = PIE_TEXTURE_SIZE / 2;
+    const r = c * 0.92;
+    ctx.clearRect(0, 0, PIE_TEXTURE_SIZE, PIE_TEXTURE_SIZE);
+
+    // Faint full-circle track so the not-yet-filled portion still reads as a disc.
+    ctx.beginPath();
+    ctx.arc(c, c, r, 0, Math.PI * 2);
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.18)';
+    ctx.fill();
+
+    // Filled progress wedge from the centre, sweeping from 12 o'clock.
+    ctx.beginPath();
+    ctx.moveTo(c, c);
+    ctx.arc(c, c, r, PIE_START_ANGLE, PIE_START_ANGLE + progress * Math.PI * 2);
+    ctx.closePath();
+    ctx.fillStyle = 'rgba(64, 200, 255, 0.85)';
+    ctx.fill();
+
+    this._pieTexture?.upload();
+  }
 
   private _trackHead(): boolean {
     const views = this.app.xr?.views?.list;
@@ -59,8 +155,12 @@ export class XrGazeDwell extends Script {
   }
 
   update(dt: number) {
+    if (!this._pieEntity) {
+      return;
+    }
     if (!this._isVrActive() || !this._trackHead()) {
       this._dwell = INITIAL_DWELL_STATE;
+      this._hidePie();
 
       return;
     }
@@ -73,7 +173,9 @@ export class XrGazeDwell extends Script {
     this._dwell = result.state;
 
     if (target !== null && result.progress > 0 && result.progress < 1) {
-      this._drawRing(candidates[target].entity, result.progress);
+      this._showPie(candidates[target].entity, result.progress);
+    } else {
+      this._hidePie();
     }
 
     if (result.justOpened && target !== null) {
@@ -84,30 +186,45 @@ export class XrGazeDwell extends Script {
     }
   }
 
-  private _drawRing(entity: any, progress: number) {
-    const center = entity.getPosition();
+  private _showPie(entity: any, progress: number) {
+    if (!this._pieEntity) {
+      return;
+    }
+    if (Math.abs(progress - this._drawnProgress) > 0.001) {
+      this._drawnProgress = progress;
+      this._drawPie(progress);
+    }
+
+    // The unit quad has half-extent HOTSPOT_HALF_EXTENT, so scale it to reach the desired world size.
     entity.getWorldTransform().getScale(this._scratchScale);
-    const radius = HOTSPOT_HALF_EXTENT * this._scratchScale.x * RING_RADIUS_SCALE;
+    const scale = this._scratchScale.x * PIE_RADIUS_SCALE;
 
-    this._headRot.transformVector(LOCAL_RIGHT, this._right);
-    this._headRot.transformVector(LOCAL_UP, this._up);
+    this._pieEntity.enabled = true;
+    this._pieEntity.setLocalScale(scale, scale, scale);
+    this._pieEntity.setPosition(entity.getPosition());
+    this._pieEntity.setRotation(this._headRot);
+  }
 
-    const segments = Math.max(1, Math.ceil(progress * RING_SEGMENTS));
-    const step = (Math.PI * 2) / RING_SEGMENTS;
-    for (let i = 0; i < segments; i++) {
-      this._ringPoint(center, radius, i * step, this._p0);
-      this._ringPoint(center, radius, (i + 1) * step, this._p1);
-      this.app.drawLine(this._p0, this._p1, RING_COLOR, false);
+  private _hidePie() {
+    if (this._pieEntity && this._pieEntity.enabled) {
+      this._pieEntity.enabled = false;
+      this._drawnProgress = -1;
     }
   }
 
-  private _ringPoint(center: Vec3, radius: number, angle: number, out: Vec3) {
-    const c = Math.cos(angle) * radius;
-    const s = Math.sin(angle) * radius;
-    out.set(
-      center.x + this._right.x * c + this._up.x * s,
-      center.y + this._right.y * c + this._up.y * s,
-      center.z + this._right.z * c + this._up.z * s
-    );
+  destroy() {
+    if (this._pieEntity) {
+      if (this._pieEntity.render) {
+        this._pieEntity.render.meshInstances = [];
+      }
+      this._pieEntity.destroy();
+      this._pieEntity = undefined;
+    }
+    this._pieMesh?.destroy();
+    this._pieMaterial?.destroy();
+    this._pieTexture?.destroy();
+    this._pieMesh = undefined;
+    this._pieMaterial = undefined;
+    this._pieTexture = undefined;
   }
 }

--- a/src/components/VirtualWalkthrough/xr-gaze-dwell.ts
+++ b/src/components/VirtualWalkthrough/xr-gaze-dwell.ts
@@ -1,0 +1,113 @@
+import { Color, Quat, Script, Vec3, XRTYPE_VR } from 'playcanvas';
+
+import { collectAnnotationHitCandidates } from './xr-annotation-candidates';
+import { nearestAnnotationHit } from './xr-annotation-targeting';
+import { DwellState, INITIAL_DWELL_STATE, advanceDwell } from './xr-gaze-dwell-state';
+
+/** Multiplier on the hotspot's world radius for gaze targeting. */
+const GAZE_HIT_RADIUS_PAD = 2.5;
+
+/** Seconds of continuous gaze required to open an annotation. */
+const DWELL_SECONDS = 1.5;
+
+/** Local half-extent of the unit-plane hotspot quad. */
+const HOTSPOT_HALF_EXTENT = 0.5;
+
+/** Ring radius as a multiple of the hotspot's rendered half-extent (just outside the hotspot). */
+const RING_RADIUS_SCALE = 1.4;
+
+/** Segments in a full (100%) ring. */
+const RING_SEGMENTS = 48;
+
+const RING_COLOR = new Color(0.25, 0.8, 1);
+
+const LOCAL_FORWARD = new Vec3(0, 0, -1);
+const LOCAL_RIGHT = new Vec3(1, 0, 0);
+const LOCAL_UP = new Vec3(0, 1, 0);
+
+export class XrGazeDwell extends Script {
+  static scriptName = 'xrGazeDwell';
+
+  private _dwell: DwellState = INITIAL_DWELL_STATE;
+
+  private _headPos = new Vec3();
+  private _headRot = new Quat();
+  private _viewOffset = new Vec3();
+  private _forward = new Vec3();
+  private _right = new Vec3();
+  private _up = new Vec3();
+  private _scratchScale = new Vec3();
+  private _p0 = new Vec3();
+  private _p1 = new Vec3();
+
+  private _isVrActive = () => this.app.xr?.active === true && this.app.xr?.type === XRTYPE_VR;
+
+  private _trackHead(): boolean {
+    const views = this.app.xr?.views?.list;
+    if (!views || views.length === 0) {
+      return false;
+    }
+    this._headPos.set(0, 0, 0);
+    for (const view of views) {
+      view.viewInvOffMat.getTranslation(this._viewOffset);
+      this._headPos.add(this._viewOffset);
+    }
+    this._headPos.mulScalar(1 / views.length);
+    this._headRot.setFromMat4(views[0].viewInvOffMat);
+
+    return true;
+  }
+
+  update(dt: number) {
+    if (!this._isVrActive() || !this._trackHead()) {
+      this._dwell = INITIAL_DWELL_STATE;
+
+      return;
+    }
+
+    const candidates = collectAnnotationHitCandidates(this.app, GAZE_HIT_RADIUS_PAD);
+    this._headRot.transformVector(LOCAL_FORWARD, this._forward);
+    const target = nearestAnnotationHit(this._headPos, this._forward, candidates);
+
+    const result = advanceDwell(this._dwell, target, dt, DWELL_SECONDS);
+    this._dwell = result.state;
+
+    if (target !== null && result.progress > 0 && result.progress < 1) {
+      this._drawRing(candidates[target].entity, result.progress);
+    }
+
+    if (result.justOpened && target !== null) {
+      const { entity, script } = candidates[target];
+      const camera = this.app.root.findByName('camera') as any;
+      const screen = camera?.camera?.worldToScreen(entity.getPosition());
+      script.onVrOpenCallback(screen?.x ?? 0, screen?.y ?? 0);
+    }
+  }
+
+  private _drawRing(entity: any, progress: number) {
+    const center = entity.getPosition();
+    entity.getWorldTransform().getScale(this._scratchScale);
+    const radius = HOTSPOT_HALF_EXTENT * this._scratchScale.x * RING_RADIUS_SCALE;
+
+    this._headRot.transformVector(LOCAL_RIGHT, this._right);
+    this._headRot.transformVector(LOCAL_UP, this._up);
+
+    const segments = Math.max(1, Math.ceil(progress * RING_SEGMENTS));
+    const step = (Math.PI * 2) / RING_SEGMENTS;
+    for (let i = 0; i < segments; i++) {
+      this._ringPoint(center, radius, i * step, this._p0);
+      this._ringPoint(center, radius, (i + 1) * step, this._p1);
+      this.app.drawLine(this._p0, this._p1, RING_COLOR, false);
+    }
+  }
+
+  private _ringPoint(center: Vec3, radius: number, angle: number, out: Vec3) {
+    const c = Math.cos(angle) * radius;
+    const s = Math.sin(angle) * radius;
+    out.set(
+      center.x + this._right.x * c + this._up.x * s,
+      center.y + this._right.y * c + this._up.y * s,
+      center.z + this._right.z * c + this._up.z * s
+    );
+  }
+}

--- a/src/components/VirtualWalkthrough/xr-gaze-dwell.ts
+++ b/src/components/VirtualWalkthrough/xr-gaze-dwell.ts
@@ -24,7 +24,7 @@ import { DwellState, INITIAL_DWELL_STATE, advanceDwell } from './xr-gaze-dwell-s
 const GAZE_HIT_RADIUS_PAD = 5;
 
 /** Seconds of continuous gaze required to open an annotation. */
-const DWELL_SECONDS = 1.5;
+const DWELL_SECONDS = 1.25;
 
 /** Local half-extent of the unit-plane hotspot quad. */
 const HOTSPOT_HALF_EXTENT = 0.5;


### PR DESCRIPTION
Now that annotations work inside VR, add support for gaze dwelling to open annotations (stare at an annotation to open it).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>