### PR TITLE
SW-8691 Add circle-bounds math for XR scene limits

### DIFF
--- a/src/components/VirtualWalkthrough/xr-scene-bounds.test.ts
+++ b/src/components/VirtualWalkthrough/xr-scene-bounds.test.ts
@@ -1,0 +1,61 @@
+import { clampToCircle, distanceToCircleEdge } from './xr-scene-bounds';
+
+describe('clampToCircle', () => {
+  it('leaves a point inside the circle untouched', () => {
+    expect(clampToCircle(1, 2, 0, 0, 5)).toEqual({ x: 1, z: 2, distance: 0 });
+  });
+
+  it('leaves a point exactly on the edge untouched', () => {
+    expect(clampToCircle(5, 0, 0, 0, 5)).toEqual({ x: 5, z: 0, distance: 0 });
+  });
+
+  it('projects a point outside back onto the edge', () => {
+    const result = clampToCircle(10, 0, 0, 0, 4);
+    expect(result.x).toBeCloseTo(4);
+    expect(result.z).toBeCloseTo(0);
+    expect(result.distance).toBeCloseTo(6);
+  });
+
+  it('projects along the line from the center, preserving direction', () => {
+    const result = clampToCircle(30, 40, 0, 0, 5);
+    expect(result.x).toBeCloseTo(3);
+    expect(result.z).toBeCloseTo(4);
+    expect(result.distance).toBeCloseTo(45);
+  });
+
+  it('respects an off-origin center', () => {
+    const result = clampToCircle(12, -3, 2, -3, 4);
+    expect(result.x).toBeCloseTo(6);
+    expect(result.z).toBeCloseTo(-3);
+    expect(result.distance).toBeCloseTo(6);
+  });
+
+  it('leaves a point at the exact center untouched rather than dividing by zero', () => {
+    const result = clampToCircle(2, -3, 2, -3, 4);
+    expect(result).toEqual({ x: 2, z: -3, distance: 0 });
+    expect(Number.isNaN(result.x)).toBe(false);
+  });
+
+  it('leaves the point untouched for a non-positive radius', () => {
+    expect(clampToCircle(10, 10, 0, 0, 0)).toEqual({ x: 10, z: 10, distance: 0 });
+    expect(clampToCircle(10, 10, 0, 0, -1)).toEqual({ x: 10, z: 10, distance: 0 });
+  });
+});
+
+describe('distanceToCircleEdge', () => {
+  it('is negative inside the circle', () => {
+    expect(distanceToCircleEdge(1, 0, 0, 0, 5)).toBeCloseTo(-4);
+  });
+
+  it('is zero on the edge', () => {
+    expect(distanceToCircleEdge(0, 5, 0, 0, 5)).toBeCloseTo(0);
+  });
+
+  it('is positive outside the circle', () => {
+    expect(distanceToCircleEdge(8, 0, 0, 0, 5)).toBeCloseTo(3);
+  });
+
+  it('respects an off-origin center', () => {
+    expect(distanceToCircleEdge(2, 9, 2, 3, 4)).toBeCloseTo(2);
+  });
+});

--- a/src/components/VirtualWalkthrough/xr-scene-bounds.ts
+++ b/src/components/VirtualWalkthrough/xr-scene-bounds.ts
@@ -1,0 +1,40 @@
+/** A world-space XZ point clamped into the bounds circle, and how far it had to move to get there. */
+export type ClampResult = { x: number; z: number; distance: number };
+
+/**
+ * Clamp a world-space XZ point into the circle of `radius` about (centerX, centerZ).
+ *
+ * `distance` is how far the point was moved and is 0 whenever the point was already inside, which
+ * callers use as the "was this clamped?" signal. A non-positive radius means "no bounds" and leaves
+ * the point untouched; so does a point at the exact center, which has no direction to project along.
+ */
+export const clampToCircle = (x: number, z: number, centerX: number, centerZ: number, radius: number): ClampResult => {
+  if (radius <= 0) {
+    return { x, z, distance: 0 };
+  }
+
+  const dx = x - centerX;
+  const dz = z - centerZ;
+  const dist = Math.sqrt(dx * dx + dz * dz);
+  if (dist <= radius) {
+    return { x, z, distance: 0 };
+  }
+
+  const scale = radius / dist;
+
+  return { x: centerX + dx * scale, z: centerZ + dz * scale, distance: dist - radius };
+};
+
+/** Horizontal distance from a world-space XZ point to the circle's edge: negative inside, positive outside. */
+export const distanceToCircleEdge = (
+  x: number,
+  z: number,
+  centerX: number,
+  centerZ: number,
+  radius: number
+): number => {
+  const dx = x - centerX;
+  const dz = z - centerZ;
+
+  return Math.sqrt(dx * dx + dz * dz) - radius;
+};


### PR DESCRIPTION
In preparation for a boundary mesh, add the math necessary for it to a script and test it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>