### PR TITLE
SW-8691 Add support for Streamed SOG models

### DIFF
--- a/src/components/VirtualWalkthrough/SplatModel.tsx
+++ b/src/components/VirtualWalkthrough/SplatModel.tsx
@@ -8,9 +8,16 @@ import BlockingSpinner from './BlockingSpinner';
 import SplatCrop from './SplatCrop';
 import SplatFadeCrop from './SplatFadeCrop';
 import SplatRevealRain from './SplatRevealRain';
+import { SplatFormat, detectSplatFormat, splatLoaderFilename } from './splatFormat';
 
 export interface SplatModelProps {
   splatSrc: string;
+  /**
+   * Splat format of `splatSrc`. Inferred from the URL when omitted, which covers bundled `.sog`,
+   * unbundled sog (`meta.json`), streamed LOD sog (`lod-meta.json`) and `.ply` sources. Set this
+   * explicitly when the URL hides the filename.
+   */
+  splatFormat?: SplatFormat;
   rotation?: [number, number, number];
   cropAabbMin?: [number, number, number];
   cropAabbMax?: [number, number, number];
@@ -23,6 +30,7 @@ export interface SplatModelProps {
 
 const SplatModel = ({
   splatSrc,
+  splatFormat,
   rotation,
   cropAabbMin,
   cropAabbMax,
@@ -32,8 +40,10 @@ const SplatModel = ({
   revealRain = false,
   onError,
 }: SplatModelProps) => {
-  // A filename is required for the file props to assist with the asset loading. Otherwise it assumes that the splatSrc is a ply file.
-  const { asset, loading, error } = useSplat(splatSrc, { file: { filename: 'model.sog' } });
+  // The loader selects its parser from this filename rather than from splatSrc, so it has to name the
+  // format we are actually loading. See splatFormat.ts.
+  const filename = splatLoaderFilename(splatFormat ?? detectSplatFormat(splatSrc));
+  const { asset, loading, error } = useSplat(splatSrc, { file: { filename } });
 
   useEffect(() => {
     if (error) {

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -25,6 +25,7 @@ import XrAnnotationInteraction from './XrAnnotationInteraction';
 import XrExitButton from './XrExitButton';
 import XrGazeDwell from './XrGazeDwell';
 import XrPointerRay from './XrPointerRay';
+import { SplatFormat } from './splatFormat';
 import { WalkthroughCamera } from './walkthrough-camera';
 import { rayHitsInteractiveUi } from './xr-interactive-ui';
 
@@ -39,6 +40,7 @@ const WALL_INSET = 0.25;
 
 export interface VirtualWalkthroughViewerProps {
   splatSrc: string;
+  splatFormat?: SplatFormat;
   origin?: [number, number, number];
   cameraPosition?: [number, number, number];
   sceneBounds?: { x: number; y: number; z: number; m: number };
@@ -59,6 +61,7 @@ export interface VirtualWalkthroughViewerProps {
 
 const VirtualWalkthroughViewer = ({
   splatSrc,
+  splatFormat,
   origin = DEFAULT_FOCUS_POINT,
   cameraPosition = DEFAULT_POSITION,
   sceneBounds,
@@ -294,8 +297,16 @@ const VirtualWalkthroughViewer = ({
   );
 
   const splatModel = useMemo(
-    () => <SplatModel key='splat' splatSrc={splatSrc} rotation={[-180, 0, 0]} revealRain={isHighPerformance} />,
-    [isHighPerformance, splatSrc]
+    () => (
+      <SplatModel
+        key='splat'
+        splatSrc={splatSrc}
+        splatFormat={splatFormat}
+        rotation={[-180, 0, 0]}
+        revealRain={isHighPerformance}
+      />
+    ),
+    [isHighPerformance, splatSrc, splatFormat]
   );
 
   return (

--- a/src/components/VirtualWalkthrough/splatFormat.test.ts
+++ b/src/components/VirtualWalkthrough/splatFormat.test.ts
@@ -1,0 +1,66 @@
+import { detectSplatFormat, splatLoaderFilename } from './splatFormat';
+
+describe('detectSplatFormat', () => {
+  it('detects a bundled .sog archive', () => {
+    expect(detectSplatFormat('https://example.com/scenes/7154.sog')).toBe('sog');
+  });
+
+  it('detects an unbundled sog meta.json', () => {
+    expect(detectSplatFormat('https://example.com/scenes/7154/meta.json')).toBe('sogUnbundled');
+  });
+
+  it('detects a streamed LOD sog lod-meta.json', () => {
+    expect(detectSplatFormat('https://example.com/scenes/7154/lod-meta.json')).toBe('sogStreamed');
+  });
+
+  it('detects a .ply model', () => {
+    expect(detectSplatFormat('https://example.com/scenes/7154.ply')).toBe('ply');
+  });
+
+  it('ignores query strings on signed urls', () => {
+    expect(detectSplatFormat('https://example.com/7154/meta.json?rlkey=abc123&raw=1')).toBe('sogUnbundled');
+  });
+
+  it('ignores url fragments', () => {
+    expect(detectSplatFormat('https://example.com/7154/lod-meta.json#frag')).toBe('sogStreamed');
+  });
+
+  it('is case insensitive', () => {
+    expect(detectSplatFormat('https://example.com/7154/Meta.JSON')).toBe('sogUnbundled');
+    expect(detectSplatFormat('https://example.com/7154.SOG')).toBe('sog');
+  });
+
+  it('handles a bare filename with no directory', () => {
+    expect(detectSplatFormat('meta.json')).toBe('sogUnbundled');
+  });
+
+  it('does not mistake lod-meta.json for the unbundled format', () => {
+    expect(detectSplatFormat('https://example.com/lod-meta.json')).not.toBe('sogUnbundled');
+  });
+
+  it('does not treat an arbitrary .json file as a sog manifest', () => {
+    expect(detectSplatFormat('https://example.com/scene.json')).toBe('sog');
+  });
+
+  it('falls back to the bundled sog format for extensionless urls', () => {
+    expect(detectSplatFormat('https://example.com/assets/abc123?raw=1')).toBe('sog');
+  });
+});
+
+describe('splatLoaderFilename', () => {
+  it('maps the bundled format to a .sog filename so the loader picks the sog bundle parser', () => {
+    expect(splatLoaderFilename('sog')).toBe('model.sog');
+  });
+
+  it('maps the unbundled format to meta.json so the loader picks the plain sog parser', () => {
+    expect(splatLoaderFilename('sogUnbundled')).toBe('meta.json');
+  });
+
+  it('maps the streamed format to the exact basename the octree parser matches on', () => {
+    expect(splatLoaderFilename('sogStreamed')).toBe('lod-meta.json');
+  });
+
+  it('maps ply to a .ply filename', () => {
+    expect(splatLoaderFilename('ply')).toBe('model.ply');
+  });
+});

--- a/src/components/VirtualWalkthrough/splatFormat.ts
+++ b/src/components/VirtualWalkthrough/splatFormat.ts
@@ -1,0 +1,57 @@
+/*
+ * The playcanvas gsplat loader picks its parser from the asset's `filename`, not from the URL it
+ * actually downloads, because a splat is frequently served from a signed or extensionless URL. Each
+ * supported format therefore maps to a canonical filename whose extension/basename routes the asset
+ * to the matching engine parser:
+ *
+ *   model.sog     -> SogBundleParser      sog packed into a single zip archive
+ *   meta.json     -> SogParser            the same sog data left unpacked as separate files
+ *   lod-meta.json -> GSplatOctreeParser   sog with LOD levels, streamed in as the camera moves
+ *   model.ply     -> PlyParser
+ *
+ * `sog` and `sogUnbundled` are two packagings of one format, not two formats: both parsers build a
+ * GSplatSogData/GSplatSogResource and both await every texture before the resource exists. Only
+ * `sogStreamed` streams — playcanvas.d.ts on GSplatOctreeResource#numSplats: "Not all of these are
+ * resident at runtime: the LOD streaming system selects a subset per node based on view distance and
+ * the configured splat budget."
+ *
+ * Only the filename is faked; the textures an unbundled or streamed sog references are still
+ * resolved relative to the real URL, so no rewriting of splatSrc is needed.
+ */
+const LOADER_FILENAMES = {
+  sog: 'model.sog',
+  sogUnbundled: 'meta.json',
+  sogStreamed: 'lod-meta.json',
+  ply: 'model.ply',
+} as const;
+
+export type SplatFormat = keyof typeof LOADER_FILENAMES;
+
+/**
+ * Format assumed when a URL is too opaque to tell us anything. Kept as the bundled `.sog` archive so
+ * that existing extensionless splat URLs keep loading the way they did before the other formats were
+ * supported.
+ */
+export const DEFAULT_SPLAT_FORMAT: SplatFormat = 'sog';
+
+export const splatLoaderFilename = (format: SplatFormat): string => LOADER_FILENAMES[format];
+
+export const detectSplatFormat = (splatSrc: string): SplatFormat => {
+  const path = splatSrc.split(/[?#]/)[0];
+  const basename = path.slice(path.lastIndexOf('/') + 1).toLowerCase();
+
+  if (basename === 'lod-meta.json') {
+    return 'sogStreamed';
+  }
+  if (basename === 'meta.json') {
+    return 'sogUnbundled';
+  }
+  if (basename.endsWith('.ply')) {
+    return 'ply';
+  }
+  if (basename.endsWith('.sog')) {
+    return 'sog';
+  }
+
+  return DEFAULT_SPLAT_FORMAT;
+};

--- a/src/stories/VirtualWalkthroughViewer.stories.tsx
+++ b/src/stories/VirtualWalkthroughViewer.stories.tsx
@@ -18,6 +18,12 @@ export default {
     // rebuilding. Defaults to a remote hosted .sog/.ply URL; paste your own to
     // swap scenes.
     splatSrc: { control: 'text' },
+    // The format is inferred from splatSrc, so leave this unset unless the URL
+    // hides the filename (signed download URLs) and the guess is wrong.
+    splatFormat: {
+      control: 'select',
+      options: [undefined, 'sog', 'sogUnbundled', 'sogStreamed', 'ply'],
+    },
   },
 };
 

--- a/src/virtualWalkthrough.ts
+++ b/src/virtualWalkthrough.ts
@@ -25,6 +25,7 @@ import { TfXrNavigation } from './components/VirtualWalkthrough/TfXrNavigation';
 import VirtualWalkthroughViewer from './components/VirtualWalkthrough/VirtualWalkthroughViewer';
 import { BoundaryRingScript, boundaryRingMesh } from './components/VirtualWalkthrough/boundary-ring';
 import { computeGroundPlane, yOnPlane } from './components/VirtualWalkthrough/groundPlane';
+import { detectSplatFormat, splatLoaderFilename } from './components/VirtualWalkthrough/splatFormat';
 import { WalkthroughCamera } from './components/VirtualWalkthrough/walkthrough-camera';
 import { useDevicePerformance } from './hooks/useDevicePerformance';
 
@@ -37,6 +38,7 @@ export type { BoundaryRingGeometry, BoundaryRingGeometryParams } from './compone
 export type { GroundPlane } from './components/VirtualWalkthrough/groundPlane';
 export type { BoundaryRingProps } from './components/VirtualWalkthrough/BoundaryRing';
 export type { SplatModelProps } from './components/VirtualWalkthrough/SplatModel';
+export type { SplatFormat } from './components/VirtualWalkthrough/splatFormat';
 export type { VirtualWalkthroughViewerProps } from './components/VirtualWalkthrough/VirtualWalkthroughViewer';
 
 export {
@@ -52,10 +54,12 @@ export {
   CameraInfo,
   computeGroundPlane,
   ControlsInfoPane,
+  detectSplatFormat,
   GradientSky,
   SplatControls,
   SplatCrop,
   SplatFadeCrop,
+  splatLoaderFilename,
   SplatModel,
   SplatRevealRain,
   TfAnnotationManager,


### PR DESCRIPTION
Playcanvas created a new Streamed SOG format for faster rendering of large gsplat models. 
Add support for this to VirtualWalkthroughViewer.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>