### PR TITLE
SW-8691

SW-8691 Add clamp distance to navigation

### DIFF
--- a/src/components/VirtualWalkthrough/TfXrNavigation.test.ts
+++ b/src/components/VirtualWalkthrough/TfXrNavigation.test.ts
@@ -1,0 +1,99 @@
+import { AppBase, Entity, Vec3 } from 'playcanvas';
+
+// The real base script is an .mjs file that Jest's default CRA transform config never transforms
+// (node_modules is excluded), so importing it directly fails to parse. TfXrNavigation.postUpdate
+// never calls into the base class, so a stub with no behaviour is enough to satisfy `extends`.
+jest.mock('playcanvas/scripts/esm/xr/xr-navigation.mjs', () => ({
+  XrNavigation: class {},
+}));
+
+import { TfXrNavigation } from './TfXrNavigation';
+
+const BOUNDS_CENTER = new Vec3(2, 0, 3);
+const BOUNDS_RADIUS = 5;
+
+const makeNavigation = (options: { xrActive: boolean; boundsRadius: number; head: Vec3 }) => {
+  const translate = jest.fn();
+  const navigation = Object.create(TfXrNavigation.prototype) as TfXrNavigation;
+
+  navigation.boundsCenter = BOUNDS_CENTER.clone();
+  navigation.boundsRadius = options.boundsRadius;
+  navigation.clampDistance = 0;
+  navigation.app = { xr: { active: options.xrActive } } as unknown as AppBase;
+  navigation.entity = { translate } as unknown as Entity;
+  Object.assign(navigation, { _cameraEntity: { getPosition: () => options.head } });
+
+  return { navigation, translate };
+};
+
+describe('TfXrNavigation.postUpdate', () => {
+  it('does not clamp when there is no active XR session, even with the head far outside the circle', () => {
+    const { navigation, translate } = makeNavigation({
+      xrActive: false,
+      boundsRadius: BOUNDS_RADIUS,
+      head: new Vec3(1000, 1.5, 1000),
+    });
+
+    navigation.postUpdate();
+
+    expect(translate).not.toHaveBeenCalled();
+    expect(navigation.clampDistance).toBe(0);
+  });
+
+  it('does not clamp when boundsRadius is 0', () => {
+    const { navigation, translate } = makeNavigation({
+      xrActive: true,
+      boundsRadius: 0,
+      head: new Vec3(1000, 1.5, 1000),
+    });
+
+    navigation.postUpdate();
+
+    expect(translate).not.toHaveBeenCalled();
+    expect(navigation.clampDistance).toBe(0);
+  });
+
+  it('does not clamp when the head is inside the circle', () => {
+    const { navigation, translate } = makeNavigation({
+      xrActive: true,
+      boundsRadius: BOUNDS_RADIUS,
+      head: new Vec3(3, 1.5, 4),
+    });
+
+    navigation.postUpdate();
+
+    expect(translate).not.toHaveBeenCalled();
+    expect(navigation.clampDistance).toBe(0);
+  });
+
+  it('pulls the rig back and records the overshoot when the head is outside the circle in an active session', () => {
+    const { navigation, translate } = makeNavigation({
+      xrActive: true,
+      boundsRadius: BOUNDS_RADIUS,
+      head: new Vec3(10, 1.5, 3),
+    });
+
+    navigation.postUpdate();
+
+    expect(translate).toHaveBeenCalledTimes(1);
+    expect(translate).toHaveBeenCalledWith(-3, 0, 0);
+    expect(navigation.clampDistance).toBe(3);
+  });
+
+  it('does not latch clampDistance across frames', () => {
+    const { navigation, translate } = makeNavigation({
+      xrActive: true,
+      boundsRadius: BOUNDS_RADIUS,
+      head: new Vec3(10, 1.5, 3),
+    });
+
+    navigation.postUpdate();
+    expect(navigation.clampDistance).toBe(3);
+
+    Object.assign(navigation, { _cameraEntity: { getPosition: () => new Vec3(3, 1.5, 4) } });
+    navigation.postUpdate();
+
+    expect(translate).toHaveBeenCalledTimes(1);
+    expect(navigation.clampDistance).toBe(0);
+  });
+});

