### PR TITLE
SW-8666 Assume that only the model needs to be scaled

### DIFF
--- a/src/components/VirtualWalkthrough/BoundaryWall.tsx
+++ b/src/components/VirtualWalkthrough/BoundaryWall.tsx
@@ -8,7 +8,6 @@ import { Vec3 } from 'playcanvas';
 import { BoundaryWallScript } from './boundary-wall';
 
 export type BoundaryWallProps = {
-  /** World-space, i.e. already multiplied by the scene scaleFactor. */
   center: Vec3;
   radius: number;
   groundPlane: Vec3[];

--- a/src/components/VirtualWalkthrough/SplatModel.tsx
+++ b/src/components/VirtualWalkthrough/SplatModel.tsx
@@ -19,6 +19,11 @@ export interface SplatModelProps {
    */
   splatFormat?: SplatFormat;
   rotation?: [number, number, number];
+  /**
+   * Scale applied to the splat entity. Splat models come out of reconstruction in their own
+   * arbitrary units, so this is what converts them world units.
+   */
+  scaleFactor?: number;
   cropAabbMin?: [number, number, number];
   cropAabbMax?: [number, number, number];
   cropEdgeScaleFactor?: number;
@@ -32,6 +37,7 @@ const SplatModel = ({
   splatSrc,
   splatFormat,
   rotation,
+  scaleFactor = 1,
   cropAabbMin,
   cropAabbMax,
   cropEdgeScaleFactor,
@@ -60,7 +66,7 @@ const SplatModel = ({
   }
 
   return (
-    <Entity name='splat' rotation={rotation}>
+    <Entity name='splat' rotation={rotation} scale={[scaleFactor, scaleFactor, scaleFactor]}>
       <GSplat asset={asset} unified />
       {(cropAabbMin || cropAabbMax) &&
         (cropFade ? (

--- a/src/components/VirtualWalkthrough/TfAnnotationManager.ts
+++ b/src/components/VirtualWalkthrough/TfAnnotationManager.ts
@@ -1,7 +1,7 @@
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
-import { FILTER_LINEAR, PIXELFORMAT_RGBA8, Texture, Vec3 } from 'playcanvas';
+import { FILTER_LINEAR, PIXELFORMAT_RGBA8, Texture } from 'playcanvas';
 import { AnnotationManager as PcAnnotationManager } from 'playcanvas/scripts/esm/annotations.mjs';
 
 import Icon from '../Icon/Icon';
@@ -29,7 +29,6 @@ export class TfAnnotationManager extends PcAnnotationManager {
   static scriptName = 'tfAnnotationManager';
 
   private _maxWorldSize = 1.0;
-  private _scratchScale = new Vec3();
   private _customParentDom: HTMLElement | null = null;
   private _clickHandlersAttached = new Set<any>();
   private _hotspotBackgroundColor = '#2C8658';
@@ -177,9 +176,9 @@ export class TfAnnotationManager extends PcAnnotationManager {
     super._registerAnnotation(annotation);
     this._applyAnnotationIcon(annotation);
 
-    // Keep the hotspot mesh hidden until the first scale pass clamps it. The annotation entity
-    // starts at unit local scale, so under a scaled content-root the plane would render many world
-    // units across for the frames before _updateAnnotationRotationAndScale runs.
+    // Keep the hotspot mesh hidden until the first scale pass sizes it. The annotation entity
+    // starts at unit scale, so the plane would render a metre across for the frames before
+    // _updateAnnotationRotationAndScale runs.
     const resources = (this as any)._annotationResources.get(annotation);
     if (resources) {
       resources.baseEntity.enabled = false;
@@ -302,8 +301,8 @@ export class TfAnnotationManager extends PcAnnotationManager {
 
   /**
    * Override to also disable the hotspot mesh (not just the DOM) when the annotation is behind the
-   * camera. The base implementation leaves the mesh enabled, so a not-yet-scaled plane under a
-   * scaled content-root would stay huge in view until the camera moves the anchor in front.
+   * camera. The base implementation leaves the mesh enabled, so a not-yet-scaled plane would stay
+   * in view at its full unit size until the camera moves the anchor in front.
    * @private
    */
   _hideAnnotationElements(annotation: any, resources: any) {
@@ -331,14 +330,9 @@ export class TfAnnotationManager extends PcAnnotationManager {
     // The world size that projects to _hotspotSize screen pixels at this distance.
     const targetWorldSize = ((this as any)._hotspotSize / screenHeight) * ((2 * distance) / projMatrix.data[5]);
 
-    // setLocalScale is applied on top of the parent's world scale (e.g. a scaled
-    // content-root), so divide it out to keep the on-screen size independent of it.
-    const parentScale = this._getParentWorldScale(annotation.entity);
-    const unclampedScale = targetWorldSize / parentScale;
-
-    // Clamp in the annotation's own (parent-local) space so maxWorldSize keeps the
-    // same size relative to the model regardless of the content-root scale.
-    const clampedScale = Math.min(unclampedScale, this._maxWorldSize);
+    // Annotations hang off an unscaled parent, so local scale is world scale and maxWorldSize
+    // clamps the hotspot at a size in metres.
+    const clampedScale = Math.min(targetWorldSize, this._maxWorldSize);
 
     const hovered = (this as any)._hoverAnnotation === annotation;
     const hoverScale = hovered ? HOTSPOT_HOVER_SCALE : 1;
@@ -348,8 +342,7 @@ export class TfAnnotationManager extends PcAnnotationManager {
 
     // Scale the hotspot DOM element proportionally when clamped, including the
     // hover growth so it tracks the visible circle. This is a pure screen-space
-    // size, so it uses the true _hotspotSize and the clamp ratio only (never the
-    // parent scale, which the DOM overlay does not inherit).
+    // size, so it uses the true _hotspotSize and the clamp ratio only.
     const resources = (this as any)._annotationResources.get(annotation);
     if (resources) {
       // This branch only runs for annotations in front of the camera, and the scale above is now
@@ -358,27 +351,12 @@ export class TfAnnotationManager extends PcAnnotationManager {
       resources.overlayEntity.enabled = true;
     }
     if (resources && resources.hotspotDom) {
-      const clampRatio = clampedScale / unclampedScale;
+      const clampRatio = clampedScale / targetWorldSize;
       const baseSize = (this as any)._hotspotSize + 5; // Match the +5 from the stylesheet
       const scaledSize = baseSize * clampRatio * hoverScale;
       resources.hotspotDom.style.width = `${scaledSize}px`;
       resources.hotspotDom.style.height = `${scaledSize}px`;
     }
-  }
-
-  /**
-   * World-space uniform scale of the annotation entity's parent (e.g. a scaled
-   * content-root). Returns 1 when there is no parent or it has no scale.
-   * @private
-   */
-  _getParentWorldScale(entity: any) {
-    const parent = entity.parent;
-    if (!parent) {
-      return 1;
-    }
-    parent.getWorldTransform().getScale(this._scratchScale);
-
-    return this._scratchScale.x || 1;
   }
 
   /**

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -34,20 +34,39 @@ const DEFAULT_POSITION: [number, number, number] = [1, 0.1, 0];
 
 // How far outside the clamp radius the boundary wall stands. Without it the wall would be coplanar
 // with the surface the head is clamped to, so a pinned user would have it in their face and through
-// their near clip plane. Deliberately an absolute world-space distance rather than one scaled by
-// scaleFactor: it is about the size of the user's body, not about the size of the scene.
+// their near clip plane.
 const WALL_INSET = 0.25;
 
+/**
+ * Largest world size (metres) a hotspot is allowed to reach as the camera approaches it, so it
+ * stops growing rather than filling the view from close up.
+ */
+const MAX_HOTSPOT_WORLD_SIZE = 0.75;
+
+/**
+ * Every coordinate, distance and size in this component is world-space, in the metres an XR
+ * headset imposes on the scene: `scaleFactor` converts the splat's own arbitrary units to them,
+ * and is applied to nothing but the splat itself.
+ */
 export interface VirtualWalkthroughViewerProps {
   splatSrc: string;
   splatFormat?: SplatFormat;
+  /** World-space point the camera looks at. */
   origin?: [number, number, number];
+  /** World-space point the camera starts at. */
   cameraPosition?: [number, number, number];
+  /** World-space centre (x, y, z) and radius (m) of the circle the camera is held inside. */
   sceneBounds?: { x: number; y: number; z: number; m: number };
+  /** Three world-space points defining the plane the camera walks on. */
   groundPlane?: [number, number, number][];
   skyColor?: string;
   groundColor?: string;
+  /** Eye height (m) above the ground plane. */
   averageCameraHeight?: number;
+  /**
+   * Scale that converts the splat model's units to the world's metres. Applied to the splat
+   * entity alone — every other coordinate this component takes is already world-space.
+   */
   scaleFactor?: number;
   annotations: AnnotationProps[];
   onSaveAnnotations: (annotations: AnnotationProps[]) => void | Promise<void>;
@@ -113,19 +132,9 @@ const VirtualWalkthroughViewer = ({
     [sceneBounds, origin, cameraPosition]
   );
 
-  const cameraBoundsCenter = useMemo(
-    () => sceneBoundsCenter.clone().mulScalar(scaleFactor),
-    [sceneBoundsCenter, scaleFactor]
-  );
-
   const groundPlane = useMemo<Vec3[]>(
     () => (groundPlaneProp?.length === 3 ? groundPlaneProp.map((p) => new Vec3(p[0], p[1], p[2])) : []),
     [groundPlaneProp]
-  );
-
-  const cameraGroundPlane = useMemo<Vec3[]>(
-    () => groundPlane.map((p) => p.clone().mulScalar(scaleFactor)),
-    [groundPlane, scaleFactor]
   );
 
   useEffect(() => {
@@ -133,16 +142,16 @@ const VirtualWalkthroughViewer = ({
   }, [origin, cameraPosition, setCamera]);
 
   useEffect(() => {
-    if (!cameraGroundPlane.length) {
+    if (!groundPlane.length) {
       return;
     }
     // @ts-expect-error - scripts are added dynamically to the camera entity
     const walkthroughCam = app.root.findByName('camera')?.script?.walkthroughCamera;
     if (walkthroughCam) {
       // Should be changed to a react prop if shallowEquals in playcanvas/react is fixed (see https://github.com/playcanvas/react/pull/298)
-      walkthroughCam.groundPlane = cameraGroundPlane;
+      walkthroughCam.groundPlane = groundPlane;
     }
-  }, [cameraGroundPlane, app]);
+  }, [groundPlane, app]);
 
   useEffect(() => {
     // Set imperatively for the same reason as BoundaryRing: boundsCenter is a Vec3, and the
@@ -150,10 +159,10 @@ const VirtualWalkthroughViewer = ({
     // @ts-expect-error - scripts are added dynamically to the entity
     const navigation = app.root.findByName('camera-root')?.script?.tfXrNavigation;
     if (navigation) {
-      navigation.boundsCenter = cameraBoundsCenter;
-      navigation.boundsRadius = sceneBoundsRadius * scaleFactor;
+      navigation.boundsCenter = sceneBoundsCenter;
+      navigation.boundsRadius = sceneBoundsRadius;
     }
-  }, [app, cameraBoundsCenter, sceneBoundsRadius, scaleFactor]);
+  }, [app, sceneBoundsCenter, sceneBoundsRadius]);
 
   const handleToggleFreeFly = useCallback(() => {
     const newFreeFly = !isFreeFly;
@@ -301,10 +310,11 @@ const VirtualWalkthroughViewer = ({
         splatSrc={splatSrc}
         splatFormat={splatFormat}
         rotation={[-180, 0, 0]}
+        scaleFactor={scaleFactor}
         revealRain={isHighPerformance}
       />
     ),
-    [isHighPerformance, splatSrc, splatFormat]
+    [isHighPerformance, splatSrc, splatFormat, scaleFactor]
   );
 
   return (
@@ -321,13 +331,10 @@ const VirtualWalkthroughViewer = ({
           {!isCurrentlyInXr && (
             <Script
               script={WalkthroughCamera}
-              boundsCenter={cameraBoundsCenter}
-              boundsRadius={sceneBoundsRadius * scaleFactor}
+              boundsCenter={sceneBoundsCenter}
+              boundsRadius={sceneBoundsRadius}
               enableFly={!isTextFieldFocused}
-              averageCameraHeight={scaleFactor * averageCameraHeight}
-              moveSpeed={0.3 * scaleFactor}
-              moveFastSpeed={0.5 * scaleFactor}
-              moveSlowSpeed={0.15 * scaleFactor}
+              averageCameraHeight={averageCameraHeight}
             />
           )}
         </Entity>
@@ -343,7 +350,6 @@ const VirtualWalkthroughViewer = ({
             key={viewingAnnotationIndex}
             annotation={viewingAnnotation}
             annotationIndex={viewingAnnotationIndex}
-            scaleFactor={scaleFactor}
           />
         )}
         {isCurrentlyInXr && <XrGazeDwell activeIndex={viewingAnnotationIndex} />}
@@ -366,7 +372,9 @@ const VirtualWalkthroughViewer = ({
         )}
       </Entity>
 
-      <Entity name='content-root' scale={[scaleFactor, scaleFactor, scaleFactor]}>
+      {/* Deliberately unscaled: the splat carries scaleFactor itself, so everything mounted here
+          shares the one world space the camera rig and the XR head pose already live in. */}
+      <Entity name='content-root'>
         {splatModel}
 
         {sceneBounds?.m !== undefined && groundPlane.length === 3 && (
@@ -379,7 +387,7 @@ const VirtualWalkthroughViewer = ({
               script={TfAnnotationManager}
               enabled={true}
               hotspotSize={30}
-              maxWorldSize={0.05}
+              maxWorldSize={MAX_HOTSPOT_WORLD_SIZE}
               opacity={1}
               hotspotColor={new Color().fromString(theme.palette.TwClrIcnBrand as string)}
               hoverColor={new Color().fromString('#ffffff')}
@@ -406,9 +414,9 @@ const VirtualWalkthroughViewer = ({
 
       {isCurrentlyInXr && sceneBoundsRadius > 0 && (
         <BoundaryWall
-          center={cameraBoundsCenter}
-          radius={sceneBoundsRadius * scaleFactor + WALL_INSET}
-          groundPlane={cameraGroundPlane}
+          center={sceneBoundsCenter}
+          radius={sceneBoundsRadius + WALL_INSET}
+          groundPlane={groundPlane}
           baseY={0}
         />
       )}

--- a/src/components/VirtualWalkthrough/VrAnnotationPanel.tsx
+++ b/src/components/VirtualWalkthrough/VrAnnotationPanel.tsx
@@ -9,10 +9,9 @@ import { VrAnnotationPanel as VrAnnotationPanelScript } from './vr-annotation-pa
 interface VrAnnotationPanelProps {
   annotation: AnnotationProps;
   annotationIndex: number;
-  scaleFactor: number;
 }
 
-const VrAnnotationPanel = ({ annotation, annotationIndex, scaleFactor }: VrAnnotationPanelProps) => (
+const VrAnnotationPanel = ({ annotation, annotationIndex }: VrAnnotationPanelProps) => (
   <Entity name='vr-annotation-panel'>
     <Script
       script={VrAnnotationPanelScript}
@@ -21,7 +20,6 @@ const VrAnnotationPanel = ({ annotation, annotationIndex, scaleFactor }: VrAnnot
       bodyText={annotation.bodyText}
       imageUrls={annotation.imageUrls}
       annotationIndex={annotationIndex}
-      scaleFactor={scaleFactor}
     />
   </Entity>
 );

--- a/src/components/VirtualWalkthrough/boundary-wall.ts
+++ b/src/components/VirtualWalkthrough/boundary-wall.ts
@@ -196,8 +196,6 @@ type BoundaryWallNavigation = { clampDistance: number; enabled?: boolean };
  *
  * center / radius / groundPlane / baseY are set imperatively by the BoundaryWall component (see
  * BoundaryWall.tsx for why they are not reactive Script props), which calls `rebuild()` afterwards.
- * All of them are world-space: this entity is deliberately mounted outside `content-root`, which
- * carries the scene's scaleFactor.
  */
 export class BoundaryWallScript extends Script {
   static scriptName = 'boundaryWall';

--- a/src/components/VirtualWalkthrough/vr-annotation-panel.ts
+++ b/src/components/VirtualWalkthrough/vr-annotation-panel.ts
@@ -21,13 +21,15 @@ import { rayQuadHit } from './xr-ray-quad';
 const CANVAS_WIDTH = 1024;
 const CANVAS_HEIGHT = 768;
 
-/** Panel width in world meters; height derived from the canvas aspect ratio. */
-const PANEL_WIDTH = 0.5;
+const PANEL_WIDTH = 7.5;
 const PANEL_HEIGHT = (PANEL_WIDTH * CANVAS_HEIGHT) / CANVAS_WIDTH;
+
+/** Gap (m) between the top of the hotspot and the bottom edge of the panel. */
+const PANEL_GAP = 0.75;
 
 /** World-space offset from the anchored hotspot: raise the panel above it so the
  * (tall) panel clears the hotspot rather than covering it. */
-const PANEL_OFFSET = new Vec3(0, PANEL_HEIGHT / 2 + 0.05, 0);
+const PANEL_OFFSET = new Vec3(0, PANEL_HEIGHT / 2 + PANEL_GAP, 0);
 
 const PAD_X = 48;
 
@@ -55,7 +57,6 @@ export class VrAnnotationPanel extends Script {
   bodyText?: string;
   imageUrls?: string[];
   annotationIndex = -1;
-  scaleFactor = 1;
 
   private _material?: StandardMaterial;
   private _texture?: Texture;
@@ -342,13 +343,10 @@ export class VrAnnotationPanel extends Script {
       return;
     }
     this._anchor.copy(anchor.getPosition());
-    // Panel size and its offset from the hotspot scale with the scene so the panel keeps its
-    // proportions relative to the (content-root-scaled) annotations across scenes.
-    this.entity.setLocalScale(this.scaleFactor, this.scaleFactor, this.scaleFactor);
     this.entity.setPosition(
-      this._anchor.x + PANEL_OFFSET.x * this.scaleFactor,
-      this._anchor.y + PANEL_OFFSET.y * this.scaleFactor,
-      this._anchor.z + PANEL_OFFSET.z * this.scaleFactor
+      this._anchor.x + PANEL_OFFSET.x,
+      this._anchor.y + PANEL_OFFSET.y,
+      this._anchor.z + PANEL_OFFSET.z
     );
 
     // Billboard on yaw only: face the viewer horizontally but stay upright and level, so

--- a/src/components/VirtualWalkthrough/walkthrough-camera.ts
+++ b/src/components/VirtualWalkthrough/walkthrough-camera.ts
@@ -31,14 +31,13 @@ const POSITION_EPSILON = 1e-5;
 export class WalkthroughCamera extends Script {
   static scriptName = 'walkthroughCamera';
 
-  /** @attribute */
-  moveSpeed = 0.3;
+  moveSpeed = 4.5;
 
   /** @attribute */
-  moveFastSpeed = 0.5;
+  moveFastSpeed = 7.5;
 
   /** @attribute */
-  moveSlowSpeed = 0.15;
+  moveSlowSpeed = 2.25;
 
   /** @attribute */
   lookSensitivity = 0.1;

--- a/src/stories/VirtualWalkthroughViewer.stories.tsx
+++ b/src/stories/VirtualWalkthroughViewer.stories.tsx
@@ -33,7 +33,7 @@ const DEFAULT_SPLAT_SRC =
 
 const sampleAnnotations: AnnotationProps[] = [
   {
-    position: [0.1, 0.05, 0],
+    position: [1.5, 0.75, 0],
     title: 'Mangrove nursery',
     bodyText:
       'Seedlings raised here are transplanted along the coastline to restore the mangrove belt that protects the village from storm surge.',
@@ -43,7 +43,7 @@ const sampleAnnotations: AnnotationProps[] = [
     imageUrls: ['https://picsum.photos/seed/mangrove/800/600'],
   },
   {
-    position: [-0.4, 0.1, -0.3],
+    position: [-6, 1.5, -4.5],
     title: 'Monitoring station',
     bodyText: 'Sensors here track soil moisture and canopy growth over time.',
     icon: 'image',
@@ -54,7 +54,7 @@ const sampleAnnotations: AnnotationProps[] = [
     ],
   },
   {
-    position: [0.45, 0.08, -0.7],
+    position: [6.75, 1.2, -10.5],
     title: 'Community trail',
     label: 'Trail',
     bodyText:
@@ -78,12 +78,13 @@ const Template: Story<Partial<VirtualWalkthroughViewerProps>> = (args) => (
         skyColor={'#4286DC'}
         groundColor={'#98932E'}
         groundPlane={[
-          [-0.15, -0.1, 0],
-          [0.8, -0.1, -0.1],
-          [-0.3, -0.1, -1],
+          [-2.25, -1.5, 0],
+          [12, -1.5, -1.5],
+          [-4.5, -1.5, -15],
         ]}
-        sceneBounds={{ x: 0, y: -0.1, z: -0.1, m: 1 }}
-        averageCameraHeight={0.2}
+        sceneBounds={{ x: 0, y: -1.5, z: -1.5, m: 15 }}
+        averageCameraHeight={3}
+        cameraPosition={[5, 0.1, -3]}
         scaleFactor={15}
         {...args}
       />
@@ -92,6 +93,3 @@ const Template: Story<Partial<VirtualWalkthroughViewerProps>> = (args) => (
 );
 
 export const Default = Template.bind({});
-Default.args = {
-  splatSrc: DEFAULT_SPLAT_SRC,
-};


### PR DESCRIPTION
Previously we passed in a scaleFactor per model which required multiplying everything and passing it to everything else, with a default scale of 1 for all models.
Instead, make the scaleFactor apply to only the gsplat model, and assume everything else is already scaled. 

Because splatter calculates some values at model generation time (e.g. sceneBounds, camera height, ground plane), assume that either terraware-server will apply the scale factor before handing data back (but assumes that it's incapable of scaling the model for us). This allows simpler implementations (virtual-walkthrough-story) to assume that all values can be in world space already. It also paves the way for splatter to determine the scale and apply it to models and data at generation time, thus using a scaleFactor of 1.

This greatly simplifies the logic around scaling and reduces maintenance overhead in the future.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>