### PR TITLE
Scale walkthrough camera targets by the scene scaleFactor

### DIFF
--- a/src/components/VirtualWalkthrough/Annotation.tsx
+++ b/src/components/VirtualWalkthrough/Annotation.tsx
@@ -9,6 +9,7 @@ import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 
 import { useCameraPosition } from '../../hooks/useCameraPosition';
 import './annotation-styles.css';
+import { toWorldScale } from './scene-scale';
 
 export type AnnotationIconType = 'text' | 'image' | 'video';
 
@@ -54,8 +55,10 @@ export interface AnnotationProps {
  * @param props.isSelected - Optional flag indicating if this annotation is selected. Defaults to false
  * @param props.onSelect - Optional callback when annotation is clicked in edit mode
  * @param props.onPositionChange - Optional callback when annotation position changes
+ * @param props.scaleFactor - Scale applied to the scene by content-root, used to convert this
+ *   annotation's scene-space coordinates to world space for the camera. Defaults to 1
  */
-const Annotation = (props: AnnotationProps & { index: number }) => {
+const Annotation = (props: AnnotationProps & { index: number; scaleFactor?: number }) => {
   const {
     position,
     cameraPosition,
@@ -73,6 +76,7 @@ const Annotation = (props: AnnotationProps & { index: number }) => {
     onView,
     onScreenPositionUpdate,
     index,
+    scaleFactor = 1,
   } = props;
   const app = useApp();
   const { setCamera } = useCameraPosition();
@@ -86,6 +90,7 @@ const Annotation = (props: AnnotationProps & { index: number }) => {
   const onScreenPositionUpdateRef = useRef(onScreenPositionUpdate);
   const positionRef = useRef(position);
   const cameraPositionRef = useRef(cameraPosition);
+  const scaleFactorRef = useRef(scaleFactor);
   const annotationForViewRef = useRef<AnnotationProps>({
     position,
     title,
@@ -102,8 +107,21 @@ const Annotation = (props: AnnotationProps & { index: number }) => {
     onScreenPositionUpdateRef.current = onScreenPositionUpdate;
     positionRef.current = position;
     cameraPositionRef.current = cameraPosition;
+    scaleFactorRef.current = scaleFactor;
     annotationForViewRef.current = { position, title, label, bodyText, imageUrls, cameraPosition };
-  }, [isEdit, onSelect, onView, onScreenPositionUpdate, position, cameraPosition, title, label, bodyText, imageUrls]);
+  }, [
+    isEdit,
+    onSelect,
+    onView,
+    onScreenPositionUpdate,
+    position,
+    cameraPosition,
+    scaleFactor,
+    title,
+    label,
+    bodyText,
+    imageUrls,
+  ]);
 
   // Create a stable callback that reads from refs, because this is read from TfAnnotationManager when the annotation is added to the scene
   const handleClick = useCallback(
@@ -111,7 +129,12 @@ const Annotation = (props: AnnotationProps & { index: number }) => {
       if (isEditRef.current) {
         onSelectRef.current?.();
       } else {
-        setCamera(positionRef.current, cameraPositionRef.current, VIEW_HORIZONTAL_NDC_BIAS);
+        const scale = scaleFactorRef.current;
+        setCamera(
+          toWorldScale(positionRef.current, scale),
+          cameraPositionRef.current && toWorldScale(cameraPositionRef.current, scale),
+          VIEW_HORIZONTAL_NDC_BIAS
+        );
         if (onViewRef.current && screenX !== undefined && screenY !== undefined) {
           onViewRef.current(annotationForViewRef.current, screenX, screenY);
         }

--- a/src/components/VirtualWalkthrough/SplatControls.tsx
+++ b/src/components/VirtualWalkthrough/SplatControls.tsx
@@ -14,6 +14,7 @@ import { AnnotationProps } from './Annotation';
 import AnnotationEditPane, { AnnotationEditPaneStrings } from './AnnotationEditPane';
 import CameraInfo, { CameraInfoStrings } from './CameraInfo';
 import ControlsInfoPane, { ControlsInfoPaneStrings } from './ControlsInfoPane';
+import { fromWorldScale } from './scene-scale';
 
 export interface SplatControlsStrings {
   addAnnotation: string;
@@ -33,8 +34,12 @@ export interface SplatControlsStrings {
 
 export interface SplatControlsProps {
   strings: SplatControlsStrings;
+  /** World-space, i.e. already multiplied by the scene scaleFactor. */
   defaultCameraPosition?: [number, number, number];
+  /** World-space, i.e. already multiplied by the scene scaleFactor. */
   defaultCameraFocus?: [number, number, number];
+  /** Scene scale, used to report the camera pose in the coordinates the viewer's props use. */
+  scaleFactor?: number;
   showAnnotations?: boolean;
   onToggleAnnotations?: (show: boolean) => void;
   autoRotate?: boolean;
@@ -67,6 +72,7 @@ const SplatControls = ({
   strings,
   defaultCameraPosition,
   defaultCameraFocus,
+  scaleFactor = 1,
   showAnnotations,
   onToggleAnnotations,
   autoRotate,
@@ -117,6 +123,19 @@ const SplatControls = ({
       window.removeEventListener('keydown', handleKeyPress);
     };
   }, [isEdit, defaultCameraFocus, defaultCameraPosition, setCamera, selectedAnnotation]);
+
+  // CameraInfo exists to author `cameraPosition` / annotation coordinates, so it has to report the
+  // pose in scene space — the camera itself lives in world space, outside the scaled content-root.
+  const getSceneCameraState = useCallback(() => {
+    const state = getCameraState();
+
+    return (
+      state && {
+        position: fromWorldScale(state.position, scaleFactor),
+        focus: fromWorldScale(state.focus, scaleFactor),
+      }
+    );
+  }, [getCameraState, scaleFactor]);
 
   const handleInfo = useCallback(() => {
     setIsInfoVisible((prev) => !prev);
@@ -258,7 +277,7 @@ const SplatControls = ({
         maxImages={maxImagesPerAnnotation}
         onImagesChange={onImagesChange}
       />
-      {isEdit && <CameraInfo strings={strings.cameraInfo} getCameraState={getCameraState} />}
+      {isEdit && <CameraInfo strings={strings.cameraInfo} getCameraState={getSceneCameraState} />}
     </Box>
   );
 };

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -25,6 +25,7 @@ import XrAnnotationInteraction from './XrAnnotationInteraction';
 import XrExitButton from './XrExitButton';
 import XrGazeDwell from './XrGazeDwell';
 import XrPointerRay from './XrPointerRay';
+import { toWorldScale } from './scene-scale';
 import { SplatFormat } from './splatFormat';
 import { WalkthroughCamera } from './walkthrough-camera';
 import { rayHitsInteractiveUi } from './xr-interactive-ui';
@@ -130,9 +131,14 @@ const VirtualWalkthroughViewer = ({
     [groundPlane, scaleFactor]
   );
 
+  // The camera rig lives outside the scaled content-root, so the scene-space focus and eye points
+  // have to be scaled to match the bounds, ground plane and camera height it is already given.
+  const cameraFocus = useMemo(() => toWorldScale(origin, scaleFactor), [origin, scaleFactor]);
+  const cameraEyePosition = useMemo(() => toWorldScale(cameraPosition, scaleFactor), [cameraPosition, scaleFactor]);
+
   useEffect(() => {
-    setCamera(origin, cameraPosition);
-  }, [origin, cameraPosition, setCamera]);
+    setCamera(cameraFocus, cameraEyePosition);
+  }, [cameraFocus, cameraEyePosition, setCamera]);
 
   useEffect(() => {
     if (!cameraGroundPlane.length) {
@@ -165,10 +171,10 @@ const VirtualWalkthroughViewer = ({
       walkthroughCam.freeFly = newFreeFly;
     }
     if (!newFreeFly) {
-      setCamera(origin, cameraPosition);
+      setCamera(cameraFocus, cameraEyePosition);
     }
     setIsFreeFly(newFreeFly);
-  }, [isFreeFly, app, setCamera, origin, cameraPosition]);
+  }, [isFreeFly, app, setCamera, cameraFocus, cameraEyePosition]);
 
   useEffect(() => {
     setLocalAnnotations(annotations);
@@ -392,6 +398,7 @@ const VirtualWalkthroughViewer = ({
                 key={`annotation-${index}`}
                 {...annotation}
                 index={index}
+                scaleFactor={scaleFactor}
                 visible={showAnnotations}
                 isEdit={isEdit}
                 isSelected={selectedAnnotationIndex === index}
@@ -416,8 +423,9 @@ const VirtualWalkthroughViewer = ({
       )}
 
       <SplatControls
-        defaultCameraFocus={origin}
-        defaultCameraPosition={cameraPosition}
+        defaultCameraFocus={cameraFocus}
+        defaultCameraPosition={cameraEyePosition}
+        scaleFactor={scaleFactor}
         showAnnotations={showAnnotations}
         onToggleAnnotations={setShowAnnotations}
         autoRotate={autoRotate}

--- a/src/components/VirtualWalkthrough/scene-scale.test.ts
+++ b/src/components/VirtualWalkthrough/scene-scale.test.ts
@@ -1,0 +1,31 @@
+import { fromWorldScale, toWorldScale } from './scene-scale';
+
+describe('toWorldScale', () => {
+  it('scales every axis by the scale factor', () => {
+    expect(toWorldScale([1, 0.1, -2], 15)).toEqual([15, 1.5, -30]);
+  });
+
+  it('is a no-op at a scale factor of 1', () => {
+    expect(toWorldScale([1, 0.1, -2], 1)).toEqual([1, 0.1, -2]);
+  });
+
+  it('does not mutate the input', () => {
+    const point: [number, number, number] = [1, 2, 3];
+    toWorldScale(point, 15);
+    expect(point).toEqual([1, 2, 3]);
+  });
+});
+
+describe('fromWorldScale', () => {
+  it('round-trips a point scaled to world space', () => {
+    const point: [number, number, number] = [1, 0.1, -2];
+    const [x, y, z] = fromWorldScale(toWorldScale(point, 15), 15);
+    expect(x).toBeCloseTo(1);
+    expect(y).toBeCloseTo(0.1);
+    expect(z).toBeCloseTo(-2);
+  });
+
+  it('passes the point through at a scale factor of 0 rather than dividing by zero', () => {
+    expect(fromWorldScale([1, 2, 3], 0)).toEqual([1, 2, 3]);
+  });
+});

--- a/src/components/VirtualWalkthrough/scene-scale.ts
+++ b/src/components/VirtualWalkthrough/scene-scale.ts
@@ -1,0 +1,19 @@
+/**
+ * Scene-space points — `origin`, `cameraPosition`, annotation positions — are expressed in the
+ * splat's own coordinates, which the `content-root` entity scales by `scaleFactor`. The camera rig
+ * sits outside that entity, so any scene point handed to the camera has to be converted to world
+ * space first, the same way `cameraBoundsCenter` and the ground plane already are.
+ */
+export const toWorldScale = (point: [number, number, number], scaleFactor: number): [number, number, number] => [
+  point[0] * scaleFactor,
+  point[1] * scaleFactor,
+  point[2] * scaleFactor,
+];
+
+/**
+ * Inverse of {@link toWorldScale}, for reporting a camera pose back in the coordinates the viewer's
+ * props are written in. A scaleFactor of 0 collapses the scene, leaving no scene-space point to
+ * report, so the world point is passed through rather than divided into infinities.
+ */
+export const fromWorldScale = (point: [number, number, number], scaleFactor: number): [number, number, number] =>
+  scaleFactor === 0 ? [...point] : toWorldScale(point, 1 / scaleFactor);


### PR DESCRIPTION
The camera rig sits outside content-root, which scales the scene by
scaleFactor, but the focus and eye points handed to WalkthroughCamera.reset
were passed through in scene space. The bounds circle, ground plane and
average camera height were already scaled, so the reset landed the camera a
scaleFactor closer to the middle of the splat than intended - at
scaleFactor 15 that is inside the model.

Convert origin, cameraPosition and annotation coordinates to world space at
the call sites, and report CameraInfo's readout back in scene space so the
poses it is used to author round-trip through the same coordinates.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>