--- a/src/components/VirtualWalkthrough/TfXrNavigation.ts
+++ b/src/components/VirtualWalkthrough/TfXrNavigation.ts
@@ -1,6 +1,7 @@
-import { XrInputSource } from 'playcanvas';
+import { Entity, Vec3, XrInputSource } from 'playcanvas';
 import { XrNavigation as PcXrNavigation } from 'playcanvas/scripts/esm/xr/xr-navigation.mjs';
 
+import { clampToCircle } from './xr-scene-bounds';
 import { TeleportGestureLatch } from './xr-teleport-gesture';
 
 interface ArcVisual {
@@ -13,6 +14,7 @@ interface XrNavigationInternals {
   _inputSources: Set<XrInputSource>;
   _arcVisuals: Map<XrInputSource, ArcVisual>;
   _activePointers: Map<XrInputSource, boolean>;
+  _cameraEntity: Entity | null;
 }
 
 /**
@@ -25,6 +27,18 @@ export class TfXrNavigation extends PcXrNavigation {
 
   /** Assigned by the React wrapper. True when this source's ray is over interactive UI. */
   isTeleportBlocked?: (inputSource: XrInputSource) => boolean;
+
+  /**
+   * World-space bounds circle. Assigned by the React wrapper rather than passed as a Script prop:
+   * boundsCenter is a Vec3, and @playcanvas/react's memo() comparator stops at the first prop with
+   * an .equals() method, so any prop after it would never propagate.
+   * A boundsRadius of 0 disables clamping entirely.
+   */
+  boundsCenter = new Vec3();
+  boundsRadius = 0;
+
+  /** How far the rig was pulled back in the last postUpdate to keep the head inside the bounds. */
+  clampDistance = 0;
 
   private _gestures = new TeleportGestureLatch();
 
@@ -77,5 +91,61 @@ export class TfXrNavigation extends PcXrNavigation {
         visual.ringEntity.enabled = false;
       }
     }
+  }
+
+  /**
+   * Holds the head inside the bounds circle. Runs in postUpdate, after PlayCanvas has written this
+   * frame's head pose into the camera's local transform (xr.update runs before app.update) and after
+   * the base script's locomotion, so one clamp covers every way the head can move: thumbstick
+   * translation of the rig, room-scale walking within the rig, and snap turns pivoting the rig.
+   */
+  postUpdate() {
+    this.clampDistance = 0;
+
+    const camera = (this as unknown as XrNavigationInternals)._cameraEntity;
+    if (!camera || this.boundsRadius <= 0) {
+      return;
+    }
+
+    const head = camera.getPosition();
+    const clamped = clampToCircle(head.x, head.z, this.boundsCenter.x, this.boundsCenter.z, this.boundsRadius);
+    if (clamped.distance === 0) {
+      return;
+    }
+
+    // World-space translate, not translateLocal: a snap turn has yawed the rig, so a local-space
+    // correction would be rotated away from the direction the head actually overshot.
+    this.entity.translate(clamped.x - head.x, 0, clamped.z - head.z);
+    this.clampDistance = clamped.distance;
+  }
+
+  /**
+   * Clamps the teleport landing point to the bounds circle. Overriding here rather than in
+   * tryTeleport covers both paths that produce a landing point — the per-frame aim in
+   * _handleTeleportation and tryTeleport's own recompute when no hit is cached — and because
+   * _handleTeleportation positions the landing ring from this same record immediately afterwards,
+   * the ring previews the clamped destination without any extra work.
+   *
+   * Only valid hits are clamped: when the base finds no hit it leaves rec.point holding a stale
+   * value from an earlier frame, which must not be projected onto the circle and shown as a target.
+   * Clamping only ever shortens the throw, so a hit that passed the base's distance check still does.
+   */
+  _computeArcHit(origin: Vec3, direction: Vec3, rec: { point: Vec3; valid: boolean }) {
+    super._computeArcHit(origin, direction, rec);
+
+    if (!rec.valid || this.boundsRadius <= 0) {
+      return;
+    }
+
+    // Y is left alone: it is the navigation plane height, and bounds are XZ-only.
+    const clamped = clampToCircle(
+      rec.point.x,
+      rec.point.z,
+      this.boundsCenter.x,
+      this.boundsCenter.z,
+      this.boundsRadius
+    );
+    rec.point.x = clamped.x;
+    rec.point.z = clamped.z;
   }
 }

