### PR TITLE
Fix PhotosCarousel default import of react-multi-carousel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "4.2.25",
+  "version": "4.2.26-rc.0",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/PhotosCarousel/index.tsx
+++ b/src/components/PhotosCarousel/index.tsx
@@ -1,11 +1,19 @@
 import React, { type JSX, useCallback, useEffect, useRef, useState } from 'react';
-import Carousel from 'react-multi-carousel';
+import CarouselImport from 'react-multi-carousel';
 import 'react-multi-carousel/lib/styles.css';
 
 import { Box, Typography } from '@mui/material';
 
 import BusySpinner from '../BusySpinner';
 import './styles.scss';
+
+// react-multi-carousel is CommonJS compiled by TypeScript, so it exports the component as
+// `exports.default` alongside an `__esModule` flag. We publish native ES modules, where the
+// default import of a CommonJS module is the whole `module.exports` object and no bundler
+// unwraps `.default` for us. Unwrap it here; the `??` keeps this correct under bundlers that
+// do apply the legacy interop.
+type CarouselInstance = InstanceType<typeof CarouselImport>;
+const Carousel = (CarouselImport as unknown as { default?: typeof CarouselImport }).default ?? CarouselImport;
 
 export type PhotoItem = {
   url: string;
@@ -34,7 +42,7 @@ export default function PhotosCarousel(props: PhotosCarouselProps): JSX.Element 
   const isControlled = selectedSlide !== undefined;
   const [internalSlide, setInternalSlide] = useState(0);
   const [isLoading, setIsLoading] = useState<boolean[]>([]);
-  const myCarousel = useRef<Carousel>(null);
+  const myCarousel = useRef<CarouselInstance>(null);
   const currentSlide = isControlled ? selectedSlide : internalSlide;
 
   // Keyed on the URLs (not just photos.length) so swapping in a same-length array of


### PR DESCRIPTION
Since we began publishing dist/ as native ES modules (eb23d57f5),
`import Carousel from 'react-multi-carousel'` resolves to the package's whole
`module.exports` object rather than the component, so consumers builds fail 
at runtime when PhotosCarousel renders.

react-multi-carousel is CommonJS compiled from TypeScript, so it ships the
`exports.default` + `__esModule` shape that relies on a compiler-emitted
interop helper to unwrap. Our dist Babel config applies no module transform,
so no such helper is emitted, and `"type": "module"` puts both bundlers into
Node-spec ESM mode where the default import of a CommonJS module is defined
to be `module.exports` verbatim — `__esModule` is deliberately ignored.

Unwrap the nested default at the import site. The `??` keeps this correct
under bundlers that do still apply the legacy interop.

`Carousel` was also used as a type for the ref, which a const binding cannot
provide, so derive `CarouselInstance` via `InstanceType` for `useRef`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>