### PR TITLE
SW-8725 Exit a VR model when the user holds down B/Y

### DIFF
--- a/src/components/VirtualWalkthrough/xr-button-arming.test.ts
+++ b/src/components/VirtualWalkthrough/xr-button-arming.test.ts
@@ -1,0 +1,48 @@
+import { XrInputSource } from 'playcanvas';
+
+import { ButtonArmingLatch } from './xr-button-arming';
+
+const source = (): XrInputSource => ({}) as unknown as XrInputSource;
+
+describe('ButtonArmingLatch', () => {
+  it('never counts a source pressed from the very first poll, while it stays down', () => {
+    const latch = new ButtonArmingLatch();
+    const src = source();
+
+    expect(latch.trackPress(src, true)).toBe(false);
+    expect(latch.trackPress(src, true)).toBe(false);
+    expect(latch.trackPress(src, true)).toBe(false);
+  });
+
+  it('counts a press that follows a release', () => {
+    const latch = new ButtonArmingLatch();
+    const src = source();
+
+    latch.trackPress(src, true);
+    latch.trackPress(src, false);
+
+    expect(latch.trackPress(src, true)).toBe(true);
+  });
+
+  it('tracks each input source independently, so one held from the first poll does not block another', () => {
+    const latch = new ButtonArmingLatch();
+    const held = source();
+    const other = source();
+
+    latch.trackPress(held, true);
+    latch.trackPress(other, false);
+
+    expect(latch.trackPress(held, true)).toBe(false);
+    expect(latch.trackPress(other, true)).toBe(true);
+  });
+
+  it('stays armed across later press/release cycles', () => {
+    const latch = new ButtonArmingLatch();
+    const src = source();
+
+    latch.trackPress(src, false);
+    expect(latch.trackPress(src, true)).toBe(true);
+    latch.trackPress(src, false);
+    expect(latch.trackPress(src, true)).toBe(true);
+  });
+});

--- a/src/components/VirtualWalkthrough/xr-button-arming.ts
+++ b/src/components/VirtualWalkthrough/xr-button-arming.ts
@@ -1,0 +1,23 @@
+import { XrInputSource } from 'playcanvas';
+
+/**
+ * Latches per input source whether a press may count toward a hold. A source arms itself the
+ * moment it is seen released, and stays armed from then on - so a button already down when
+ * tracking starts is ignored until it is released once, and one controller held down can't stop
+ * another from arming and counting. Callers must poll every frame for every source they care
+ * about; a press and release between polls is missed.
+ */
+export class ButtonArmingLatch {
+  private _armed = new WeakSet<XrInputSource>();
+
+  /** Records one frame for `inputSource` and returns whether its current press may count. */
+  trackPress(inputSource: XrInputSource, pressed: boolean): boolean {
+    if (!pressed) {
+      this._armed.add(inputSource);
+
+      return false;
+    }
+
+    return this._armed.has(inputSource);
+  }
+}