--- a/src/components/VirtualWalkthrough/TfXrNavigation.ts
+++ b/src/components/VirtualWalkthrough/TfXrNavigation.ts
@@ -99,10 +99,7 @@ export class TfXrNavigation extends PcXrNavigation {
    * the base script's locomotion, so one clamp covers every way the head can move: thumbstick
    * translation of the rig, room-scale walking within the rig, and snap turns pivoting the rig.
    *
-   * Gated on an active XR session because this script is mounted unconditionally (VirtualWalkthroughViewer
-   * doesn't wrap it in an `!isCurrentlyInXr` check the way it does WalkthroughCamera and AutoRotator), so
-   * postUpdate runs on desktop too. Desktop bounding — including deliberately skipping it in free-fly — is
-   * WalkthroughCamera's job; this script must stay a no-op outside XR regardless of how it's mounted.
+   * This script must stay a no-op outside XR regardless of how it's mounted.
    */
   postUpdate() {
     this.clampDistance = 0;

--- a/src/components/VirtualWalkthrough/TfXrNavigation.ts
+++ b/src/components/VirtualWalkthrough/TfXrNavigation.ts
@@ -98,12 +98,17 @@ export class TfXrNavigation extends PcXrNavigation {
    * frame's head pose into the camera's local transform (xr.update runs before app.update) and after
    * the base script's locomotion, so one clamp covers every way the head can move: thumbstick
    * translation of the rig, room-scale walking within the rig, and snap turns pivoting the rig.
+   *
+   * Gated on an active XR session because this script is mounted unconditionally (VirtualWalkthroughViewer
+   * doesn't wrap it in an `!isCurrentlyInXr` check the way it does WalkthroughCamera and AutoRotator), so
+   * postUpdate runs on desktop too. Desktop bounding — including deliberately skipping it in free-fly — is
+   * WalkthroughCamera's job; this script must stay a no-op outside XR regardless of how it's mounted.
    */
   postUpdate() {
     this.clampDistance = 0;
 
     const camera = (this as unknown as XrNavigationInternals)._cameraEntity;
-    if (!camera || this.boundsRadius <= 0) {
+    if (!this.app.xr?.active || !camera || this.boundsRadius <= 0) {
       return;
     }
 

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -136,6 +136,17 @@ const VirtualWalkthroughViewer = ({
     }
   }, [cameraGroundPlane, app]);
 
+  useEffect(() => {
+    // Set imperatively for the same reason as BoundaryRing: boundsCenter is a Vec3, and the
+    // @playcanvas/react memo() comparator stops at the first prop with an .equals() method.
+    // @ts-expect-error - scripts are added dynamically to the entity
+    const navigation = app.root.findByName('camera-root')?.script?.tfXrNavigation;
+    if (navigation) {
+      navigation.boundsCenter = cameraBoundsCenter;
+      navigation.boundsRadius = sceneBoundsRadius * scaleFactor;
+    }
+  }, [app, cameraBoundsCenter, sceneBoundsRadius, scaleFactor]);
+
   const handleToggleFreeFly = useCallback(() => {
     const newFreeFly = !isFreeFly;
     // @ts-expect-error - scripts are added dynamically to the camera entity


### PR DESCRIPTION
With the math defined, update the navigation script to actually clamp to scene bounds as needed. Include the scene bounds as inputs to the script.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>