### PR TITLE
SW-8691 Make AR require mobile, and disable VR for mobile

### DIFF
--- a/src/components/VirtualWalkthrough/SplatControls.tsx
+++ b/src/components/VirtualWalkthrough/SplatControls.tsx
@@ -79,7 +79,7 @@ const SplatControls = ({
 }: SplatControlsProps) => {
   const theme = useTheme();
   const strings = useStrings();
-  const { isDesktop } = useDeviceInfo();
+  const { isDesktop, isMobile } = useDeviceInfo();
   const { setCamera, getCameraState } = useCameraPosition();
   const { isXrAvailable, startXr } = useXr({ onError });
   const [isInfoVisible, setIsInfoVisible] = useBoolean(true);
@@ -179,8 +179,8 @@ const SplatControls = ({
           pointerEvents: 'auto',
         }}
       >
-        {isXrAvailable('AR') && !isEdit && <Button label={strings.AR} onClick={() => startXr('AR')} />}
-        {isXrAvailable('VR') && !isEdit && <Button label={strings.VR} onClick={() => startXr('VR')} />}
+        {isMobile && isXrAvailable('AR') && !isEdit && <Button label={strings.AR} onClick={() => startXr('AR')} />}
+        {!isMobile && isXrAvailable('VR') && !isEdit && <Button label={strings.VR} onClick={() => startXr('VR')} />}
         {isDesktop && editable && !isEdit && onToggleEdit && <Button label={strings.EDIT} onClick={handleEdit} />}
         {isDesktop && showFreeFly && !isEdit && onToggleFreeFly && (
           <Button label={isFreeFly ? strings.BOUNDED_FLY : strings.FREE_FLY} onClick={onToggleFreeFly} />


### PR DESCRIPTION
The AR button didn't do much in a VR headset beyond what VR did. It "felt" slightly different, but was difficult to distinguish the differences.
Remove it for non-mobile, and remove the VR button for mobile.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>