--- a/src/components/VirtualWalkthrough/xr-button-hold.test.ts
+++ b/src/components/VirtualWalkthrough/xr-button-hold.test.ts
@@ -48,7 +48,10 @@ describe('advanceHold', () => {
   });
 
   it('clamps progress to the threshold', () => {
-    expect(advanceHold(released(), true, 99, THRESHOLD).progress).toBe(1);
+    const result = advanceHold(released(), true, 99, THRESHOLD);
+
+    expect(result.progress).toBe(1);
+    expect(result.justFired).toBe(true);
   });
 
   it('resets to zero on release', () => {

--- a/src/components/VirtualWalkthrough/xr-button-hold.test.ts
+++ b/src/components/VirtualWalkthrough/xr-button-hold.test.ts
@@ -1,0 +1,70 @@
+import { HoldState, INITIAL_HOLD_STATE, advanceHold } from './xr-button-hold';
+
+const THRESHOLD = 1.25;
+
+/** Arms the timer the way a real release does, so a press can start accumulating. */
+const released = (): HoldState => advanceHold(INITIAL_HOLD_STATE, false, 0.1, THRESHOLD).state;
+
+describe('advanceHold', () => {
+  it('ignores a button that is already held when tracking starts', () => {
+    const result = advanceHold(INITIAL_HOLD_STATE, true, 2, THRESHOLD);
+
+    expect(result.progress).toBe(0);
+    expect(result.justFired).toBe(false);
+  });
+
+  it('stays unarmed for as long as a pre-held button is down', () => {
+    let state = INITIAL_HOLD_STATE;
+    for (let frame = 0; frame < 5; frame += 1) {
+      state = advanceHold(state, true, 1, THRESHOLD).state;
+    }
+
+    expect(advanceHold(state, true, 1, THRESHOLD).justFired).toBe(false);
+  });
+
+  it('arms on release so the next press accumulates', () => {
+    expect(advanceHold(released(), true, 0.5, THRESHOLD).progress).toBeCloseTo(0.4);
+  });
+
+  it('accumulates progress across frames', () => {
+    let state = released();
+    let progress = 0;
+    for (let frame = 0; frame < 3; frame += 1) {
+      const result = advanceHold(state, true, 0.25, THRESHOLD);
+      state = result.state;
+      progress = result.progress;
+    }
+
+    expect(progress).toBeCloseTo(0.6);
+  });
+
+  it('fires once when the hold reaches the threshold', () => {
+    const partial = advanceHold(released(), true, 1, THRESHOLD).state;
+    const firing = advanceHold(partial, true, 1, THRESHOLD);
+
+    expect(firing.justFired).toBe(true);
+    expect(firing.progress).toBe(1);
+    expect(advanceHold(firing.state, true, 1, THRESHOLD).justFired).toBe(false);
+  });
+
+  it('clamps progress to the threshold', () => {
+    expect(advanceHold(released(), true, 99, THRESHOLD).progress).toBe(1);
+  });
+
+  it('resets to zero on release', () => {
+    const partial = advanceHold(released(), true, 1, THRESHOLD).state;
+    const result = advanceHold(partial, false, 0.1, THRESHOLD);
+
+    expect(result.progress).toBe(0);
+    expect(result.state.elapsed).toBe(0);
+  });
+
+  it('fires again only after a fresh press', () => {
+    const fired = advanceHold(advanceHold(released(), true, 1, THRESHOLD).state, true, 1, THRESHOLD).state;
+    const afterRelease = advanceHold(fired, false, 0.1, THRESHOLD).state;
+    const rePressed = advanceHold(afterRelease, true, 1, THRESHOLD);
+
+    expect(rePressed.justFired).toBe(false);
+    expect(advanceHold(rePressed.state, true, 1, THRESHOLD).justFired).toBe(true);
+  });
+});

--- a/src/components/VirtualWalkthrough/xr-button-hold.ts
+++ b/src/components/VirtualWalkthrough/xr-button-hold.ts
@@ -1,0 +1,36 @@
+export interface HoldState {
+  elapsed: number;
+  armed: boolean;
+}
+
+export interface HoldUpdate {
+  state: HoldState;
+  progress: number;
+  justFired: boolean;
+}
+
+export const INITIAL_HOLD_STATE: HoldState = { elapsed: 0, armed: false };
+
+const RELEASED_STATE: HoldState = { elapsed: 0, armed: true };
+
+/**
+ * Advances a press-and-hold timer by one frame. `held` is whether the button is down right now.
+ *
+ * A hold only counts once a release has been seen, so a button that is already down when tracking
+ * starts does nothing until the user lets go - otherwise entering a session with a thumb on the
+ * button would fire `threshold` seconds later. `justFired` is true only on the frame elapsed first
+ * reaches `threshold`, so continuing to hold fires once.
+ */
+export const advanceHold = (prev: HoldState, held: boolean, dt: number, threshold: number): HoldUpdate => {
+  if (!held) {
+    return { state: RELEASED_STATE, progress: 0, justFired: false };
+  }
+  if (!prev.armed) {
+    return { state: prev, progress: 0, justFired: false };
+  }
+
+  const elapsed = Math.min(prev.elapsed + dt, threshold);
+  const justFired = prev.elapsed < threshold && elapsed >= threshold;
+
+  return { state: { elapsed, armed: true }, progress: elapsed / threshold, justFired };
+};

--- a/src/components/VirtualWalkthrough/xr-exit-button.ts
+++ b/src/components/VirtualWalkthrough/xr-exit-button.ts
@@ -16,7 +16,9 @@ import {
   XrInputSource,
 } from 'playcanvas';
 
-import { FaceButtonPressTracker } from './xr-face-buttons';
+import { HoldState, INITIAL_HOLD_STATE, advanceHold } from './xr-button-hold';
+import { FaceButtonPressTracker, secondaryFaceButtonPressed } from './xr-face-buttons';
+import { drawProgressPie } from './xr-progress-pie';
 
 /**
  * Boolean ray-sphere hit test. Treats the ray as a half-line (t >= 0) and returns true when it
@@ -35,6 +37,9 @@ export const raySphereIntersect = (origin: Vec3, direction: Vec3, center: Vec3, 
 };
 
 const TEXTURE_SIZE = 256;
+
+/** Seconds of continuous B/Y hold required to leave the session. Matches the gaze-dwell threshold. */
+const EXIT_HOLD_SECONDS = 1.25;
 
 export class XrExitButton extends Script {
   static scriptName = 'xrExitButton';
@@ -58,15 +63,22 @@ export class XrExitButton extends Script {
   private _worldOffset = new Vec3();
   private _faceButtons = new FaceButtonPressTracker();
 
+  private _canvas?: HTMLCanvasElement;
+  private _drawnProgress = -1;
+  private _hold: HoldState = INITIAL_HOLD_STATE;
+  private _armedSources = new WeakSet<XrInputSource>();
+
   private _isVrActive = () => this.app.xr?.active === true && this.app.xr?.type === XRTYPE_VR;
 
   private _onXrStart = () => {
     this.entity.enabled = this._isVrActive();
+    this._resetProgress();
   };
 
   private _onXrEnd = () => {
     this.entity.enabled = false;
     this._hovered = false;
+    this._resetProgress();
     this.entity.setLocalScale(1, 1, 1);
     if (this._material) {
       this._material.opacity = 0.9;
@@ -92,32 +104,15 @@ export class XrExitButton extends Script {
     return raySphereIntersect(origin, direction, this.entity.getPosition(), this.hitRadius);
   }
 
-  private _createTexture(): Texture {
+  private _createCanvas(): HTMLCanvasElement {
     const canvas = document.createElement('canvas');
     canvas.width = TEXTURE_SIZE;
     canvas.height = TEXTURE_SIZE;
-    const ctx = canvas.getContext('2d');
-    const c = TEXTURE_SIZE / 2;
 
-    if (ctx) {
-      ctx.clearRect(0, 0, TEXTURE_SIZE, TEXTURE_SIZE);
-      ctx.fillStyle = 'rgba(20, 20, 20, 0.75)';
-      ctx.beginPath();
-      ctx.arc(c, c, c * 0.92, 0, Math.PI * 2);
-      ctx.fill();
+    return canvas;
+  }
 
-      const arm = TEXTURE_SIZE * 0.24;
-      ctx.strokeStyle = '#ffffff';
-      ctx.lineWidth = TEXTURE_SIZE * 0.09;
-      ctx.lineCap = 'round';
-      ctx.beginPath();
-      ctx.moveTo(c - arm, c - arm);
-      ctx.lineTo(c + arm, c + arm);
-      ctx.moveTo(c + arm, c - arm);
-      ctx.lineTo(c - arm, c + arm);
-      ctx.stroke();
-    }
-
+  private _createTexture(canvas: HTMLCanvasElement): Texture {
     const texture = new Texture(this.app.graphicsDevice, {
       name: 'xr-exit-button',
       width: TEXTURE_SIZE,
@@ -133,6 +128,58 @@ export class XrExitButton extends Script {
     return texture;
   }
 
+  /**
+   * Repaints the button: dark disc, then the hold progress wedge, then the X arms on top so the
+   * glyph stays legible over the fill. The pie is skipped entirely at zero progress so the idle
+   * button doesn't wear the pie's faint track.
+   */
+  private _drawButton(progress: number) {
+    const ctx = this._canvas?.getContext('2d');
+    if (!ctx) {
+      return;
+    }
+    const c = TEXTURE_SIZE / 2;
+
+    ctx.clearRect(0, 0, TEXTURE_SIZE, TEXTURE_SIZE);
+    ctx.fillStyle = 'rgba(20, 20, 20, 0.75)';
+    ctx.beginPath();
+    ctx.arc(c, c, c * 0.92, 0, Math.PI * 2);
+    ctx.fill();
+
+    if (progress > 0) {
+      drawProgressPie(ctx, TEXTURE_SIZE, progress);
+    }
+
+    const arm = TEXTURE_SIZE * 0.24;
+    ctx.strokeStyle = '#ffffff';
+    ctx.lineWidth = TEXTURE_SIZE * 0.09;
+    ctx.lineCap = 'round';
+    ctx.beginPath();
+    ctx.moveTo(c - arm, c - arm);
+    ctx.lineTo(c + arm, c + arm);
+    ctx.moveTo(c + arm, c - arm);
+    ctx.lineTo(c - arm, c + arm);
+    ctx.stroke();
+
+    this._texture?.upload();
+  }
+
+  /** Repaints only when the drawn wedge would visibly move. */
+  private _setProgress(progress: number) {
+    if (Math.abs(progress - this._drawnProgress) <= 0.001) {
+      return;
+    }
+
+    this._drawnProgress = progress;
+    this._drawButton(progress);
+  }
+
+  private _resetProgress() {
+    this._hold = INITIAL_HOLD_STATE;
+    this._drawnProgress = -1;
+    this._setProgress(0);
+  }
+
   private _createMesh(): Mesh {
     const h = this.halfSize;
     const mesh = new Mesh(this.app.graphicsDevice);
@@ -146,7 +193,10 @@ export class XrExitButton extends Script {
   }
 
   initialize() {
-    this._texture = this._createTexture();
+    this._canvas = this._createCanvas();
+    this._texture = this._createTexture(this._canvas);
+    this._drawButton(0);
+    this._drawnProgress = 0;
 
     const material = new StandardMaterial();
     material.useLighting = false;
@@ -174,7 +224,7 @@ export class XrExitButton extends Script {
     this.app.xr?.input?.on('select', this._onSelect);
   }
 
-  update() {
+  update(dt: number) {
     if (!this.entity.enabled) {
       return;
     }
@@ -183,6 +233,7 @@ export class XrExitButton extends Script {
 
     const sources = this.app.xr?.input?.inputSources ?? [];
     let hovered = false;
+    let holdActive = false;
     for (const source of sources) {
       const sourceHovers = this.rayHitsButton(source.getOrigin(), source.getDirection());
       hovered = hovered || sourceHovers;
@@ -196,6 +247,24 @@ export class XrExitButton extends Script {
 
         return;
       }
+
+      // Arming is per source: a button already down when the session starts is ignored until it is
+      // released, and one controller held down can't stop the other from starting a hold.
+      if (secondaryFaceButtonPressed(source)) {
+        holdActive = holdActive || this._armedSources.has(source);
+      } else {
+        this._armedSources.add(source);
+      }
+    }
+
+    const hold = advanceHold(this._hold, holdActive, dt, EXIT_HOLD_SECONDS);
+    this._hold = hold.state;
+    this._setProgress(hold.progress);
+
+    if (hold.justFired) {
+      this.app.xr?.end();
+
+      return;
     }
 
     if (hovered !== this._hovered) {

--- a/src/components/VirtualWalkthrough/xr-exit-button.ts
+++ b/src/components/VirtualWalkthrough/xr-exit-button.ts
@@ -65,6 +65,7 @@ export class XrExitButton extends Script {
   private _faceButtons = new FaceButtonPressTracker();
 
   private _canvas?: HTMLCanvasElement;
+  private _context?: CanvasRenderingContext2D;
   private _drawnProgress = -1;
   private _hold: HoldState = INITIAL_HOLD_STATE;
   private _arming = new ButtonArmingLatch();
@@ -132,12 +133,13 @@ export class XrExitButton extends Script {
   /**
    * Repaints the button: dark disc, then the hold progress wedge, then the X arms on top so the
    * glyph stays legible over the fill. The pie is skipped entirely at zero progress so the idle
-   * button doesn't wear the pie's faint track.
+   * button doesn't wear the pie's faint track. Returns whether it painted, so callers can tell a
+   * missing context from a successful repaint.
    */
-  private _drawButton(progress: number) {
-    const ctx = this._canvas?.getContext('2d');
+  private _drawButton(progress: number): boolean {
+    const ctx = this._context;
     if (!ctx) {
-      return;
+      return false;
     }
     const c = TEXTURE_SIZE / 2;
 
@@ -163,16 +165,20 @@ export class XrExitButton extends Script {
     ctx.stroke();
 
     this._texture?.upload();
+
+    return true;
   }
 
-  /** Repaints only when the drawn wedge would visibly move. */
+  /** Repaints only when the drawn wedge would visibly move. Only records the paint on success, so a
+   * missing context doesn't fool the dedupe cache into thinking a repaint already happened. */
   private _setProgress(progress: number) {
     if (Math.abs(progress - this._drawnProgress) <= 0.001) {
       return;
     }
 
-    this._drawnProgress = progress;
-    this._drawButton(progress);
+    if (this._drawButton(progress)) {
+      this._drawnProgress = progress;
+    }
   }
 
   private _resetProgress() {
@@ -195,9 +201,9 @@ export class XrExitButton extends Script {
 
   initialize() {
     this._canvas = this._createCanvas();
+    this._context = this._canvas.getContext('2d') ?? undefined;
     this._texture = this._createTexture(this._canvas);
-    this._drawButton(0);
-    this._drawnProgress = 0;
+    this._resetProgress();
 
     const material = new StandardMaterial();
     material.useLighting = false;
@@ -319,5 +325,7 @@ export class XrExitButton extends Script {
     this._mesh = undefined;
     this._material = undefined;
     this._texture = undefined;
+    this._canvas = undefined;
+    this._context = undefined;
   }
 }

--- a/src/components/VirtualWalkthrough/xr-exit-button.ts
+++ b/src/components/VirtualWalkthrough/xr-exit-button.ts
@@ -16,6 +16,7 @@ import {
   XrInputSource,
 } from 'playcanvas';
 
+import { ButtonArmingLatch } from './xr-button-arming';
 import { HoldState, INITIAL_HOLD_STATE, advanceHold } from './xr-button-hold';
 import { FaceButtonPressTracker, secondaryFaceButtonPressed } from './xr-face-buttons';
 import { drawProgressPie } from './xr-progress-pie';
@@ -66,7 +67,7 @@ export class XrExitButton extends Script {
   private _canvas?: HTMLCanvasElement;
   private _drawnProgress = -1;
   private _hold: HoldState = INITIAL_HOLD_STATE;
-  private _armedSources = new WeakSet<XrInputSource>();
+  private _arming = new ButtonArmingLatch();
 
   private _isVrActive = () => this.app.xr?.active === true && this.app.xr?.type === XRTYPE_VR;
 
@@ -248,13 +249,11 @@ export class XrExitButton extends Script {
         return;
       }
 
-      // Arming is per source: a button already down when the session starts is ignored until it is
-      // released, and one controller held down can't stop the other from starting a hold.
-      if (secondaryFaceButtonPressed(source)) {
-        holdActive = holdActive || this._armedSources.has(source);
-      } else {
-        this._armedSources.add(source);
-      }
+      // Two statements, not `holdActive = holdActive || this._arming.trackPress(...)`: trackPress
+      // arms the source as a side effect and must run for every source every frame, but `||`
+      // short-circuits once holdActive is true and would skip arming later sources.
+      const armedPress = this._arming.trackPress(source, secondaryFaceButtonPressed(source));
+      holdActive = holdActive || armedPress;
     }
 
     const hold = advanceHold(this._hold, holdActive, dt, EXIT_HOLD_SECONDS);

--- a/src/components/VirtualWalkthrough/xr-face-buttons.test.ts
+++ b/src/components/VirtualWalkthrough/xr-face-buttons.test.ts
@@ -1,6 +1,6 @@
 import { XrInputSource } from 'playcanvas';
 
-import { FaceButtonPressTracker, faceButtonPressed } from './xr-face-buttons';
+import { FaceButtonPressTracker, faceButtonPressed, secondaryFaceButtonPressed } from './xr-face-buttons';
 
 /** Fake input source whose gamepad reports `pressedIndices` as held. */
 const source = (pressedIndices: number[], buttonCount = 6): XrInputSource =>
@@ -35,6 +35,24 @@ describe('faceButtonPressed', () => {
 
   it('is false when nothing is pressed', () => {
     expect(faceButtonPressed(source([]))).toBe(false);
+  });
+});
+
+describe('secondaryFaceButtonPressed', () => {
+  it('is true when B/Y is pressed', () => {
+    expect(secondaryFaceButtonPressed(source([5]))).toBe(true);
+  });
+
+  it('is false when only A/X is pressed', () => {
+    expect(secondaryFaceButtonPressed(source([4]))).toBe(false);
+  });
+
+  it('is false for an input source with no gamepad', () => {
+    expect(secondaryFaceButtonPressed(handTrackedSource())).toBe(false);
+  });
+
+  it('is false when the gamepad has fewer buttons than the face buttons', () => {
+    expect(secondaryFaceButtonPressed(source([0], 2))).toBe(false);
   });
 });
 

--- a/src/components/VirtualWalkthrough/xr-face-buttons.ts
+++ b/src/components/VirtualWalkthrough/xr-face-buttons.ts
@@ -3,7 +3,7 @@ import { XrInputSource } from 'playcanvas';
 /** xr-standard gamepad button indices for the face buttons: A/X (4) and B/Y (5). */
 const FACE_BUTTON_INDICES = [4, 5];
 
-/** xr-standard gamepad button index for the secondary face button: B on the right hand, Y on the left. */
+/** xr-standard gamepad button indices for the secondary face button: B on the right hand, Y on the left. */
 const SECONDARY_FACE_BUTTON_INDICES = [5];
 
 const anyButtonPressed = (inputSource: XrInputSource, indices: number[]): boolean => {

--- a/src/components/VirtualWalkthrough/xr-face-buttons.ts
+++ b/src/components/VirtualWalkthrough/xr-face-buttons.ts
@@ -3,12 +3,22 @@ import { XrInputSource } from 'playcanvas';
 /** xr-standard gamepad button indices for the face buttons: A/X (4) and B/Y (5). */
 const FACE_BUTTON_INDICES = [4, 5];
 
-/** True while either face button is held. False for hand-tracked sources, which have no gamepad. */
-export const faceButtonPressed = (inputSource: XrInputSource): boolean => {
+/** xr-standard gamepad button index for the secondary face button: B on the right hand, Y on the left. */
+const SECONDARY_FACE_BUTTON_INDICES = [5];
+
+const anyButtonPressed = (inputSource: XrInputSource, indices: number[]): boolean => {
   const buttons = inputSource.gamepad?.buttons;
 
-  return buttons ? FACE_BUTTON_INDICES.some((index) => buttons[index]?.pressed === true) : false;
+  return buttons ? indices.some((index) => buttons[index]?.pressed === true) : false;
 };
+
+/** True while either face button is held. False for hand-tracked sources, which have no gamepad. */
+export const faceButtonPressed = (inputSource: XrInputSource): boolean =>
+  anyButtonPressed(inputSource, FACE_BUTTON_INDICES);
+
+/** True while B or Y is held, regardless of which hand holds the controller. */
+export const secondaryFaceButtonPressed = (inputSource: XrInputSource): boolean =>
+  anyButtonPressed(inputSource, SECONDARY_FACE_BUTTON_INDICES);
 
 /**
  * Edge-detects face-button presses per input source so one press fires once. Callers must poll every

--- a/src/components/VirtualWalkthrough/xr-gaze-dwell.ts
+++ b/src/components/VirtualWalkthrough/xr-gaze-dwell.ts
@@ -19,6 +19,7 @@ import {
 import { HOTSPOT_HALF_EXTENT, collectAnnotationHitCandidates } from './xr-annotation-candidates';
 import { nearestAnnotationHit } from './xr-annotation-targeting';
 import { DwellState, INITIAL_DWELL_STATE, advanceDwell } from './xr-gaze-dwell-state';
+import { drawProgressPie } from './xr-progress-pie';
 
 /** Multiplier on the hotspot's world radius for gaze targeting. */
 const GAZE_HIT_RADIUS_PAD = 5;
@@ -31,9 +32,6 @@ const PIE_RADIUS_SCALE = 1.25;
 
 /** Progress-pie texture resolution. */
 const PIE_TEXTURE_SIZE = 128;
-
-/** Sweep starts at 12 o'clock. */
-const PIE_START_ANGLE = -Math.PI / 2;
 
 const LOCAL_FORWARD = new Vec3(0, 0, -1);
 
@@ -118,24 +116,9 @@ export class XrGazeDwell extends Script {
     if (!ctx) {
       return;
     }
-    const c = PIE_TEXTURE_SIZE / 2;
-    const r = c * 0.92;
+
     ctx.clearRect(0, 0, PIE_TEXTURE_SIZE, PIE_TEXTURE_SIZE);
-
-    // Faint full-circle track so the not-yet-filled portion still reads as a disc.
-    ctx.beginPath();
-    ctx.arc(c, c, r, 0, Math.PI * 2);
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.18)';
-    ctx.fill();
-
-    // Filled progress wedge from the centre, sweeping from 12 o'clock.
-    ctx.beginPath();
-    ctx.moveTo(c, c);
-    ctx.arc(c, c, r, PIE_START_ANGLE, PIE_START_ANGLE + progress * Math.PI * 2);
-    ctx.closePath();
-    ctx.fillStyle = 'rgba(64, 200, 255, 0.85)';
-    ctx.fill();
-
+    drawProgressPie(ctx, PIE_TEXTURE_SIZE, progress);
     this._pieTexture?.upload();
   }
 

--- a/src/components/VirtualWalkthrough/xr-progress-pie.test.ts
+++ b/src/components/VirtualWalkthrough/xr-progress-pie.test.ts
@@ -9,6 +9,8 @@ const stubContext = () => {
   const fills: string[] = [];
   const ctx = {
     fillStyle: '',
+    save: () => undefined,
+    restore: () => undefined,
     beginPath: () => undefined,
     moveTo: () => undefined,
     closePath: () => undefined,

--- a/src/components/VirtualWalkthrough/xr-progress-pie.test.ts
+++ b/src/components/VirtualWalkthrough/xr-progress-pie.test.ts
@@ -1,0 +1,65 @@
+import { drawProgressPie } from './xr-progress-pie';
+
+const TRACK_FILL = 'rgba(255, 255, 255, 0.18)';
+const WEDGE_FILL = 'rgba(64, 200, 255, 0.85)';
+
+/** Minimal 2D-context stand-in that records the arcs drawn and the fill colour used for each. */
+const stubContext = () => {
+  const arcs: { radius: number; start: number; end: number }[] = [];
+  const fills: string[] = [];
+  const ctx = {
+    fillStyle: '',
+    beginPath: () => undefined,
+    moveTo: () => undefined,
+    closePath: () => undefined,
+    arc: (_x: number, _y: number, radius: number, start: number, end: number) => {
+      arcs.push({ radius, start, end });
+    },
+    fill: () => {
+      fills.push(ctx.fillStyle);
+    },
+  };
+
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, arcs, fills };
+};
+
+describe('drawProgressPie', () => {
+  it('draws only the full-circle track at zero progress', () => {
+    const { ctx, arcs, fills } = stubContext();
+    drawProgressPie(ctx, 128, 0);
+
+    expect(arcs).toHaveLength(1);
+    expect(arcs[0].end - arcs[0].start).toBeCloseTo(Math.PI * 2);
+    expect(fills).toEqual([TRACK_FILL]);
+  });
+
+  it('sweeps a quarter turn clockwise from the top at quarter progress', () => {
+    const { ctx, arcs } = stubContext();
+    drawProgressPie(ctx, 128, 0.25);
+
+    expect(arcs).toHaveLength(2);
+    expect(arcs[1].start).toBeCloseTo(-Math.PI / 2);
+    expect(arcs[1].end).toBeCloseTo(0);
+  });
+
+  it('sweeps a full turn at full progress', () => {
+    const { ctx, arcs } = stubContext();
+    drawProgressPie(ctx, 128, 1);
+
+    expect(arcs[1].end - arcs[1].start).toBeCloseTo(Math.PI * 2);
+  });
+
+  it('fills the wedge over the track', () => {
+    const { ctx, fills } = stubContext();
+    drawProgressPie(ctx, 128, 0.5);
+
+    expect(fills).toEqual([TRACK_FILL, WEDGE_FILL]);
+  });
+
+  it('scales the radius to the drawn size', () => {
+    const { ctx, arcs } = stubContext();
+    drawProgressPie(ctx, 256, 0);
+
+    expect(arcs[0].radius).toBeCloseTo(128 * 0.92);
+  });
+});

--- a/src/components/VirtualWalkthrough/xr-progress-pie.ts
+++ b/src/components/VirtualWalkthrough/xr-progress-pie.ts
@@ -3,26 +3,32 @@ const PIE_START_ANGLE = -Math.PI / 2;
 
 /**
  * Draws a circular progress pie into the `size` x `size` region at the context origin: a faint
- * full-circle track under a wedge that sweeps clockwise as `progress` goes 0 -> 1. Neither clears the
- * context nor uploads a texture, so callers can composite it between their own layers.
+ * full-circle track under a wedge that sweeps clockwise as `progress` goes 0 -> 1. A `progress`
+ * above 1 simply sweeps a full circle. Neither clears the context nor uploads a texture, so callers
+ * can composite it between their own layers. Saves and restores the drawing state it touches and
+ * leaves the path clean on exit, so callers can stroke or fill right after without an explicit
+ * `beginPath()` of their own.
  */
 export const drawProgressPie = (ctx: CanvasRenderingContext2D, size: number, progress: number) => {
   const c = size / 2;
   const r = c * 0.92;
+
+  ctx.save();
 
   ctx.beginPath();
   ctx.arc(c, c, r, 0, Math.PI * 2);
   ctx.fillStyle = 'rgba(255, 255, 255, 0.18)';
   ctx.fill();
 
-  if (progress <= 0) {
-    return;
+  if (progress > 0) {
+    ctx.beginPath();
+    ctx.moveTo(c, c);
+    ctx.arc(c, c, r, PIE_START_ANGLE, PIE_START_ANGLE + progress * Math.PI * 2);
+    ctx.closePath();
+    ctx.fillStyle = 'rgba(64, 200, 255, 0.85)';
+    ctx.fill();
   }
 
+  ctx.restore();
   ctx.beginPath();
-  ctx.moveTo(c, c);
-  ctx.arc(c, c, r, PIE_START_ANGLE, PIE_START_ANGLE + progress * Math.PI * 2);
-  ctx.closePath();
-  ctx.fillStyle = 'rgba(64, 200, 255, 0.85)';
-  ctx.fill();
 };

--- a/src/components/VirtualWalkthrough/xr-progress-pie.ts
+++ b/src/components/VirtualWalkthrough/xr-progress-pie.ts
@@ -1,0 +1,28 @@
+/** Sweep starts at 12 o'clock. */
+const PIE_START_ANGLE = -Math.PI / 2;
+
+/**
+ * Draws a circular progress pie into the `size` x `size` region at the context origin: a faint
+ * full-circle track under a wedge that sweeps clockwise as `progress` goes 0 -> 1. Neither clears the
+ * context nor uploads a texture, so callers can composite it between their own layers.
+ */
+export const drawProgressPie = (ctx: CanvasRenderingContext2D, size: number, progress: number) => {
+  const c = size / 2;
+  const r = c * 0.92;
+
+  ctx.beginPath();
+  ctx.arc(c, c, r, 0, Math.PI * 2);
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.18)';
+  ctx.fill();
+
+  if (progress <= 0) {
+    return;
+  }
+
+  ctx.beginPath();
+  ctx.moveTo(c, c);
+  ctx.arc(c, c, r, PIE_START_ANGLE, PIE_START_ANGLE + progress * Math.PI * 2);
+  ctx.closePath();
+  ctx.fillStyle = 'rgba(64, 200, 255, 0.85)';
+  ctx.fill();
+};


### PR DESCRIPTION
Instead of requiring the user to point the controller up at the X button which moves with the headset movement, allow the user to hold down B/Y to exit.
Use the same progress pie as the gaze dwell for annotations.
Refactor the code for reusability.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>