### PR TITLE
SW-8691 Start XR sessions at the scene camera position facing the origin

### DIFF
--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -122,9 +122,6 @@ const VirtualWalkthroughViewer = ({
     const dy = cameraPosition[1] - origin[1];
     const dz = cameraPosition[2] - origin[2];
 
-    // The whole origin-to-camera distance, not half of it: the camera position is a place the user
-    // is meant to be able to stand, so a circle that stopped short of it would clamp them off their
-    // own starting point.
     return Math.sqrt(dx * dx + dy * dy + dz * dz);
   }, [cameraPosition, sceneBounds, origin]);
 

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -369,6 +369,7 @@ const VirtualWalkthroughViewer = ({
           script={TfXrNavigation}
           enabled={!isEdit}
           enableTeleport={!isCurrentlyInAr && !viewingAnnotation}
+          enableSnapVertical={false}
           isTeleportBlocked={isTeleportBlocked}
         />
         {!isCurrentlyInXr && (

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -122,7 +122,10 @@ const VirtualWalkthroughViewer = ({
     const dy = cameraPosition[1] - origin[1];
     const dz = cameraPosition[2] - origin[2];
 
-    return Math.sqrt(dx * dx + dy * dy + dz * dz) * 0.5;
+    // The whole origin-to-camera distance, not half of it: the camera position is a place the user
+    // is meant to be able to stand, so a circle that stopped short of it would clamp them off their
+    // own starting point.
+    return Math.sqrt(dx * dx + dy * dy + dz * dz);
   }, [cameraPosition, sceneBounds, origin]);
 
   const sceneBoundsCenter = useMemo(

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -25,6 +25,7 @@ import XrAnnotationInteraction from './XrAnnotationInteraction';
 import XrExitButton from './XrExitButton';
 import XrGazeDwell from './XrGazeDwell';
 import XrPointerRay from './XrPointerRay';
+import { XrStartPose } from './XrStartPose';
 import { SplatFormat } from './splatFormat';
 import { WalkthroughCamera } from './walkthrough-camera';
 import { rayHitsInteractiveUi } from './xr-interactive-ui';
@@ -355,6 +356,15 @@ const VirtualWalkthroughViewer = ({
         {isCurrentlyInXr && <XrGazeDwell activeIndex={viewingAnnotationIndex} />}
         {/* Teleport is off in AR, where it can be disorienting, and while an annotation panel is open,
             so the trigger can operate the panel and click out to dismiss it. */}
+        {/* Number props rather than a Vec3: @playcanvas/react's memo() comparator stops at the
+            first prop with an .equals() method, so a Vec3 would stop the ones after it updating. */}
+        <Script
+          script={XrStartPose}
+          targetX={cameraPosition[0]}
+          targetZ={cameraPosition[2]}
+          focusX={origin[0]}
+          focusZ={origin[2]}
+        />
         <Script
           script={TfXrNavigation}
           enabled={!isEdit}

--- a/src/components/VirtualWalkthrough/XrStartPose.test.ts
+++ b/src/components/VirtualWalkthrough/XrStartPose.test.ts
@@ -1,0 +1,198 @@
+import { XRTYPE_AR, XRTYPE_VR } from 'playcanvas';
+
+import { XrStartPose } from './XrStartPose';
+
+const DEG_TO_RAD = Math.PI / 180;
+
+type Point3 = { x: number; y: number; z: number };
+
+/** Minimal stand-ins for the pieces of the engine the script touches. */
+const buildRig = ({
+  head = { x: 0, y: 1.7, z: 0 },
+  headForward = { x: 0, z: -1 },
+  headRight = { x: 1, z: 0 },
+  rig = { x: 0, y: 0, z: 0 },
+  navigation,
+}: {
+  head?: Point3;
+  headForward?: { x: number; z: number };
+  headRight?: { x: number; z: number };
+  rig?: Point3;
+  navigation?: { boundsCenter: { x: number; z: number }; boundsRadius: number };
+} = {}) => {
+  const camera = { getPosition: () => head, forward: headForward, right: headRight };
+  const rigPosition = { ...rig };
+  const entity = {
+    enabled: true,
+    script: { enabled: true, tfXrNavigation: navigation },
+    findComponent: (type: string) => (type === 'camera' ? { entity: camera } : null),
+    getPosition: () => rigPosition,
+    rotate: jest.fn((_x: number, y: number) => {
+      entity.yaw += y;
+    }),
+    setPosition: jest.fn((x: number, y: number, z: number) => {
+      rigPosition.x = x;
+      rigPosition.y = y;
+      rigPosition.z = z;
+    }),
+    yaw: 0,
+  };
+
+  return { entity, head, rig, rigPosition };
+};
+
+const buildApp = ({ active = false, type = XRTYPE_VR }: { active?: boolean; type?: string } = {}) => {
+  const handlers = new Map<string, () => void>();
+
+  return {
+    xr: {
+      active,
+      type,
+      on: (event: string, handler: () => void) => handlers.set(event, handler),
+      off: (event: string) => handlers.delete(event),
+    },
+    /** Starts a session the way the engine does: flip `active`, then fire the event. */
+    startSession(sessionType: string = XRTYPE_VR) {
+      this.xr.active = true;
+      this.xr.type = sessionType;
+      handlers.get('start')?.();
+    },
+  };
+};
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const mountScript = (app: any, entity: any) => {
+  const script = new XrStartPose({ app, entity } as any);
+  script.initialize();
+
+  return script;
+};
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+/** Where the head ends up once the rig has been turned about its own origin and moved. */
+const headAfter = (rigBefore: Point3, headBefore: Point3, rigAfter: Point3, yawDelta: number) => {
+  const radians = yawDelta * DEG_TO_RAD;
+  const cos = Math.cos(radians);
+  const sin = Math.sin(radians);
+  const ox = headBefore.x - rigBefore.x;
+  const oz = headBefore.z - rigBefore.z;
+
+  return { x: rigAfter.x + (ox * cos + oz * sin), z: rigAfter.z + (-ox * sin + oz * cos) };
+};
+
+/** Yaw of the heading from `from` to `to`, in PlayCanvas' convention. */
+const headingYaw = (from: { x: number; z: number }, to: { x: number; z: number }) =>
+  (Math.atan2(-(to.x - from.x), -(to.z - from.z)) * 180) / Math.PI;
+
+describe('XrStartPose', () => {
+  it('does nothing before a session starts', () => {
+    const app = buildApp();
+    const { entity } = buildRig();
+    const script = mountScript(app, entity);
+    script.targetX = 5;
+    script.targetZ = -3;
+
+    script.update();
+
+    expect(entity.setPosition).not.toHaveBeenCalled();
+    expect(entity.rotate).not.toHaveBeenCalled();
+  });
+
+  it('lands the head on the target facing the focus on the first frame of a session', () => {
+    const app = buildApp();
+    // Head offset from the rig, i.e. the user standing away from their reference space origin.
+    const head = { x: 2, y: 1.7, z: 1 };
+    const { entity, rig, rigPosition } = buildRig({ head });
+    const script = mountScript(app, entity);
+    script.targetX = 12;
+    script.targetZ = -9;
+    script.focusX = 0;
+    script.focusZ = 0;
+
+    app.startSession();
+    script.update();
+
+    const landed = headAfter(rig, head, rigPosition, entity.yaw);
+    expect(landed.x).toBeCloseTo(12);
+    expect(landed.z).toBeCloseTo(-9);
+    // The head started facing -z (yaw 0), so the rig's turn is the whole heading to the focus.
+    expect(entity.yaw).toBeCloseTo(headingYaw({ x: 12, z: -9 }, { x: 0, z: 0 }));
+  });
+
+  it('places the rig only once per session', () => {
+    const app = buildApp();
+    const { entity } = buildRig();
+    const script = mountScript(app, entity);
+    script.targetX = 4;
+
+    app.startSession();
+    script.update();
+    script.update();
+
+    expect(entity.setPosition).toHaveBeenCalledTimes(1);
+  });
+
+  it('places the rig when mounted into a session that is already running', () => {
+    const app = buildApp({ active: true });
+    const { entity } = buildRig();
+    const script = mountScript(app, entity);
+    script.targetX = 7;
+    script.targetZ = 7;
+
+    script.update();
+
+    expect(entity.setPosition).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves an AR session where it is', () => {
+    const app = buildApp();
+    const { entity } = buildRig();
+    const script = mountScript(app, entity);
+    script.targetX = 5;
+
+    app.startSession(XRTYPE_AR);
+    script.update();
+
+    expect(entity.setPosition).not.toHaveBeenCalled();
+  });
+
+  it('keeps the start point inside the navigation bounds, facing the focus from where it lands', () => {
+    const app = buildApp();
+    const navigation = { boundsCenter: { x: 0, z: -1.5 }, boundsRadius: 15 };
+    const head = { x: 0, y: 1.7, z: 0 };
+    const { entity, rig, rigPosition } = buildRig({ head, navigation });
+    const script = mountScript(app, entity);
+    // 87 m out, well beyond the 15 m circle the head will be held inside.
+    script.targetX = 75;
+    script.targetZ = -45;
+    script.focusX = 0;
+    script.focusZ = 0;
+
+    app.startSession();
+    script.update();
+
+    const landed = headAfter(rig, head, rigPosition, entity.yaw);
+    const distance = Math.hypot(landed.x - navigation.boundsCenter.x, landed.z - navigation.boundsCenter.z);
+    expect(distance).toBeCloseTo(navigation.boundsRadius);
+    // The heading is solved from the clamped landing point, not the target that was asked for.
+    expect(entity.yaw).toBeCloseTo(headingYaw(landed, { x: 0, z: 0 }));
+    expect(entity.yaw).not.toBeCloseTo(headingYaw({ x: 75, z: -45 }, { x: 0, z: 0 }));
+  });
+
+  it('places the head on the target as given when nothing is clamping it', () => {
+    const app = buildApp();
+    const navigation = { boundsCenter: { x: 0, z: 0 }, boundsRadius: 0 };
+    const head = { x: 0, y: 1.7, z: 0 };
+    const { entity, rig, rigPosition } = buildRig({ head, navigation });
+    const script = mountScript(app, entity);
+    script.targetX = 75;
+    script.targetZ = -45;
+
+    app.startSession();
+    script.update();
+
+    const landed = headAfter(rig, head, rigPosition, entity.yaw);
+    expect(landed.x).toBeCloseTo(75);
+    expect(landed.z).toBeCloseTo(-45);
+  });
+});

--- a/src/components/VirtualWalkthrough/XrStartPose.test.ts
+++ b/src/components/VirtualWalkthrough/XrStartPose.test.ts
@@ -61,6 +61,7 @@ const buildApp = ({ active = false, type = XRTYPE_VR }: { active?: boolean; type
       handlers.get('start')?.();
     },
     /** A frame carrying a viewer pose, after which the camera holds a real head transform. */
+    // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
     poseFrame() {
       handlers.get('update')?.();
     },
@@ -71,14 +72,12 @@ const buildApp = ({ active = false, type = XRTYPE_VR }: { active?: boolean; type
   };
 };
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 const mountScript = (app: any, entity: any) => {
-  const script = new XrStartPose({ app, entity } as any);
+  const script = new XrStartPose({ app, entity });
   script.initialize();
 
   return script;
 };
-/* eslint-enable @typescript-eslint/no-explicit-any */
 
 /** Where the head ends up once the rig has been turned about its own origin and moved. */
 const headAfter = (rigBefore: Point3, headBefore: Point3, rigAfter: Point3, yawDelta: number) => {

--- a/src/components/VirtualWalkthrough/XrStartPose.test.ts
+++ b/src/components/VirtualWalkthrough/XrStartPose.test.ts
@@ -1,4 +1,4 @@
-import { XRTYPE_AR, XRTYPE_VR } from 'playcanvas';
+import { XRTYPE_AR, XRTYPE_INLINE, XRTYPE_VR } from 'playcanvas';
 
 import { XrStartPose } from './XrStartPose';
 
@@ -197,13 +197,33 @@ describe('XrStartPose', () => {
     expect(entity.setPosition).toHaveBeenCalledTimes(1);
   });
 
-  it('leaves an AR session where it is', () => {
+  it('places the rig in an AR session too', () => {
+    const app = buildApp();
+    const head = { x: 1, y: 1.7, z: 2 };
+    const { entity, rig, rigPosition } = buildRig({ head });
+    const script = mountScript(app, entity);
+    script.targetX = 8;
+    script.targetZ = -4;
+    script.focusX = 0;
+    script.focusZ = 0;
+
+    app.startSession(XRTYPE_AR);
+    app.poseFrame();
+    script.update();
+
+    const landed = headAfter(rig, head, rigPosition, entity.yaw);
+    expect(landed.x).toBeCloseTo(8);
+    expect(landed.z).toBeCloseTo(-4);
+    expect(entity.yaw).toBeCloseTo(headingYaw({ x: 8, z: -4 }, { x: 0, z: 0 }));
+  });
+
+  it('leaves an inline session where it is', () => {
     const app = buildApp();
     const { entity } = buildRig();
     const script = mountScript(app, entity);
     script.targetX = 5;
 
-    app.startSession(XRTYPE_AR);
+    app.startSession(XRTYPE_INLINE);
     app.poseFrame();
     script.update();
 

--- a/src/components/VirtualWalkthrough/XrStartPose.test.ts
+++ b/src/components/VirtualWalkthrough/XrStartPose.test.ts
@@ -51,11 +51,22 @@ const buildApp = ({ active = false, type = XRTYPE_VR }: { active?: boolean; type
       on: (event: string, handler: () => void) => handlers.set(event, handler),
       off: (event: string) => handlers.delete(event),
     },
-    /** Starts a session the way the engine does: flip `active`, then fire the event. */
+    /**
+     * Starts a session the way the engine does: the session object exists (so `active` is already
+     * true) and 'start' fires once the reference space resolves — both before any head pose.
+     */
     startSession(sessionType: string = XRTYPE_VR) {
       this.xr.active = true;
       this.xr.type = sessionType;
       handlers.get('start')?.();
+    },
+    /** A frame carrying a viewer pose, after which the camera holds a real head transform. */
+    poseFrame() {
+      handlers.get('update')?.();
+    },
+    endSession() {
+      this.xr.active = false;
+      handlers.get('end')?.();
     },
   };
 };
@@ -110,6 +121,7 @@ describe('XrStartPose', () => {
     script.focusZ = 0;
 
     app.startSession();
+    app.poseFrame();
     script.update();
 
     const landed = headAfter(rig, head, rigPosition, entity.yaw);
@@ -119,6 +131,45 @@ describe('XrStartPose', () => {
     expect(entity.yaw).toBeCloseTo(headingYaw({ x: 12, z: -9 }, { x: 0, z: 0 }));
   });
 
+  it('ignores an update that runs before the session has posed', () => {
+    const app = buildApp();
+    // The camera still holds the desktop pose, which sits on the target it was reset to.
+    const head = { x: 5, y: 1.5, z: -3 };
+    const { entity } = buildRig({ head });
+    const script = mountScript(app, entity);
+    script.targetX = 5;
+    script.targetZ = -3;
+
+    // A window.requestAnimationFrame tick scheduled before the session started still runs scripts,
+    // and solving from the desktop pose here would put the rig — and so the head — on the origin.
+    app.startSession();
+    script.update();
+
+    expect(entity.setPosition).not.toHaveBeenCalled();
+
+    app.poseFrame();
+    script.update();
+
+    expect(entity.setPosition).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for a pose again in a second session', () => {
+    const app = buildApp();
+    const { entity } = buildRig();
+    const script = mountScript(app, entity);
+    script.targetX = 6;
+
+    app.startSession();
+    app.poseFrame();
+    script.update();
+    app.endSession();
+
+    app.startSession();
+    script.update();
+
+    expect(entity.setPosition).toHaveBeenCalledTimes(1);
+  });
+
   it('places the rig only once per session', () => {
     const app = buildApp();
     const { entity } = buildRig();
@@ -126,6 +177,7 @@ describe('XrStartPose', () => {
     script.targetX = 4;
 
     app.startSession();
+    app.poseFrame();
     script.update();
     script.update();
 
@@ -139,6 +191,7 @@ describe('XrStartPose', () => {
     script.targetX = 7;
     script.targetZ = 7;
 
+    app.poseFrame();
     script.update();
 
     expect(entity.setPosition).toHaveBeenCalledTimes(1);
@@ -151,6 +204,7 @@ describe('XrStartPose', () => {
     script.targetX = 5;
 
     app.startSession(XRTYPE_AR);
+    app.poseFrame();
     script.update();
 
     expect(entity.setPosition).not.toHaveBeenCalled();
@@ -169,6 +223,7 @@ describe('XrStartPose', () => {
     script.focusZ = 0;
 
     app.startSession();
+    app.poseFrame();
     script.update();
 
     const landed = headAfter(rig, head, rigPosition, entity.yaw);
@@ -189,6 +244,7 @@ describe('XrStartPose', () => {
     script.targetZ = -45;
 
     app.startSession();
+    app.poseFrame();
     script.update();
 
     const landed = headAfter(rig, head, rigPosition, entity.yaw);

--- a/src/components/VirtualWalkthrough/XrStartPose.ts
+++ b/src/components/VirtualWalkthrough/XrStartPose.ts
@@ -17,10 +17,6 @@ type XrStartPoseNavigation = { boundsCenter: { x: number; z: number }; boundsRad
  *
  * Attach to the rig entity — the camera's parent, alongside TfXrNavigation, whose bounds clamp
  * pulls the start point back inside the scene bounds when the camera position sits outside them.
- *
- * AR as well as VR: it is a one-off placement rather than the repeated movement teleport is kept
- * off in AR to avoid, and with teleport off it is the only way an AR user reaches the scene.
- * Inline sessions are left alone — a window onto the scene, not a rig the user stands in.
  */
 export class XrStartPose extends Script {
   static scriptName = 'xrStartPose';

--- a/src/components/VirtualWalkthrough/XrStartPose.ts
+++ b/src/components/VirtualWalkthrough/XrStartPose.ts
@@ -2,11 +2,6 @@ import { Script, XRTYPE_VR } from 'playcanvas';
 
 import { XrStartBounds, xrStartRigPose, yawFromBasis } from './xr-start-pose';
 
-/**
- * Structural shape of the TfXrNavigation instance sharing this entity, kept local so this script
- * does not have to import the navigation script. Read rather than duplicated as props so the circle
- * the start point is placed in is always the one the head will actually be held inside.
- */
 type XrStartPoseNavigation = { boundsCenter: { x: number; z: number }; boundsRadius: number };
 
 /**
@@ -45,14 +40,6 @@ export class XrStartPose extends Script {
 
   /**
    * Whether the engine has written a head pose for this session yet.
-   *
-   * `app.xr.active` goes true the moment the session object exists, but the camera entity keeps
-   * whatever transform it had until a frame carrying a viewer pose arrives. In between, a
-   * `window.requestAnimationFrame` tick scheduled before the session started can still run scripts
-   * (AppBase.tick only skips the update for *XR* frames without a pose), and on that frame the
-   * camera still holds the desktop pose. Solving from it would place the rig as though the user
-   * were already standing at the desktop camera — which, since that is where the target usually is,
-   * lands them back at the world origin.
    */
   private _posed = false;
 
@@ -100,8 +87,7 @@ export class XrStartPose extends Script {
   /**
    * Runs in update rather than on the 'start' event: the engine writes the head pose during
    * xr.update, which precedes the script update in the same tick, so a frame that has posed is the
-   * first point at which there is a real head to solve the rig pose from. Running before postUpdate
-   * also leaves TfXrNavigation's clamp free to act on the same frame if it needs to.
+   * first point at which there is a real head to solve the rig pose from.
    */
   update() {
     if (!this._pending || !this._posed || !this._isVrActive()) {

--- a/src/components/VirtualWalkthrough/XrStartPose.ts
+++ b/src/components/VirtualWalkthrough/XrStartPose.ts
@@ -1,6 +1,13 @@
 import { Script, XRTYPE_VR } from 'playcanvas';
 
-import { xrStartRigPose, yawFromBasis } from './xr-start-pose';
+import { XrStartBounds, xrStartRigPose, yawFromBasis } from './xr-start-pose';
+
+/**
+ * Structural shape of the TfXrNavigation instance sharing this entity, kept local so this script
+ * does not have to import the navigation script. Read rather than duplicated as props so the circle
+ * the start point is placed in is always the one the head will actually be held inside.
+ */
+type XrStartPoseNavigation = { boundsCenter: { x: number; z: number }; boundsRadius: number };
 
 /**
  * Starts a VR session at the scene's camera position rather than at the world origin.
@@ -49,6 +56,21 @@ export class XrStartPose extends Script {
   private _isVrActive = () => this.app.xr?.active === true && this.app.xr?.type === XRTYPE_VR;
 
   /**
+   * The bounds circle to place the start point in, or undefined when nothing is clamping the head.
+   * Resolved per call rather than cached: the React wrapper assigns the bounds to the navigation
+   * script imperatively, so they can land after this script initializes.
+   */
+  private _bounds = (): XrStartBounds | undefined => {
+    // @ts-expect-error - scripts are added dynamically to the entity
+    const navigation = this.entity.script?.tfXrNavigation as XrStartPoseNavigation | undefined;
+    if (!navigation || navigation.boundsRadius <= 0) {
+      return undefined;
+    }
+
+    return { x: navigation.boundsCenter.x, z: navigation.boundsCenter.z, radius: navigation.boundsRadius };
+  };
+
+  /**
    * Runs in update rather than on the 'start' event: the head pose for the frame is written before
    * scripts update (and a frame with no pose skips the update entirely), so this is the first point
    * at which there is a head to solve the rig pose from. Running before postUpdate also leaves
@@ -73,6 +95,7 @@ export class XrStartPose extends Script {
       rig: { x: rig.x, z: rig.z },
       target: { x: this.targetX, z: this.targetZ },
       focus: { x: this.focusX, z: this.focusZ },
+      bounds: this._bounds(),
     });
 
     this.entity.rotate(0, pose.yawDelta, 0);

--- a/src/components/VirtualWalkthrough/XrStartPose.ts
+++ b/src/components/VirtualWalkthrough/XrStartPose.ts
@@ -1,11 +1,11 @@
-import { Script, XRTYPE_VR } from 'playcanvas';
+import { Script, XRTYPE_AR, XRTYPE_VR } from 'playcanvas';
 
 import { XrStartBounds, xrStartRigPose, yawFromBasis } from './xr-start-pose';
 
 type XrStartPoseNavigation = { boundsCenter: { x: number; z: number }; boundsRadius: number };
 
 /**
- * Starts a VR session at the scene's camera position rather than at the world origin.
+ * Starts an immersive session at the scene's camera position rather than at the world origin.
  *
  * PlayCanvas overwrites the camera entity's local transform with the head pose every frame, so the
  * head lands wherever the headset's reference space puts it — near (0, 0) for a rig that has never
@@ -18,7 +18,9 @@ type XrStartPoseNavigation = { boundsCenter: { x: number; z: number }; boundsRad
  * Attach to the rig entity — the camera's parent, alongside TfXrNavigation, whose bounds clamp
  * pulls the start point back inside the scene bounds when the camera position sits outside them.
  *
- * VR only: an AR user is anchored to the room they can see, so moving them is disorienting.
+ * AR as well as VR: it is a one-off placement rather than the repeated movement teleport is kept
+ * off in AR to avoid, and with teleport off it is the only way an AR user reaches the scene.
+ * Inline sessions are left alone — a window onto the scene, not a rig the user stands in.
  */
 export class XrStartPose extends Script {
   static scriptName = 'xrStartPose';
@@ -58,7 +60,7 @@ export class XrStartPose extends Script {
 
   initialize() {
     // Covers mounting into a session that is already running as well as the usual mount before one.
-    this._pending = this._isVrActive();
+    this._pending = this._isXrActive();
     this.app.xr?.on('start', this._onXrStart);
     this.app.xr?.on('update', this._onXrUpdate);
     this.app.xr?.on('end', this._onXrEnd);
@@ -67,7 +69,8 @@ export class XrStartPose extends Script {
     this.once('destroy', () => this._teardown());
   }
 
-  private _isVrActive = () => this.app.xr?.active === true && this.app.xr?.type === XRTYPE_VR;
+  private _isXrActive = () =>
+    this.app.xr?.active === true && (this.app.xr?.type === XRTYPE_VR || this.app.xr?.type === XRTYPE_AR);
 
   /**
    * The bounds circle to place the start point in, or undefined when nothing is clamping the head.
@@ -90,7 +93,7 @@ export class XrStartPose extends Script {
    * first point at which there is a real head to solve the rig pose from.
    */
   update() {
-    if (!this._pending || !this._posed || !this._isVrActive()) {
+    if (!this._pending || !this._posed || !this._isXrActive()) {
       return;
     }
 

--- a/src/components/VirtualWalkthrough/XrStartPose.ts
+++ b/src/components/VirtualWalkthrough/XrStartPose.ts
@@ -43,14 +43,41 @@ export class XrStartPose extends Script {
   /** Set when a session starts, cleared once the rig has been placed. */
   private _pending = false;
 
+  /**
+   * Whether the engine has written a head pose for this session yet.
+   *
+   * `app.xr.active` goes true the moment the session object exists, but the camera entity keeps
+   * whatever transform it had until a frame carrying a viewer pose arrives. In between, a
+   * `window.requestAnimationFrame` tick scheduled before the session started can still run scripts
+   * (AppBase.tick only skips the update for *XR* frames without a pose), and on that frame the
+   * camera still holds the desktop pose. Solving from it would place the rig as though the user
+   * were already standing at the desktop camera — which, since that is where the target usually is,
+   * lands them back at the world origin.
+   */
+  private _posed = false;
+
   private _onXrStart = () => {
     this._pending = true;
+  };
+
+  /** Fired from XrManager.update only after the head pose has been written to the camera. */
+  private _onXrUpdate = () => {
+    this._posed = true;
+  };
+
+  private _onXrEnd = () => {
+    this._posed = false;
   };
 
   initialize() {
     // Covers mounting into a session that is already running as well as the usual mount before one.
     this._pending = this._isVrActive();
     this.app.xr?.on('start', this._onXrStart);
+    this.app.xr?.on('update', this._onXrUpdate);
+    this.app.xr?.on('end', this._onXrEnd);
+    // Script removal fires a 'destroy' event rather than calling a destroy() method, so the
+    // teardown has to be registered as a listener or these handlers outlive the script.
+    this.once('destroy', () => this._teardown());
   }
 
   private _isVrActive = () => this.app.xr?.active === true && this.app.xr?.type === XRTYPE_VR;
@@ -71,13 +98,13 @@ export class XrStartPose extends Script {
   };
 
   /**
-   * Runs in update rather than on the 'start' event: the head pose for the frame is written before
-   * scripts update (and a frame with no pose skips the update entirely), so this is the first point
-   * at which there is a head to solve the rig pose from. Running before postUpdate also leaves
-   * TfXrNavigation's clamp to bring the head inside the bounds on this same frame.
+   * Runs in update rather than on the 'start' event: the engine writes the head pose during
+   * xr.update, which precedes the script update in the same tick, so a frame that has posed is the
+   * first point at which there is a real head to solve the rig pose from. Running before postUpdate
+   * also leaves TfXrNavigation's clamp free to act on the same frame if it needs to.
    */
   update() {
-    if (!this._pending || !this._isVrActive()) {
+    if (!this._pending || !this._posed || !this._isVrActive()) {
       return;
     }
 
@@ -103,7 +130,9 @@ export class XrStartPose extends Script {
     this._pending = false;
   }
 
-  destroy() {
+  private _teardown() {
     this.app.xr?.off('start', this._onXrStart);
+    this.app.xr?.off('update', this._onXrUpdate);
+    this.app.xr?.off('end', this._onXrEnd);
   }
 }

--- a/src/components/VirtualWalkthrough/XrStartPose.ts
+++ b/src/components/VirtualWalkthrough/XrStartPose.ts
@@ -1,0 +1,86 @@
+import { Script, XRTYPE_VR } from 'playcanvas';
+
+import { xrStartRigPose, yawFromBasis } from './xr-start-pose';
+
+/**
+ * Starts a VR session at the scene's camera position rather than at the world origin.
+ *
+ * PlayCanvas overwrites the camera entity's local transform with the head pose every frame, so the
+ * head lands wherever the headset's reference space puts it — near (0, 0) for a rig that has never
+ * been moved. This script moves the rig on the first frame of a session so the head instead starts
+ * at `targetX`/`targetZ` facing `focusX`/`focusZ`.
+ *
+ * Only XZ is touched: the user stands on the rig floor, which the boundary wall is also built
+ * against, so lifting the rig onto the splat's ground plane would put them through it.
+ *
+ * Attach to the rig entity — the camera's parent, alongside TfXrNavigation, whose bounds clamp
+ * pulls the start point back inside the scene bounds when the camera position sits outside them.
+ *
+ * VR only: an AR user is anchored to the room they can see, so moving them is disorienting.
+ */
+export class XrStartPose extends Script {
+  static scriptName = 'xrStartPose';
+
+  /** World-space X the head should start at, i.e. the viewer's `cameraPosition`. */
+  targetX = 0;
+
+  /** World-space Z the head should start at. */
+  targetZ = 0;
+
+  /** World-space X the head should face from there, i.e. the viewer's `origin`. */
+  focusX = 0;
+
+  /** World-space Z the head should face from there. */
+  focusZ = 0;
+
+  /** Set when a session starts, cleared once the rig has been placed. */
+  private _pending = false;
+
+  private _onXrStart = () => {
+    this._pending = true;
+  };
+
+  initialize() {
+    // Covers mounting into a session that is already running as well as the usual mount before one.
+    this._pending = this._isVrActive();
+    this.app.xr?.on('start', this._onXrStart);
+  }
+
+  private _isVrActive = () => this.app.xr?.active === true && this.app.xr?.type === XRTYPE_VR;
+
+  /**
+   * Runs in update rather than on the 'start' event: the head pose for the frame is written before
+   * scripts update (and a frame with no pose skips the update entirely), so this is the first point
+   * at which there is a head to solve the rig pose from. Running before postUpdate also leaves
+   * TfXrNavigation's clamp to bring the head inside the bounds on this same frame.
+   */
+  update() {
+    if (!this._pending || !this._isVrActive()) {
+      return;
+    }
+
+    const camera = this.entity.findComponent('camera')?.entity;
+    if (!camera) {
+      return;
+    }
+
+    const head = camera.getPosition();
+    const rig = this.entity.getPosition();
+    const rigY = rig.y;
+    const pose = xrStartRigPose({
+      head: { x: head.x, z: head.z },
+      headYaw: yawFromBasis(camera.forward, camera.right),
+      rig: { x: rig.x, z: rig.z },
+      target: { x: this.targetX, z: this.targetZ },
+      focus: { x: this.focusX, z: this.focusZ },
+    });
+
+    this.entity.rotate(0, pose.yawDelta, 0);
+    this.entity.setPosition(pose.x, rigY, pose.z);
+    this._pending = false;
+  }
+
+  destroy() {
+    this.app.xr?.off('start', this._onXrStart);
+  }
+}

--- a/src/components/VirtualWalkthrough/xr-start-pose.test.ts
+++ b/src/components/VirtualWalkthrough/xr-start-pose.test.ts
@@ -1,0 +1,138 @@
+import { XrStartPoseInput, xrStartRigPose, yawFromBasis, yawFromDirection } from './xr-start-pose';
+
+/** A point one unit ahead of the origin along the heading `yaw` faces. */
+const pointAtYaw = (yaw: number) => {
+  const radians = (yaw * Math.PI) / 180;
+
+  return { x: -Math.sin(radians), z: -Math.cos(radians) };
+};
+
+/** Where the head ends up once the rig is turned by `yawDelta` and moved to (x, z). */
+const headAfter = (input: XrStartPoseInput) => {
+  const pose = xrStartRigPose(input);
+  const radians = (pose.yawDelta * Math.PI) / 180;
+  const cos = Math.cos(radians);
+  const sin = Math.sin(radians);
+  const ox = input.head.x - input.rig.x;
+  const oz = input.head.z - input.rig.z;
+
+  return { x: pose.x + (ox * cos + oz * sin), z: pose.z + (-ox * sin + oz * cos) };
+};
+
+describe('yawFromDirection', () => {
+  it('reads 0 for the -Z axis, which is PlayCanvas forward', () => {
+    expect(yawFromDirection(0, -1)).toBeCloseTo(0);
+  });
+
+  it('reads 90 for the -X axis', () => {
+    expect(yawFromDirection(-1, 0)).toBeCloseTo(90);
+  });
+
+  it('returns null for a direction with no horizontal component', () => {
+    expect(yawFromDirection(0, 0)).toBeNull();
+  });
+});
+
+describe('yawFromBasis', () => {
+  it('reads the yaw from the forward vector', () => {
+    expect(yawFromBasis({ x: -1, z: 0 }, { x: 0, z: -1 })).toBeCloseTo(90);
+  });
+
+  it('falls back to the right vector when forward is vertical', () => {
+    // Head tipped straight down: forward has no horizontal component, right still faces -Z.
+    expect(yawFromBasis({ x: 0, z: 0 }, { x: 0, z: -1 })).toBeCloseTo(90);
+  });
+});
+
+describe('xrStartRigPose', () => {
+  const origin = { x: 0, z: 0 };
+
+  it('lands the head on the target when the head starts at the rig origin', () => {
+    const pose = xrStartRigPose({
+      head: origin,
+      headYaw: 0,
+      rig: origin,
+      target: { x: 10, z: 0 },
+      focus: origin,
+    });
+
+    expect(pose.x).toBeCloseTo(10);
+    expect(pose.z).toBeCloseTo(0);
+    // Facing -X, back toward the focus point.
+    expect(pose.yawDelta).toBeCloseTo(90);
+  });
+
+  it('offsets the rig so a head standing away from the rig origin still lands on the target', () => {
+    const input: XrStartPoseInput = {
+      head: { x: 2, z: 0 },
+      headYaw: 0,
+      rig: origin,
+      target: origin,
+      focus: { x: 0, z: -10 },
+    };
+    const pose = xrStartRigPose(input);
+
+    expect(pose.yawDelta).toBeCloseTo(0);
+    expect(pose.x).toBeCloseTo(-2);
+    expect(pose.z).toBeCloseTo(0);
+    expect(headAfter(input).x).toBeCloseTo(0);
+    expect(headAfter(input).z).toBeCloseTo(0);
+  });
+
+  it('keeps the head on the target when the turn swings it around the rig origin', () => {
+    const input: XrStartPoseInput = {
+      head: { x: 2, z: 0 },
+      headYaw: 0,
+      rig: origin,
+      target: origin,
+      focus: { x: 10, z: 0 },
+    };
+    const pose = xrStartRigPose(input);
+    const head = headAfter(input);
+
+    expect(pose.yawDelta).toBeCloseTo(-90);
+    expect(head.x).toBeCloseTo(0);
+    expect(head.z).toBeCloseTo(0);
+  });
+
+  it('turns the short way round rather than the long way', () => {
+    const pose = xrStartRigPose({
+      head: origin,
+      headYaw: 170,
+      rig: origin,
+      target: origin,
+      // Facing yaw of -170 degrees: 20 degrees away from 170, not 340.
+      focus: pointAtYaw(-170),
+    });
+
+    expect(pose.yawDelta).toBeCloseTo(20);
+  });
+
+  it('only moves the rig when the focus point sits on the target', () => {
+    const pose = xrStartRigPose({
+      head: { x: 1, z: 1 },
+      headYaw: 45,
+      rig: origin,
+      target: { x: 5, z: 5 },
+      focus: { x: 5, z: 5 },
+    });
+
+    expect(pose.yawDelta).toBe(0);
+    expect(pose.x).toBeCloseTo(4);
+    expect(pose.z).toBeCloseTo(4);
+  });
+
+  it('lands the head on the target from an already-moved, already-turned rig', () => {
+    const input: XrStartPoseInput = {
+      head: { x: 7, z: -3 },
+      headYaw: 125,
+      rig: { x: 4, z: -1 },
+      target: { x: -6, z: 2 },
+      focus: { x: 1, z: 9 },
+    };
+    const head = headAfter(input);
+
+    expect(head.x).toBeCloseTo(-6);
+    expect(head.z).toBeCloseTo(2);
+  });
+});

--- a/src/components/VirtualWalkthrough/xr-start-pose.ts
+++ b/src/components/VirtualWalkthrough/xr-start-pose.ts
@@ -14,7 +14,6 @@ import { clampToCircle } from './xr-scene-bounds';
 
 export type Point2 = { x: number; z: number };
 
-/** The circle the head is held inside, i.e. XR navigation's bounds. */
 export type XrStartBounds = Point2 & { radius: number };
 
 export type XrStartPoseInput = {
@@ -86,11 +85,6 @@ const rotateXz = (point: Point2, degrees: number): Point2 => {
  * Turning the rig swings the head around the rig's origin, so the turn is applied to the head's
  * offset within the rig first and the rig is then placed so that swung offset lands on the target.
  * A focus point on top of the target gives no heading, so the rig is only moved, not turned.
- *
- * The target is clamped into `bounds` here rather than left to XR navigation, which clamps the head
- * on the same frame anyway: the heading has to be solved from where the head actually ends up, or a
- * target outside the circle leaves the user facing beside the focus point by the angle the clamp
- * moved them through.
  */
 export const xrStartRigPose = ({ head, headYaw, rig, target, focus, bounds }: XrStartPoseInput): XrStartPose => {
   const landing = bounds ? clampToCircle(target.x, target.z, bounds.x, bounds.z, bounds.radius) : target;

--- a/src/components/VirtualWalkthrough/xr-start-pose.ts
+++ b/src/components/VirtualWalkthrough/xr-start-pose.ts
@@ -1,0 +1,87 @@
+/**
+ * Where to put the XR rig so the head starts at a chosen spot facing a chosen point.
+ *
+ * PlayCanvas writes the head pose into the camera entity's *local* transform every frame, so the
+ * only thing a scene can move is the rig the camera hangs off. The head sits at an arbitrary offset
+ * within the rig — the reference space is pinned to wherever the user physically stood when the
+ * session began — so the rig pose has to be solved backwards from the head pose rather than set to
+ * the target outright.
+ *
+ * All angles are degrees and all coordinates world-space XZ; Y is left to the caller, since the
+ * user stands on the rig floor rather than on the scene's ground plane.
+ */
+
+export type Point2 = { x: number; z: number };
+
+export type XrStartPoseInput = {
+  /** Where the head is now. */
+  head: Point2;
+  /** Yaw of the head's forward direction now. */
+  headYaw: number;
+  /** Where the rig is now. */
+  rig: Point2;
+  /** Where the head should end up. */
+  target: Point2;
+  /** What the head should face from there. */
+  focus: Point2;
+};
+
+export type XrStartPose = {
+  /** Yaw to turn the rig by, about its own origin. */
+  yawDelta: number;
+  /** Where the rig ends up once turned. */
+  x: number;
+  z: number;
+};
+
+const RAD_TO_DEG = 180 / Math.PI;
+const DEG_TO_RAD = Math.PI / 180;
+
+/** Below this length a direction vector carries no usable heading. */
+const DIRECTION_EPSILON = 1e-6;
+
+/** Wraps to (-180, 180] so the rig always turns the short way round. */
+const normalizeAngle = (degrees: number): number => {
+  const wrapped = ((((degrees + 180) % 360) + 360) % 360) - 180;
+
+  return wrapped === -180 ? 180 : wrapped;
+};
+
+/**
+ * Yaw of a heading on the XZ plane, matching PlayCanvas' right-handed CCW Y rotation:
+ * forward = (-sin(yaw), 0, -cos(yaw)).
+ */
+export const yawFromDirection = (dx: number, dz: number): number | null =>
+  Math.abs(dx) < DIRECTION_EPSILON && Math.abs(dz) < DIRECTION_EPSILON ? null : Math.atan2(-dx, -dz) * RAD_TO_DEG;
+
+/**
+ * Yaw an entity is facing, from its world basis vectors. Falls back to the right vector when the
+ * forward vector is vertical — a head tipped fully up or down still has a heading, but its forward
+ * vector has no horizontal component to read it from.
+ */
+export const yawFromBasis = (forward: { x: number; z: number }, right: { x: number; z: number }): number =>
+  yawFromDirection(forward.x, forward.z) ?? Math.atan2(-right.z, right.x) * RAD_TO_DEG;
+
+/** Rotates a point about the origin by `degrees` of PlayCanvas yaw. */
+const rotateXz = (point: Point2, degrees: number): Point2 => {
+  const radians = degrees * DEG_TO_RAD;
+  const cos = Math.cos(radians);
+  const sin = Math.sin(radians);
+
+  return { x: point.x * cos + point.z * sin, z: -point.x * sin + point.z * cos };
+};
+
+/**
+ * Solves for the rig pose that lands the head on `target` facing `focus`.
+ *
+ * Turning the rig swings the head around the rig's origin, so the turn is applied to the head's
+ * offset within the rig first and the rig is then placed so that swung offset lands on the target.
+ * A focus point on top of the target gives no heading, so the rig is only moved, not turned.
+ */
+export const xrStartRigPose = ({ head, headYaw, rig, target, focus }: XrStartPoseInput): XrStartPose => {
+  const facingYaw = yawFromDirection(focus.x - target.x, focus.z - target.z);
+  const yawDelta = facingYaw === null ? 0 : normalizeAngle(facingYaw - headYaw);
+  const offset = rotateXz({ x: head.x - rig.x, z: head.z - rig.z }, yawDelta);
+
+  return { yawDelta, x: target.x - offset.x, z: target.z - offset.z };
+};

--- a/src/components/VirtualWalkthrough/xr-start-pose.ts
+++ b/src/components/VirtualWalkthrough/xr-start-pose.ts
@@ -10,8 +10,12 @@
  * All angles are degrees and all coordinates world-space XZ; Y is left to the caller, since the
  * user stands on the rig floor rather than on the scene's ground plane.
  */
+import { clampToCircle } from './xr-scene-bounds';
 
 export type Point2 = { x: number; z: number };
+
+/** The circle the head is held inside, i.e. XR navigation's bounds. */
+export type XrStartBounds = Point2 & { radius: number };
 
 export type XrStartPoseInput = {
   /** Where the head is now. */
@@ -24,6 +28,11 @@ export type XrStartPoseInput = {
   target: Point2;
   /** What the head should face from there. */
   focus: Point2;
+  /**
+   * Circle to keep the target inside. Omit (or pass a non-positive radius) to place the head on the
+   * target as given.
+   */
+  bounds?: XrStartBounds;
 };
 
 export type XrStartPose = {
@@ -77,11 +86,17 @@ const rotateXz = (point: Point2, degrees: number): Point2 => {
  * Turning the rig swings the head around the rig's origin, so the turn is applied to the head's
  * offset within the rig first and the rig is then placed so that swung offset lands on the target.
  * A focus point on top of the target gives no heading, so the rig is only moved, not turned.
+ *
+ * The target is clamped into `bounds` here rather than left to XR navigation, which clamps the head
+ * on the same frame anyway: the heading has to be solved from where the head actually ends up, or a
+ * target outside the circle leaves the user facing beside the focus point by the angle the clamp
+ * moved them through.
  */
-export const xrStartRigPose = ({ head, headYaw, rig, target, focus }: XrStartPoseInput): XrStartPose => {
-  const facingYaw = yawFromDirection(focus.x - target.x, focus.z - target.z);
+export const xrStartRigPose = ({ head, headYaw, rig, target, focus, bounds }: XrStartPoseInput): XrStartPose => {
+  const landing = bounds ? clampToCircle(target.x, target.z, bounds.x, bounds.z, bounds.radius) : target;
+  const facingYaw = yawFromDirection(focus.x - landing.x, focus.z - landing.z);
   const yawDelta = facingYaw === null ? 0 : normalizeAngle(facingYaw - headYaw);
   const offset = rotateXz({ x: head.x - rig.x, z: head.z - rig.z }, yawDelta);
 
-  return { yawDelta, x: target.x - offset.x, z: target.z - offset.z };
+  return { yawDelta, x: landing.x - offset.x, z: landing.z - offset.z };
 };


### PR DESCRIPTION
Add scripts to wait for XR start, then place the camera facing in the same location and orientation as in desktop sessions.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>