### PR TITLE
SW-8691 Enable teleporting when in VR

### DIFF
--- a/src/components/VirtualWalkthrough/TfXrNavigation.ts
+++ b/src/components/VirtualWalkthrough/TfXrNavigation.ts
@@ -1,6 +1,8 @@
 import { XrInputSource } from 'playcanvas';
 import { XrNavigation as PcXrNavigation } from 'playcanvas/scripts/esm/xr/xr-navigation.mjs';
 
+import { TeleportGestureLatch } from './xr-teleport-gesture';
+
 interface ArcVisual {
   entity: { enabled: boolean };
   ringEntity: { enabled: boolean };
@@ -24,20 +26,18 @@ export class TfXrNavigation extends PcXrNavigation {
   /** Assigned by the React wrapper. True when this source's ray is over interactive UI. */
   isTeleportBlocked?: (inputSource: XrInputSource) => boolean;
 
-  /** Sources whose current press began or passed through a teleport-disabled frame. */
-  private _poisonedGestures = new WeakSet<XrInputSource>();
+  private _gestures = new TeleportGestureLatch();
 
   private _isBlocked(inputSource: XrInputSource): boolean {
     return !this.enableTeleport || this.isTeleportBlocked?.(inputSource) === true;
   }
 
   tryTeleport(inputSource: XrInputSource) {
-    // Layer A is latched per press: React re-enables teleport as soon as the select dismisses the
-    // panel, and that can land before the selectend that gets us here.
-    const poisoned = this._poisonedGestures.has(inputSource);
-    this._poisonedGestures.delete(inputSource);
-
-    if (poisoned || this._isBlocked(inputSource)) {
+    // The latch decides on the frames the press actually aimed through, because super.tryTeleport
+    // commits the arc hit cached back then rather than re-tracing the release-time ray. The live
+    // check stays too: the same release also fires 'select', so a ray that lands on UI at release
+    // is operating that UI and must not move the rig as well.
+    if (this._gestures.consumeBlocked(inputSource) || this._isBlocked(inputSource)) {
       return;
     }
 
@@ -47,30 +47,32 @@ export class TfXrNavigation extends PcXrNavigation {
   update(dt: number) {
     super.update(dt);
 
-    // The base hides the arc only from inside its own teleport handling, which it skips entirely once
-    // teleport is off - so an arc raised before the block (gaze dwell can open a panel while the
-    // trigger is held) would otherwise stay frozen in the world. These writes are idempotent, and the
-    // base re-enables the visuals itself on the first frame a source is unblocked.
     const internals = this as unknown as XrNavigationInternals;
     for (const inputSource of internals._inputSources) {
-      // Record (or clear) the layer-A latch before the arc-hiding work below, and unconditionally -
-      // a source that isn't currently pressed carries no gesture to poison, so any stale entry from
-      // a press that ended while teleport was disabled (skipping tryTeleport entirely) is dropped
-      // here rather than leaking into the source's next press.
-      if (internals._activePointers.get(inputSource)) {
-        if (!this.enableTeleport) {
-          this._poisonedGestures.add(inputSource);
-        }
-      } else {
-        this._poisonedGestures.delete(inputSource);
-      }
+      // Sampled once per source per frame: isTeleportBlocked ray-tests every hotspot.
+      const uiBlocked = this.isTeleportBlocked?.(inputSource) === true;
 
+      // Tracked unconditionally, and before the arc-hiding work below. super.update has just cached
+      // this frame's arc hit, which is what a release would commit, so the latch has to see the same
+      // frame. A source that isn't pressed carries no gesture, so any stale entry from a press that
+      // ended while teleport was disabled (skipping tryTeleport entirely) is dropped here rather
+      // than leaking into the source's next press.
+      this._gestures.track(inputSource, {
+        pressed: internals._activePointers.get(inputSource) === true,
+        teleportDisabled: !this.enableTeleport,
+        uiBlocked,
+      });
+
+      // The base hides the arc only from inside its own teleport handling, which it skips entirely
+      // once teleport is off - so an arc raised before the block (gaze dwell can open a panel while
+      // the trigger is held) would otherwise stay frozen in the world. These writes are idempotent,
+      // and the base re-enables the visuals itself on the first frame a source is unblocked.
       const visual = internals._arcVisuals.get(inputSource);
       if (!visual || (!visual.entity.enabled && !visual.ringEntity.enabled)) {
         continue;
       }
 
-      if (this._isBlocked(inputSource)) {
+      if (!this.enableTeleport || uiBlocked) {
         visual.entity.enabled = false;
         visual.ringEntity.enabled = false;
       }

--- a/src/components/VirtualWalkthrough/TfXrNavigation.ts
+++ b/src/components/VirtualWalkthrough/TfXrNavigation.ts
@@ -1,24 +1,56 @@
+import { XrInputSource } from 'playcanvas';
 import { XrNavigation as PcXrNavigation } from 'playcanvas/scripts/esm/xr/xr-navigation.mjs';
 
+interface ArcVisual {
+  entity: { enabled: boolean };
+  ringEntity: { enabled: boolean };
+}
+
+/** The base script's per-source aim state, which it exposes only as underscore-private fields. */
+interface XrNavigationInternals {
+  _inputSources: Set<XrInputSource>;
+  _arcVisuals: Map<XrInputSource, ArcVisual>;
+}
+
 /**
- * Extended XrNavigation that fixes the bug where tryTeleport doesn't respect
- * the enableTeleport flag setting.
+ * XrNavigation that never teleports on a select meant for something else: it honours the
+ * enableTeleport flag (which the base ignores in tryTeleport) and skips sources whose ray is over
+ * interactive UI.
  */
 export class TfXrNavigation extends PcXrNavigation {
   static scriptName = 'tfXrNavigation';
 
-  /**
-   * Override tryTeleport to respect the enableTeleport flag.
-   * The base implementation is always called from handleSelectEnd,
-   * but we only want to teleport when enableTeleport is true.
-   */
-  tryTeleport(inputSource: any) {
-    // Only proceed with teleportation if enableTeleport is true
-    if (!this.enableTeleport) {
+  /** Assigned by the React wrapper. True when this source's ray is over interactive UI. */
+  isTeleportBlocked?: (inputSource: XrInputSource) => boolean;
+
+  private _isBlocked(inputSource: XrInputSource): boolean {
+    return !this.enableTeleport || this.isTeleportBlocked?.(inputSource) === true;
+  }
+
+  tryTeleport(inputSource: XrInputSource) {
+    if (this._isBlocked(inputSource)) {
       return;
     }
 
-    // Call the parent implementation
     super.tryTeleport(inputSource);
+  }
+
+  update(dt: number) {
+    super.update(dt);
+
+    // The base hides the arc only from inside its own teleport handling, which it skips entirely once
+    // teleport is off - so an arc raised before the block (gaze dwell can open a panel while the
+    // trigger is held) would otherwise stay frozen in the world. These writes are idempotent, and the
+    // base re-enables the visuals itself on the first frame a source is unblocked.
+    const internals = this as unknown as XrNavigationInternals;
+    for (const inputSource of internals._inputSources) {
+      if (this._isBlocked(inputSource)) {
+        const visual = internals._arcVisuals.get(inputSource);
+        if (visual) {
+          visual.entity.enabled = false;
+          visual.ringEntity.enabled = false;
+        }
+      }
+    }
   }
 }

--- a/src/components/VirtualWalkthrough/TfXrNavigation.ts
+++ b/src/components/VirtualWalkthrough/TfXrNavigation.ts
@@ -10,6 +10,7 @@ interface ArcVisual {
 interface XrNavigationInternals {
   _inputSources: Set<XrInputSource>;
   _arcVisuals: Map<XrInputSource, ArcVisual>;
+  _activePointers: Map<XrInputSource, boolean>;
 }
 
 /**
@@ -23,12 +24,20 @@ export class TfXrNavigation extends PcXrNavigation {
   /** Assigned by the React wrapper. True when this source's ray is over interactive UI. */
   isTeleportBlocked?: (inputSource: XrInputSource) => boolean;
 
+  /** Sources whose current press began or passed through a teleport-disabled frame. */
+  private _poisonedGestures = new WeakSet<XrInputSource>();
+
   private _isBlocked(inputSource: XrInputSource): boolean {
     return !this.enableTeleport || this.isTeleportBlocked?.(inputSource) === true;
   }
 
   tryTeleport(inputSource: XrInputSource) {
-    if (this._isBlocked(inputSource)) {
+    // Layer A is latched per press: React re-enables teleport as soon as the select dismisses the
+    // panel, and that can land before the selectend that gets us here.
+    const poisoned = this._poisonedGestures.has(inputSource);
+    this._poisonedGestures.delete(inputSource);
+
+    if (poisoned || this._isBlocked(inputSource)) {
       return;
     }
 
@@ -44,12 +53,26 @@ export class TfXrNavigation extends PcXrNavigation {
     // base re-enables the visuals itself on the first frame a source is unblocked.
     const internals = this as unknown as XrNavigationInternals;
     for (const inputSource of internals._inputSources) {
-      if (this._isBlocked(inputSource)) {
-        const visual = internals._arcVisuals.get(inputSource);
-        if (visual) {
-          visual.entity.enabled = false;
-          visual.ringEntity.enabled = false;
+      // Record (or clear) the layer-A latch before the arc-hiding work below, and unconditionally -
+      // a source that isn't currently pressed carries no gesture to poison, so any stale entry from
+      // a press that ended while teleport was disabled (skipping tryTeleport entirely) is dropped
+      // here rather than leaking into the source's next press.
+      if (internals._activePointers.get(inputSource)) {
+        if (!this.enableTeleport) {
+          this._poisonedGestures.add(inputSource);
         }
+      } else {
+        this._poisonedGestures.delete(inputSource);
+      }
+
+      const visual = internals._arcVisuals.get(inputSource);
+      if (!visual || (!visual.entity.enabled && !visual.ringEntity.enabled)) {
+        continue;
+      }
+
+      if (this._isBlocked(inputSource)) {
+        visual.entity.enabled = false;
+        visual.ringEntity.enabled = false;
       }
     }
   }

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -302,7 +302,7 @@ const VirtualWalkthroughViewer = ({
             transform every frame, so the button drives its own world pose from the XR head pose. */}
         <XrExitButton />
         <Script script={XrControllers} enabled={!isEdit} />
-        <XrAnnotationInteraction onEmptySelect={handleCloseAnnotation} />
+        <XrAnnotationInteraction onDismiss={handleCloseAnnotation} />
         <XrPointerRay />
         {/* VR only: the panel is driven by controller rays, which AR sessions don't have. */}
         {isCurrentlyInVr && viewingAnnotation && (

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -83,7 +83,7 @@ const VirtualWalkthroughViewer = ({
   const [viewingAnnotation, setViewingAnnotation] = useState<AnnotationProps | null>(null);
   const [viewingAnnotationIndex, setViewingAnnotationIndex] = useState(-1);
   const [viewedScreenPos, setViewedScreenPos] = useState<{ x: number; y: number; size?: number } | null>(null);
-  const { isCurrentlyInXr, isCurrentlyInVr } = useXr();
+  const { isCurrentlyInXr, isCurrentlyInVr, isCurrentlyInAr } = useXr();
 
   const sceneBoundsRadius = useMemo(() => {
     if (sceneBounds?.m !== undefined) {
@@ -315,7 +315,7 @@ const VirtualWalkthroughViewer = ({
         )}
         {isCurrentlyInXr && <XrGazeDwell activeIndex={viewingAnnotationIndex} />}
         {/* Disable teleport for AR as it can be disorienting */}
-        <Script script={TfXrNavigation} enabled={!isEdit} enableTeleport={false} />
+        <Script script={TfXrNavigation} enabled={!isEdit} enableTeleport={!isCurrentlyInAr} />
         {!isCurrentlyInXr && (
           <Script
             script={AutoRotator}

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -4,7 +4,7 @@ import { useTheme } from '@mui/material';
 import { Entity } from '@playcanvas/react';
 import { Camera, Script } from '@playcanvas/react/components';
 import { useApp } from '@playcanvas/react/hooks';
-import { Color, Vec3 } from 'playcanvas';
+import { Color, Vec3, XrInputSource } from 'playcanvas';
 import { XrControllers } from 'playcanvas/scripts/esm/xr/xr-controllers.mjs';
 
 import { useCameraPosition } from '../../hooks/useCameraPosition';
@@ -25,6 +25,7 @@ import XrExitButton from './XrExitButton';
 import XrGazeDwell from './XrGazeDwell';
 import XrPointerRay from './XrPointerRay';
 import { WalkthroughCamera } from './walkthrough-camera';
+import { rayHitsInteractiveUi } from './xr-interactive-ui';
 
 const DEFAULT_FOCUS_POINT: [number, number, number] = [0, 0.1, 0];
 const DEFAULT_POSITION: [number, number, number] = [1, 0.1, 0];
@@ -238,6 +239,11 @@ const VirtualWalkthroughViewer = ({
     setViewedScreenPos(null);
   }, []);
 
+  const isTeleportBlocked = useCallback(
+    (inputSource: XrInputSource) => rayHitsInteractiveUi(app, inputSource.getOrigin(), inputSource.getDirection()),
+    [app]
+  );
+
   useEffect(() => {
     if (!isCurrentlyInXr) {
       handleCloseAnnotation();
@@ -314,8 +320,14 @@ const VirtualWalkthroughViewer = ({
           />
         )}
         {isCurrentlyInXr && <XrGazeDwell activeIndex={viewingAnnotationIndex} />}
-        {/* Disable teleport for AR as it can be disorienting */}
-        <Script script={TfXrNavigation} enabled={!isEdit} enableTeleport={!isCurrentlyInAr} />
+        {/* Teleport is off in AR, where it can be disorienting, and while an annotation panel is open,
+            so the trigger can operate the panel and click out to dismiss it. */}
+        <Script
+          script={TfXrNavigation}
+          enabled={!isEdit}
+          enableTeleport={!isCurrentlyInAr && !viewingAnnotation}
+          isTeleportBlocked={isTeleportBlocked}
+        />
         {!isCurrentlyInXr && (
           <Script
             script={AutoRotator}

--- a/src/components/VirtualWalkthrough/XrAnnotationInteraction.tsx
+++ b/src/components/VirtualWalkthrough/XrAnnotationInteraction.tsx
@@ -6,12 +6,12 @@ import { Script } from '@playcanvas/react/components';
 import { XrAnnotationInteraction as XrAnnotationInteractionScript } from './xr-annotation-interaction';
 
 interface XrAnnotationInteractionProps {
-  onEmptySelect?: () => void;
+  onDismiss?: () => void;
 }
 
-const XrAnnotationInteraction = ({ onEmptySelect }: XrAnnotationInteractionProps) => (
+const XrAnnotationInteraction = ({ onDismiss }: XrAnnotationInteractionProps) => (
   <Entity name='xr-annotation-interaction'>
-    <Script script={XrAnnotationInteractionScript} onEmptySelectCallback={onEmptySelect} />
+    <Script script={XrAnnotationInteractionScript} onDismissCallback={onDismiss} />
   </Entity>
 );
 

--- a/src/components/VirtualWalkthrough/xr-annotation-candidates.ts
+++ b/src/components/VirtualWalkthrough/xr-annotation-candidates.ts
@@ -4,6 +4,9 @@ import { Annotation as PcAnnotation } from 'playcanvas/scripts/esm/annotations.m
 /** Local half-extent of the unit-plane hotspot quad. */
 export const HOTSPOT_HALF_EXTENT = 0.5;
 
+/** Multiplier on the hotspot's world radius to make controller targeting forgiving. */
+export const HIT_RADIUS_PAD = 2.5;
+
 export interface AnnotationCandidate {
   entity: any;
   script: any;

--- a/src/components/VirtualWalkthrough/xr-annotation-interaction.ts
+++ b/src/components/VirtualWalkthrough/xr-annotation-interaction.ts
@@ -1,11 +1,8 @@
 import { Script, Vec3, XRTYPE_VR, XrInputSource } from 'playcanvas';
 
-import { VrAnnotationPanel } from './vr-annotation-panel';
-import { collectAnnotationHitCandidates } from './xr-annotation-candidates';
+import { HIT_RADIUS_PAD, collectAnnotationHitCandidates } from './xr-annotation-candidates';
 import { nearestAnnotationHit } from './xr-annotation-targeting';
-
-/** Multiplier on the hotspot's world radius to make controller targeting forgiving. */
-const HIT_RADIUS_PAD = 2.5;
+import { rayHitsAnnotationPanel } from './xr-interactive-ui';
 
 export class XrAnnotationInteraction extends Script {
   static scriptName = 'xrAnnotationInteraction';
@@ -21,18 +18,10 @@ export class XrAnnotationInteraction extends Script {
     this._openAnnotationUnderRay(inputSource.getOrigin(), inputSource.getDirection());
   };
 
-  /** True when an open panel is under the ray; it draws in front of everything, so it wins. */
-  private _rayHitsOpenPanel(origin: Vec3, direction: Vec3): boolean {
-    const panel = this.app.root.findByName('vr-annotation-panel') as any;
-    const panelScript = panel?.script?.get(VrAnnotationPanel.scriptName);
-
-    return typeof panelScript?.rayHitsPanel === 'function' && panelScript.rayHitsPanel(origin, direction);
-  }
-
   private _openAnnotationUnderRay(origin: Vec3, direction: Vec3) {
     // Checked before the hotspots so aiming at the panel (e.g. its carousel arrows) neither
     // dismisses it nor opens an annotation whose padded hit sphere sits behind it.
-    if (this._rayHitsOpenPanel(origin, direction)) {
+    if (rayHitsAnnotationPanel(this.app, origin, direction)) {
       return;
     }
 

--- a/src/components/VirtualWalkthrough/xr-annotation-interaction.ts
+++ b/src/components/VirtualWalkthrough/xr-annotation-interaction.ts
@@ -2,14 +2,23 @@ import { Script, Vec3, XRTYPE_VR, XrInputSource } from 'playcanvas';
 
 import { HIT_RADIUS_PAD, collectAnnotationHitCandidates } from './xr-annotation-candidates';
 import { nearestAnnotationHit } from './xr-annotation-targeting';
+import { FaceButtonPressTracker } from './xr-face-buttons';
 import { rayHitsAnnotationPanel } from './xr-interactive-ui';
 
 export class XrAnnotationInteraction extends Script {
   static scriptName = 'xrAnnotationInteraction';
 
-  onEmptySelectCallback?: () => void;
+  onDismissCallback?: () => void;
+
+  private _faceButtons = new FaceButtonPressTracker();
 
   private _isVrActive = () => this.app.xr?.active === true && this.app.xr?.type === XRTYPE_VR;
+
+  private _dismiss = () => {
+    if (typeof this.onDismissCallback === 'function') {
+      this.onDismissCallback();
+    }
+  };
 
   private _onSelect = (inputSource: XrInputSource) => {
     if (!this._isVrActive()) {
@@ -28,9 +37,7 @@ export class XrAnnotationInteraction extends Script {
     const candidates = collectAnnotationHitCandidates(this.app, HIT_RADIUS_PAD);
     const index = nearestAnnotationHit(origin, direction, candidates);
     if (index === null) {
-      if (typeof this.onEmptySelectCallback === 'function') {
-        this.onEmptySelectCallback();
-      }
+      this._dismiss();
 
       return;
     }
@@ -44,5 +51,21 @@ export class XrAnnotationInteraction extends Script {
   initialize() {
     this.app.xr?.input?.on('select', this._onSelect);
     this.once('destroy', () => this.app.xr?.input?.off('select', this._onSelect));
+  }
+
+  update() {
+    if (!this._isVrActive()) {
+      return;
+    }
+
+    // A face button dismisses from any aim direction, unlike the click-out select. Harmless when
+    // nothing is open: the React close handler re-sets state it already holds.
+    for (const inputSource of this.app.xr?.input?.inputSources ?? []) {
+      if (this._faceButtons.justPressed(inputSource)) {
+        this._dismiss();
+
+        return;
+      }
+    }
   }
 }

--- a/src/components/VirtualWalkthrough/xr-exit-button.ts
+++ b/src/components/VirtualWalkthrough/xr-exit-button.ts
@@ -83,8 +83,12 @@ export class XrExitButton extends Script {
     }
   };
 
-  /** True when the ray points at the button's hit sphere. */
+  /** True when the ray points at the button's hit sphere. False while the button entity is disabled. */
   rayHitsButton(origin: Vec3, direction: Vec3): boolean {
+    if (!this.entity.enabled) {
+      return false;
+    }
+
     return raySphereIntersect(origin, direction, this.entity.getPosition(), this.hitRadius);
   }
 

--- a/src/components/VirtualWalkthrough/xr-exit-button.ts
+++ b/src/components/VirtualWalkthrough/xr-exit-button.ts
@@ -16,6 +16,8 @@ import {
   XrInputSource,
 } from 'playcanvas';
 
+import { FaceButtonPressTracker } from './xr-face-buttons';
+
 /**
  * Boolean ray-sphere hit test. Treats the ray as a half-line (t >= 0) and returns true when it
  * intersects the sphere or starts inside it. `direction` is normalized internally.
@@ -33,9 +35,6 @@ export const raySphereIntersect = (origin: Vec3, direction: Vec3, center: Vec3, 
 };
 
 const TEXTURE_SIZE = 256;
-
-/** xr-standard gamepad button indices for the face buttons: A/X (4) and B/Y (5). */
-const FACE_BUTTON_INDICES = [4, 5];
 
 export class XrExitButton extends Script {
   static scriptName = 'xrExitButton';
@@ -57,7 +56,7 @@ export class XrExitButton extends Script {
   private _headPosition = new Vec3();
   private _headRotation = new Quat();
   private _worldOffset = new Vec3();
-  private _faceButtonDown = new WeakMap<XrInputSource, boolean>();
+  private _faceButtons = new FaceButtonPressTracker();
 
   private _isVrActive = () => this.app.xr?.active === true && this.app.xr?.type === XRTYPE_VR;
 
@@ -91,12 +90,6 @@ export class XrExitButton extends Script {
       this.entity.getPosition(),
       this.hitRadius
     );
-  }
-
-  private _faceButtonPressed(inputSource: XrInputSource): boolean {
-    const buttons = inputSource.gamepad?.buttons;
-
-    return buttons ? FACE_BUTTON_INDICES.some((index) => buttons[index]?.pressed === true) : false;
   }
 
   private _createTexture(): Texture {
@@ -196,11 +189,9 @@ export class XrExitButton extends Script {
 
       // A face-button press exits only while that controller is aimed at the button, matching the
       // trigger. Edge-detected so holding a button and then aiming onto it doesn't fire.
-      const facePressed = this._faceButtonPressed(source);
-      const faceWasDown = this._faceButtonDown.get(source) ?? false;
-      this._faceButtonDown.set(source, facePressed);
+      const facePressed = this._faceButtons.justPressed(source);
 
-      if (sourceHovers && facePressed && !faceWasDown) {
+      if (sourceHovers && facePressed) {
         this.app.xr?.end();
 
         return;

--- a/src/components/VirtualWalkthrough/xr-exit-button.ts
+++ b/src/components/VirtualWalkthrough/xr-exit-button.ts
@@ -78,18 +78,14 @@ export class XrExitButton extends Script {
     if (!this.entity.enabled) {
       return;
     }
-    if (this._rayHitsButton(inputSource)) {
+    if (this.rayHitsButton(inputSource.getOrigin(), inputSource.getDirection())) {
       this.app.xr?.end();
     }
   };
 
-  private _rayHitsButton(inputSource: XrInputSource): boolean {
-    return raySphereIntersect(
-      inputSource.getOrigin(),
-      inputSource.getDirection(),
-      this.entity.getPosition(),
-      this.hitRadius
-    );
+  /** True when the ray points at the button's hit sphere. */
+  rayHitsButton(origin: Vec3, direction: Vec3): boolean {
+    return raySphereIntersect(origin, direction, this.entity.getPosition(), this.hitRadius);
   }
 
   private _createTexture(): Texture {
@@ -184,7 +180,7 @@ export class XrExitButton extends Script {
     const sources = this.app.xr?.input?.inputSources ?? [];
     let hovered = false;
     for (const source of sources) {
-      const sourceHovers = this._rayHitsButton(source);
+      const sourceHovers = this.rayHitsButton(source.getOrigin(), source.getDirection());
       hovered = hovered || sourceHovers;
 
       // A face-button press exits only while that controller is aimed at the button, matching the

--- a/src/components/VirtualWalkthrough/xr-face-buttons.test.ts
+++ b/src/components/VirtualWalkthrough/xr-face-buttons.test.ts
@@ -1,0 +1,73 @@
+import { XrInputSource } from 'playcanvas';
+
+import { FaceButtonPressTracker, faceButtonPressed } from './xr-face-buttons';
+
+/** Fake input source whose gamepad reports `pressedIndices` as held. */
+const source = (pressedIndices: number[], buttonCount = 6): XrInputSource =>
+  ({
+    gamepad: {
+      buttons: Array.from({ length: buttonCount }, (_, index) => ({ pressed: pressedIndices.includes(index) })),
+    },
+  }) as unknown as XrInputSource;
+
+const handTrackedSource = (): XrInputSource => ({}) as unknown as XrInputSource;
+
+describe('faceButtonPressed', () => {
+  it('is false for an input source with no gamepad', () => {
+    expect(faceButtonPressed(handTrackedSource())).toBe(false);
+  });
+
+  it('is false when the gamepad has fewer buttons than the face buttons', () => {
+    expect(faceButtonPressed(source([0], 2))).toBe(false);
+  });
+
+  it('is true when A/X is pressed', () => {
+    expect(faceButtonPressed(source([4]))).toBe(true);
+  });
+
+  it('is true when B/Y is pressed', () => {
+    expect(faceButtonPressed(source([5]))).toBe(true);
+  });
+
+  it('is false when only the trigger and grip are pressed', () => {
+    expect(faceButtonPressed(source([0, 1]))).toBe(false);
+  });
+
+  it('is false when nothing is pressed', () => {
+    expect(faceButtonPressed(source([]))).toBe(false);
+  });
+});
+
+describe('FaceButtonPressTracker', () => {
+  it('fires once for a held press and re-arms after release', () => {
+    const tracker = new FaceButtonPressTracker();
+    // One persistent source whose button state mutates, as a real XrInputSource does across frames.
+    const buttons = Array.from({ length: 6 }, () => ({ pressed: false }));
+    const controller = { gamepad: { buttons } } as unknown as XrInputSource;
+    const holdFaceButton = (pressed: boolean) => {
+      buttons[4].pressed = pressed;
+    };
+
+    expect(tracker.justPressed(controller)).toBe(false);
+
+    holdFaceButton(true);
+    expect(tracker.justPressed(controller)).toBe(true);
+    expect(tracker.justPressed(controller)).toBe(false);
+
+    holdFaceButton(false);
+    expect(tracker.justPressed(controller)).toBe(false);
+
+    holdFaceButton(true);
+    expect(tracker.justPressed(controller)).toBe(true);
+  });
+
+  it('tracks each input source independently', () => {
+    const tracker = new FaceButtonPressTracker();
+    const left = source([4]);
+    const right = source([]);
+
+    expect(tracker.justPressed(left)).toBe(true);
+    expect(tracker.justPressed(right)).toBe(false);
+    expect(tracker.justPressed(left)).toBe(false);
+  });
+});

--- a/src/components/VirtualWalkthrough/xr-face-buttons.ts
+++ b/src/components/VirtualWalkthrough/xr-face-buttons.ts
@@ -1,0 +1,28 @@
+import { XrInputSource } from 'playcanvas';
+
+/** xr-standard gamepad button indices for the face buttons: A/X (4) and B/Y (5). */
+export const FACE_BUTTON_INDICES = [4, 5];
+
+/** True while either face button is held. False for hand-tracked sources, which have no gamepad. */
+export const faceButtonPressed = (inputSource: XrInputSource): boolean => {
+  const buttons = inputSource.gamepad?.buttons;
+
+  return buttons ? FACE_BUTTON_INDICES.some((index) => buttons[index]?.pressed === true) : false;
+};
+
+/**
+ * Edge-detects face-button presses per input source so one press fires once. Callers must poll every
+ * frame for every source they care about; a press and release between polls is missed.
+ */
+export class FaceButtonPressTracker {
+  private _down = new WeakMap<XrInputSource, boolean>();
+
+  /** True only on the poll where a face button goes from released to pressed. */
+  justPressed(inputSource: XrInputSource): boolean {
+    const pressed = faceButtonPressed(inputSource);
+    const wasPressed = this._down.get(inputSource) ?? false;
+    this._down.set(inputSource, pressed);
+
+    return pressed && !wasPressed;
+  }
+}

--- a/src/components/VirtualWalkthrough/xr-face-buttons.ts
+++ b/src/components/VirtualWalkthrough/xr-face-buttons.ts
@@ -1,7 +1,7 @@
 import { XrInputSource } from 'playcanvas';
 
 /** xr-standard gamepad button indices for the face buttons: A/X (4) and B/Y (5). */
-export const FACE_BUTTON_INDICES = [4, 5];
+const FACE_BUTTON_INDICES = [4, 5];
 
 /** True while either face button is held. False for hand-tracked sources, which have no gamepad. */
 export const faceButtonPressed = (inputSource: XrInputSource): boolean => {

--- a/src/components/VirtualWalkthrough/xr-gaze-dwell.ts
+++ b/src/components/VirtualWalkthrough/xr-gaze-dwell.ts
@@ -16,7 +16,7 @@ import {
   XRTYPE_VR,
 } from 'playcanvas';
 
-import { collectAnnotationHitCandidates } from './xr-annotation-candidates';
+import { HOTSPOT_HALF_EXTENT, collectAnnotationHitCandidates } from './xr-annotation-candidates';
 import { nearestAnnotationHit } from './xr-annotation-targeting';
 import { DwellState, INITIAL_DWELL_STATE, advanceDwell } from './xr-gaze-dwell-state';
 
@@ -25,9 +25,6 @@ const GAZE_HIT_RADIUS_PAD = 5;
 
 /** Seconds of continuous gaze required to open an annotation. */
 const DWELL_SECONDS = 1.25;
-
-/** Local half-extent of the unit-plane hotspot quad. */
-const HOTSPOT_HALF_EXTENT = 0.5;
 
 /** Progress-pie quad radius as a multiple of the hotspot's rendered half-extent (covers the hotspot). */
 const PIE_RADIUS_SCALE = 1.25;

--- a/src/components/VirtualWalkthrough/xr-interactive-ui.test.ts
+++ b/src/components/VirtualWalkthrough/xr-interactive-ui.test.ts
@@ -1,0 +1,121 @@
+import { Vec3 } from 'playcanvas';
+
+import {
+  rayHitsAnnotationHotspot,
+  rayHitsAnnotationPanel,
+  rayHitsExitButton,
+  rayHitsInteractiveUi,
+} from './xr-interactive-ui';
+
+// Jest cannot parse the PlayCanvas ESM scripts that xr-annotation-candidates imports.
+jest.mock('playcanvas/scripts/esm/annotations.mjs', () => ({ Annotation: { scriptName: 'annotation' } }));
+
+const ORIGIN = new Vec3(0, 0, 5);
+const FORWARD = new Vec3(0, 0, -1);
+
+/** Fake annotation hotspot entity: unit quad at `position`, scale 1, with the stock open callback. */
+const hotspot = (position: Vec3) => ({
+  getPosition: () => position,
+  getWorldTransform: () => ({ getScale: (out: Vec3) => out.set(1, 1, 1) }),
+  script: { get: () => ({ onVrOpenCallback: () => undefined }) },
+});
+
+interface FakeSceneOptions {
+  hotspots?: ReturnType<typeof hotspot>[];
+  panelHit?: boolean;
+  panelHasScript?: boolean;
+  exitHit?: boolean;
+}
+
+/**
+ * Fake app whose `findByName` serves only the entities the helpers look up. The script stubs ignore the
+ * requested script name, so these tests cover the ray plumbing, not the script-name wiring.
+ */
+const fakeApp = ({ hotspots, panelHit, panelHasScript = true, exitHit }: FakeSceneOptions) => ({
+  root: {
+    findByName: (name: string) => {
+      if (name === 'annotations-root') {
+        return hotspots ? { children: hotspots } : null;
+      }
+      if (name === 'vr-annotation-panel') {
+        if (panelHit === undefined) {
+          return null;
+        }
+
+        return { script: { get: () => (panelHasScript ? { rayHitsPanel: () => panelHit } : {}) } };
+      }
+      if (name === 'xr-exit-button') {
+        return exitHit === undefined ? null : { script: { get: () => ({ rayHitsButton: () => exitHit }) } };
+      }
+
+      return null;
+    },
+  },
+});
+
+describe('rayHitsAnnotationHotspot', () => {
+  it('is true when the ray enters a hotspot sphere', () => {
+    const app = fakeApp({ hotspots: [hotspot(new Vec3(0, 0, 0))] });
+    expect(rayHitsAnnotationHotspot(app, ORIGIN, FORWARD)).toBe(true);
+  });
+
+  it('is false when the ray misses every hotspot', () => {
+    const app = fakeApp({ hotspots: [hotspot(new Vec3(0, 8, 0))] });
+    expect(rayHitsAnnotationHotspot(app, ORIGIN, FORWARD)).toBe(false);
+  });
+
+  it('is false when there is no annotations root', () => {
+    expect(rayHitsAnnotationHotspot(fakeApp({}), ORIGIN, FORWARD)).toBe(false);
+  });
+});
+
+describe('rayHitsAnnotationPanel', () => {
+  it('delegates to the panel script', () => {
+    expect(rayHitsAnnotationPanel(fakeApp({ panelHit: true }), ORIGIN, FORWARD)).toBe(true);
+    expect(rayHitsAnnotationPanel(fakeApp({ panelHit: false }), ORIGIN, FORWARD)).toBe(false);
+  });
+
+  it('is false when no panel is mounted', () => {
+    expect(rayHitsAnnotationPanel(fakeApp({}), ORIGIN, FORWARD)).toBe(false);
+  });
+
+  it('is false when the panel entity has no hit-test method', () => {
+    const app = fakeApp({ panelHit: true, panelHasScript: false });
+    expect(rayHitsAnnotationPanel(app, ORIGIN, FORWARD)).toBe(false);
+  });
+});
+
+describe('rayHitsExitButton', () => {
+  it('delegates to the exit button script', () => {
+    expect(rayHitsExitButton(fakeApp({ exitHit: true }), ORIGIN, FORWARD)).toBe(true);
+    expect(rayHitsExitButton(fakeApp({ exitHit: false }), ORIGIN, FORWARD)).toBe(false);
+  });
+
+  it('is false when no exit button is mounted', () => {
+    expect(rayHitsExitButton(fakeApp({}), ORIGIN, FORWARD)).toBe(false);
+  });
+});
+
+describe('rayHitsInteractiveUi', () => {
+  it('is false when the ray hits nothing interactive', () => {
+    const app = fakeApp({ hotspots: [hotspot(new Vec3(0, 8, 0))], panelHit: false, exitHit: false });
+    expect(rayHitsInteractiveUi(app, ORIGIN, FORWARD)).toBe(false);
+  });
+
+  it('is true for a hotspot hit', () => {
+    const app = fakeApp({ hotspots: [hotspot(new Vec3(0, 0, 0))], panelHit: false, exitHit: false });
+    expect(rayHitsInteractiveUi(app, ORIGIN, FORWARD)).toBe(true);
+  });
+
+  it('is true for a panel hit', () => {
+    expect(rayHitsInteractiveUi(fakeApp({ panelHit: true }), ORIGIN, FORWARD)).toBe(true);
+  });
+
+  it('is true for an exit button hit', () => {
+    expect(rayHitsInteractiveUi(fakeApp({ exitHit: true }), ORIGIN, FORWARD)).toBe(true);
+  });
+
+  it('is false in an empty scene', () => {
+    expect(rayHitsInteractiveUi(fakeApp({}), ORIGIN, FORWARD)).toBe(false);
+  });
+});

--- a/src/components/VirtualWalkthrough/xr-interactive-ui.test.ts
+++ b/src/components/VirtualWalkthrough/xr-interactive-ui.test.ts
@@ -1,5 +1,7 @@
 import { Vec3 } from 'playcanvas';
 
+import { VrAnnotationPanel } from './vr-annotation-panel';
+import { XrExitButton } from './xr-exit-button';
 import {
   rayHitsAnnotationHotspot,
   rayHitsAnnotationPanel,
@@ -28,8 +30,9 @@ interface FakeSceneOptions {
 }
 
 /**
- * Fake app whose `findByName` serves only the entities the helpers look up. The script stubs ignore the
- * requested script name, so these tests cover the ray plumbing, not the script-name wiring.
+ * Fake app whose `findByName` serves only the entities the helpers look up. Each script stub returns
+ * its fake only for the matching `scriptName`, so a lookup by the wrong name misses - the way a real
+ * `Script#get` would - instead of silently succeeding.
  */
 const fakeApp = ({ hotspots, panelHit, panelHasScript = true, exitHit }: FakeSceneOptions) => ({
   root: {
@@ -42,10 +45,26 @@ const fakeApp = ({ hotspots, panelHit, panelHasScript = true, exitHit }: FakeSce
           return null;
         }
 
-        return { script: { get: () => (panelHasScript ? { rayHitsPanel: () => panelHit } : {}) } };
+        return {
+          script: {
+            get: (scriptName: string) =>
+              scriptName === VrAnnotationPanel.scriptName
+                ? panelHasScript
+                  ? { rayHitsPanel: () => panelHit }
+                  : {}
+                : undefined,
+          },
+        };
       }
       if (name === 'xr-exit-button') {
-        return exitHit === undefined ? null : { script: { get: () => ({ rayHitsButton: () => exitHit }) } };
+        return exitHit === undefined
+          ? null
+          : {
+            script: {
+              get: (scriptName: string) =>
+                scriptName === XrExitButton.scriptName ? { rayHitsButton: () => exitHit } : undefined,
+            },
+          };
       }
 
       return null;
@@ -66,6 +85,18 @@ describe('rayHitsAnnotationHotspot', () => {
 
   it('is false when there is no annotations root', () => {
     expect(rayHitsAnnotationHotspot(fakeApp({}), ORIGIN, FORWARD)).toBe(false);
+  });
+
+  // Pins the derived radius (HOTSPOT_HALF_EXTENT 0.5 * scale 1 * HIT_RADIUS_PAD 2.5 = 1.25) against
+  // drift: a hotspot at (0,0,0) or (0,8,0) would pass the two tests above for nearly any radius.
+  it('is true just inside the derived hit radius', () => {
+    const app = fakeApp({ hotspots: [hotspot(new Vec3(0, 1.2, 0))] });
+    expect(rayHitsAnnotationHotspot(app, ORIGIN, FORWARD)).toBe(true);
+  });
+
+  it('is false just outside the derived hit radius', () => {
+    const app = fakeApp({ hotspots: [hotspot(new Vec3(0, 1.3, 0))] });
+    expect(rayHitsAnnotationHotspot(app, ORIGIN, FORWARD)).toBe(false);
   });
 });
 

--- a/src/components/VirtualWalkthrough/xr-interactive-ui.ts
+++ b/src/components/VirtualWalkthrough/xr-interactive-ui.ts
@@ -1,0 +1,33 @@
+import { Vec3 } from 'playcanvas';
+
+import { VrAnnotationPanel } from './vr-annotation-panel';
+import { HIT_RADIUS_PAD, collectAnnotationHitCandidates } from './xr-annotation-candidates';
+import { nearestAnnotationHit } from './xr-annotation-targeting';
+import { XrExitButton } from './xr-exit-button';
+
+/** True when the ray points at an openable annotation hotspot. */
+export const rayHitsAnnotationHotspot = (app: any, origin: Vec3, direction: Vec3): boolean =>
+  nearestAnnotationHit(origin, direction, collectAnnotationHitCandidates(app, HIT_RADIUS_PAD)) !== null;
+
+/** True when the ray points at the open VR annotation panel. False when no panel is mounted. */
+export const rayHitsAnnotationPanel = (app: any, origin: Vec3, direction: Vec3): boolean => {
+  const script = app.root.findByName('vr-annotation-panel')?.script?.get(VrAnnotationPanel.scriptName);
+
+  return typeof script?.rayHitsPanel === 'function' && script.rayHitsPanel(origin, direction) === true;
+};
+
+/** True when the ray points at the VR exit button. */
+export const rayHitsExitButton = (app: any, origin: Vec3, direction: Vec3): boolean => {
+  const script = app.root.findByName('xr-exit-button')?.script?.get(XrExitButton.scriptName);
+
+  return typeof script?.rayHitsButton === 'function' && script.rayHitsButton(origin, direction) === true;
+};
+
+/**
+ * True when the ray points at anything the trigger is meant to operate. Teleport consults this so a
+ * select that lands on UI doesn't also move the rig.
+ */
+export const rayHitsInteractiveUi = (app: any, origin: Vec3, direction: Vec3): boolean =>
+  rayHitsAnnotationHotspot(app, origin, direction) ||
+  rayHitsAnnotationPanel(app, origin, direction) ||
+  rayHitsExitButton(app, origin, direction);

--- a/src/components/VirtualWalkthrough/xr-teleport-gesture.test.ts
+++ b/src/components/VirtualWalkthrough/xr-teleport-gesture.test.ts
@@ -1,0 +1,85 @@
+import { XrInputSource } from 'playcanvas';
+
+import { TeleportGestureLatch } from './xr-teleport-gesture';
+
+const source = (): XrInputSource => ({}) as unknown as XrInputSource;
+
+/** An ordinary aiming frame: pressed, teleport on, ray clear of interactive UI. */
+const AIMING = { pressed: true, teleportDisabled: false, uiBlocked: false };
+
+describe('TeleportGestureLatch', () => {
+  it('allows a press that never aimed at UI', () => {
+    const latch = new TeleportGestureLatch();
+    const src = source();
+
+    latch.track(src, AIMING);
+    latch.track(src, AIMING);
+
+    expect(latch.consumeBlocked(src)).toBe(false);
+  });
+
+  it('blocks a press whose last aiming frame was over UI, even after the ray leaves on release', () => {
+    const latch = new TeleportGestureLatch();
+    const src = source();
+
+    latch.track(src, { ...AIMING, uiBlocked: true });
+
+    // The release-time ray no longer hits the UI, but the cached arc hit is from the frame above.
+    expect(latch.consumeBlocked(src)).toBe(true);
+  });
+
+  it('allows a press that swept across UI but came to rest on open floor', () => {
+    const latch = new TeleportGestureLatch();
+    const src = source();
+
+    latch.track(src, AIMING);
+    latch.track(src, { ...AIMING, uiBlocked: true });
+    latch.track(src, AIMING);
+
+    expect(latch.consumeBlocked(src)).toBe(false);
+  });
+
+  it('latches a teleport-disabled frame for the rest of the press', () => {
+    const latch = new TeleportGestureLatch();
+    const src = source();
+
+    latch.track(src, { ...AIMING, teleportDisabled: true });
+    latch.track(src, AIMING);
+
+    expect(latch.consumeBlocked(src)).toBe(true);
+  });
+
+  it('clears the latches once consumed, so the next press starts clean', () => {
+    const latch = new TeleportGestureLatch();
+    const src = source();
+
+    latch.track(src, { pressed: true, teleportDisabled: true, uiBlocked: true });
+    expect(latch.consumeBlocked(src)).toBe(true);
+
+    latch.track(src, AIMING);
+    expect(latch.consumeBlocked(src)).toBe(false);
+  });
+
+  it('drops latches from a press that ended without being consumed', () => {
+    const latch = new TeleportGestureLatch();
+    const src = source();
+
+    latch.track(src, { pressed: true, teleportDisabled: true, uiBlocked: true });
+    latch.track(src, { pressed: false, teleportDisabled: true, uiBlocked: true });
+    latch.track(src, AIMING);
+
+    expect(latch.consumeBlocked(src)).toBe(false);
+  });
+
+  it('tracks each input source independently', () => {
+    const latch = new TeleportGestureLatch();
+    const left = source();
+    const right = source();
+
+    latch.track(left, { ...AIMING, uiBlocked: true });
+    latch.track(right, AIMING);
+
+    expect(latch.consumeBlocked(right)).toBe(false);
+    expect(latch.consumeBlocked(left)).toBe(true);
+  });
+});

--- a/src/components/VirtualWalkthrough/xr-teleport-gesture.ts
+++ b/src/components/VirtualWalkthrough/xr-teleport-gesture.ts
@@ -1,0 +1,56 @@
+import { XrInputSource } from 'playcanvas';
+
+/** Per-frame aim state for one input source, sampled while its select gesture is in progress. */
+export interface TeleportGestureFrame {
+  pressed: boolean;
+  teleportDisabled: boolean;
+  uiBlocked: boolean;
+}
+
+/**
+ * Decides whether the select gesture that just ended is allowed to teleport. The two reasons to
+ * refuse have deliberately different lifetimes:
+ *
+ * - `teleportDisabled` latches for the rest of the press. The React flag behind it re-enables as
+ *   soon as the select dismisses the panel, which can land before the selectend that ends the press.
+ * - `uiBlocked` keeps only the newest frame, because that frame is the one whose arc hit the base
+ *   script has cached and would commit on release. Re-deciding from the release-time ray instead
+ *   would let a flick off the UI commit a target that was aimed while over it, and latching the
+ *   whole press would refuse an aim that merely swept across UI before coming to rest on floor.
+ *
+ * Callers must poll every frame for every source they care about; a press and release between polls
+ * is missed.
+ */
+export class TeleportGestureLatch {
+  private _teleportDisabled = new WeakSet<XrInputSource>();
+  private _uiBlocked = new WeakSet<XrInputSource>();
+
+  /** Records a frame of an in-progress press. A source that isn't pressed drops both latches. */
+  track(inputSource: XrInputSource, frame: TeleportGestureFrame) {
+    if (!frame.pressed) {
+      this._teleportDisabled.delete(inputSource);
+      this._uiBlocked.delete(inputSource);
+
+      return;
+    }
+
+    if (frame.teleportDisabled) {
+      this._teleportDisabled.add(inputSource);
+    }
+
+    if (frame.uiBlocked) {
+      this._uiBlocked.add(inputSource);
+    } else {
+      this._uiBlocked.delete(inputSource);
+    }
+  }
+
+  /** True when the press may not teleport. Clears both latches so they never outlive the press. */
+  consumeBlocked(inputSource: XrInputSource): boolean {
+    const blocked = this._teleportDisabled.has(inputSource) || this._uiBlocked.has(inputSource);
+    this._teleportDisabled.delete(inputSource);
+    this._uiBlocked.delete(inputSource);
+
+    return blocked;
+  }
+}


### PR DESCRIPTION
The apple vision pro doesn't have controllers, making it impossible to move around a large model in a small space.
Enable teleport so the user can pinch to move around. Disable teleport when an annotation is selected.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>