### PR TITLE
SW-8691 Reset the camera when an immersive session ends

### DIFF
--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -138,12 +138,21 @@ const VirtualWalkthroughViewer = ({
     [groundPlaneProp]
   );
 
+  // Also runs when a session ends. WalkthroughCamera is unmounted for the duration of a session, so
+  // the camera entity is left holding the last head pose — an eye height above wherever in the rig
+  // the user was standing — which is neither where nor how high the walkthrough left off.
   useEffect(() => {
+    if (isCurrentlyInXr) {
+      return;
+    }
     setCamera(origin, cameraPosition);
-  }, [origin, cameraPosition, setCamera]);
+  }, [origin, cameraPosition, setCamera, isCurrentlyInXr]);
 
+  // Re-applied when a session ends for the same reason: the script that comes back is a new
+  // instance, and without the ground plane it walks the camera at the bounds centre's height
+  // instead of an eye height above the ground.
   useEffect(() => {
-    if (!groundPlane.length) {
+    if (!groundPlane.length || isCurrentlyInXr) {
       return;
     }
     // @ts-expect-error - scripts are added dynamically to the camera entity
@@ -152,7 +161,7 @@ const VirtualWalkthroughViewer = ({
       // Should be changed to a react prop if shallowEquals in playcanvas/react is fixed (see https://github.com/playcanvas/react/pull/298)
       walkthroughCam.groundPlane = groundPlane;
     }
-  }, [groundPlane, app]);
+  }, [groundPlane, app, isCurrentlyInXr]);
 
   useEffect(() => {
     // Set imperatively for the same reason as BoundaryRing: boundsCenter is a Vec3, and the


### PR DESCRIPTION
The head can be anywhere in the scene by the time an XR session ends, which was causing the camera to be in an odd place (often underground) after exiting XR. 
Reset the camera on exit of XR.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>