### PR TITLE
Read walkthrough strings from the store instead of props

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,7 +2,21 @@ import React from 'react';
 
 import { StyledEngineProvider, ThemeProvider } from '@mui/material';
 
-import { theme } from '../src/';
+import { getSupportedLocales, setLocale, theme } from '../src/';
+
+const locales = getSupportedLocales(true);
+
+export const globalTypes = {
+  locale: {
+    description: 'Language the components render in',
+    defaultValue: 'en',
+    toolbar: {
+      icon: 'globe',
+      items: locales.map(({ id, name }) => ({ value: id, title: name })),
+      dynamicTitle: true,
+    },
+  },
+};
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
@@ -15,11 +29,15 @@ export const parameters = {
 };
 
 export const decorators = [
-  (Story) => (
-    <ThemeProvider theme={theme}>
-      <StyledEngineProvider injectFirst>
-        <Story />
-      </StyledEngineProvider>
-    </ThemeProvider>
-  ),
+  (Story, context) => {
+    setLocale(context.globals.locale);
+
+    return (
+      <ThemeProvider theme={theme}>
+        <StyledEngineProvider injectFirst>
+          <Story />
+        </StyledEngineProvider>
+      </ThemeProvider>
+    );
+  },
 ];

--- a/src/components/VirtualWalkthrough/AnnotationEditPane.tsx
+++ b/src/components/VirtualWalkthrough/AnnotationEditPane.tsx
@@ -2,34 +2,14 @@ import React, { useCallback, useMemo } from 'react';
 
 import { Box, Fade, ThemeProvider, Tooltip, Typography, useTheme } from '@mui/material';
 
+import { useStrings } from '../../strings';
 import PhotoChooser from '../PhotoChooser';
 import Textfield from '../Textfield/Textfield';
 import { AnnotationProps } from './Annotation';
 
-export interface AnnotationEditPaneStrings {
-  editAnnotation: string;
-  title: string;
-  titleTooltip: string;
-  description: string;
-  descriptionTooltip: string;
-  label: string;
-  labelTooltip: string;
-  images?: {
-    uploadTitle?: string;
-    uploadText?: string;
-    uploadDescription?: string;
-    chooseFileText?: string;
-    replaceFileText?: string;
-    photoSelectedText?: string;
-    existingImagesLabel?: string;
-    newImagesLabel?: string;
-  };
-}
-
 interface AnnotationEditPaneProps {
   visible: boolean;
   annotation: AnnotationProps | null;
-  strings: AnnotationEditPaneStrings;
   onUpdate: (updates: Partial<AnnotationProps>) => void;
   onTextFieldFocus?: (isFocused: boolean) => void;
   maxImages?: number;
@@ -40,13 +20,13 @@ interface AnnotationEditPaneProps {
 const AnnotationEditPane = ({
   visible,
   annotation,
-  strings,
   onUpdate,
   onTextFieldFocus,
   maxImages,
   onImagesChange,
 }: AnnotationEditPaneProps) => {
   const theme = useTheme();
+  const strings = useStrings();
 
   const showImageUpload = !!onImagesChange && !!maxImages && maxImages > 0;
 
@@ -152,12 +132,12 @@ const AnnotationEditPane = ({
           }}
         >
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-            <Typography sx={{ fontWeight: 600 }}>{strings.editAnnotation}</Typography>
+            <Typography sx={{ fontWeight: 600 }}>{strings.EDIT_ANNOTATION}</Typography>
 
-            <Tooltip title={strings.titleTooltip} placement='top' disableFocusListener>
+            <Tooltip title={strings.ANNOTATION_TITLE_TOOLTIP} placement='top' disableFocusListener>
               <Textfield
                 id='annotation-title'
-                label={strings.title}
+                label={strings.TITLE}
                 type='text'
                 value={annotation.title}
                 onChange={handleTitleChange}
@@ -168,10 +148,10 @@ const AnnotationEditPane = ({
               />
             </Tooltip>
 
-            <Tooltip title={strings.descriptionTooltip} placement='top' disableFocusListener>
+            <Tooltip title={strings.ANNOTATION_DESCRIPTION_TOOLTIP} placement='top' disableFocusListener>
               <Textfield
                 id='annotation-body'
-                label={strings.description}
+                label={strings.DESCRIPTION}
                 type='text'
                 value={annotation.bodyText ?? ''}
                 onChange={handleBodyTextChange}
@@ -181,10 +161,10 @@ const AnnotationEditPane = ({
               />
             </Tooltip>
 
-            <Tooltip title={strings.labelTooltip} placement='top' disableFocusListener>
+            <Tooltip title={strings.ANNOTATION_LABEL_TOOLTIP} placement='top' disableFocusListener>
               <Textfield
                 id='annotation-label'
-                label={strings.label}
+                label={strings.LABEL}
                 type='text'
                 value={annotation.label ?? ''}
                 onChange={handleLabelChange}
@@ -196,34 +176,32 @@ const AnnotationEditPane = ({
 
             {showImageUpload && (
               <Box>
-                {strings.images?.uploadTitle && (
-                  <Typography
-                    sx={{
-                      fontFamily: 'Inter',
-                      fontSize: '14px',
-                      fontWeight: 400,
-                      lineHeight: '20px',
-                      color: theme.palette.grey[400],
-                      marginBottom: 0.5,
-                    }}
-                  >
-                    {strings.images.uploadTitle}
-                  </Typography>
-                )}
+                <Typography
+                  sx={{
+                    fontFamily: 'Inter',
+                    fontSize: '14px',
+                    fontWeight: 400,
+                    lineHeight: '20px',
+                    color: theme.palette.grey[400],
+                    marginBottom: 0.5,
+                  }}
+                >
+                  {strings.IMAGES}
+                </Typography>
                 <ThemeProvider theme={photoChooserTheme}>
                   <PhotoChooser
-                    uploadText={strings.images?.uploadText}
-                    uploadDescription={strings.images?.uploadDescription}
-                    chooseFileText={strings.images?.chooseFileText}
-                    replaceFileText={strings.images?.replaceFileText}
-                    photoSelectedText={strings.images?.photoSelectedText}
+                    uploadText={strings.UPLOAD_FILES}
+                    uploadDescription={strings.UPLOAD_FILES_DESCRIPTION}
+                    chooseFileText={strings.CHOOSE_FILE}
+                    replaceFileText={strings.REPLACE_FILE}
+                    photoSelectedText={strings.FILE_SELECTED}
                     multipleSelection={(maxImages ?? 0) > 1}
                     maxPhotos={remainingImageSlots}
                     onPhotosChanged={(files) => onImagesChange?.(files)}
                     existingPhotos={annotation.imageUrls}
                     onExistingPhotoRemoved={handleRemoveExistingImage}
-                    existingImagesLabel={strings.images?.existingImagesLabel}
-                    newImagesLabel={strings.images?.newImagesLabel}
+                    existingImagesLabel={strings.EXISTING}
+                    newImagesLabel={strings.NEW}
                   />
                 </ThemeProvider>
               </Box>

--- a/src/components/VirtualWalkthrough/CameraInfo.tsx
+++ b/src/components/VirtualWalkthrough/CameraInfo.tsx
@@ -2,18 +2,13 @@ import React, { useEffect, useState } from 'react';
 
 import { Box, Typography, useTheme } from '@mui/material';
 
+import { useStrings } from '../../strings';
 import { getRgbaFromHex } from '../../utils/color';
 
 const UPDATE_FREQUENCY_MS = 200;
 const COORDINATE_LABELS = ['X', 'Y', 'Z'] as const;
 
 const formatNumber = (num: number) => num.toFixed(6);
-
-export interface CameraInfoStrings {
-  cameraInfo: string;
-  cameraPosition: string;
-  cameraFocusPoint: string;
-}
 
 export interface CameraState {
   position: [number, number, number];
@@ -44,12 +39,12 @@ const CoordinateDisplay = ({ label, coordinates, textColor }: CoordinateDisplayP
 );
 
 interface CameraInfoProps {
-  strings: CameraInfoStrings;
   getCameraState: () => CameraState | null;
 }
 
-const CameraInfo = ({ strings, getCameraState }: CameraInfoProps) => {
+const CameraInfo = ({ getCameraState }: CameraInfoProps) => {
   const theme = useTheme();
+  const strings = useStrings();
   const [cameraState, setCameraState] = useState<CameraState | null>(null);
 
   useEffect(() => {
@@ -86,11 +81,11 @@ const CameraInfo = ({ strings, getCameraState }: CameraInfoProps) => {
       }}
     >
       <Typography variant='body2' sx={{ color: textColor, fontWeight: 'bold', marginBottom: 1 }}>
-        {strings.cameraInfo}
+        {strings.CAMERA_INFO}
       </Typography>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-        <CoordinateDisplay label={strings.cameraPosition} coordinates={cameraState.position} textColor={textColor} />
-        <CoordinateDisplay label={strings.cameraFocusPoint} coordinates={cameraState.focus} textColor={textColor} />
+        <CoordinateDisplay label={strings.CAMERA_POSITION} coordinates={cameraState.position} textColor={textColor} />
+        <CoordinateDisplay label={strings.CAMERA_FOCUS_POINT} coordinates={cameraState.focus} textColor={textColor} />
       </Box>
     </Box>
   );

--- a/src/components/VirtualWalkthrough/ControlsInfoPane.tsx
+++ b/src/components/VirtualWalkthrough/ControlsInfoPane.tsx
@@ -2,34 +2,11 @@ import React, { useCallback } from 'react';
 
 import { Box, Checkbox, Divider, Fade, Typography, useTheme } from '@mui/material';
 
-export interface ControlsInfoPaneStrings {
-  controls: string;
-  annotations: string;
-  autoRotate: string;
-  orbit: string;
-  leftMouse: string;
-  touchDrag: string;
-  pan: string;
-  middleMouse: string;
-  swipe: string;
-  look: string;
-  rightMouse: string;
-  zoom: string;
-  mouseWheel: string;
-  pinch: string;
-  fly: string;
-  arrowKeys: string;
-  flyFaster: string;
-  shift: string;
-  flySlower: string;
-  ctrl: string;
-  resetCamera: string;
-}
+import { useStrings } from '../../strings';
 
 interface ControlsInfoPaneProps {
   visible: boolean;
   paneRef: React.RefObject<HTMLDivElement | null>;
-  strings: ControlsInfoPaneStrings;
   showAnnotations?: boolean;
   onToggleAnnotations?: (show: boolean) => void;
   autoRotate?: boolean;
@@ -40,7 +17,6 @@ interface ControlsInfoPaneProps {
 const ControlsInfoPane = ({
   visible,
   paneRef,
-  strings,
   showAnnotations,
   onToggleAnnotations,
   autoRotate,
@@ -48,6 +24,7 @@ const ControlsInfoPane = ({
   isFullScreen = false,
 }: ControlsInfoPaneProps) => {
   const theme = useTheme();
+  const strings = useStrings();
 
   const handleAnnotationsChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -108,10 +85,10 @@ const ControlsInfoPane = ({
           }}
         >
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-            <Typography sx={{ fontWeight: 600 }}>{strings.controls}</Typography>
+            <Typography sx={{ fontWeight: 600 }}>{strings.CONTROLS}</Typography>
 
             <Box sx={controlRowSx}>
-              <Typography>{strings.annotations}</Typography>
+              <Typography>{strings.ANNOTATIONS}</Typography>
               <Checkbox
                 checked={showAnnotations ?? true}
                 onChange={handleAnnotationsChange}
@@ -122,7 +99,7 @@ const ControlsInfoPane = ({
             <Divider sx={dividerSx} />
 
             <Box sx={controlRowSx}>
-              <Typography>{strings.autoRotate}</Typography>
+              <Typography>{strings.AUTO_ROTATE}</Typography>
               <Checkbox
                 checked={autoRotate ?? true}
                 onChange={handleAutoRotateChange}
@@ -133,68 +110,68 @@ const ControlsInfoPane = ({
             <Divider sx={dividerSx} />
 
             <Box sx={controlRowSx}>
-              <Typography>{strings.orbit}</Typography>
+              <Typography>{strings.ORBIT}</Typography>
               <Box sx={rightAlignedTextSx}>
-                <Typography>{strings.leftMouse}</Typography>
-                <Typography>{strings.touchDrag}</Typography>
+                <Typography>{strings.LEFT_MOUSE}</Typography>
+                <Typography>{strings.TOUCH_DRAG}</Typography>
               </Box>
             </Box>
 
             <Divider sx={dividerSx} />
 
             <Box sx={controlRowSx}>
-              <Typography>{strings.pan}</Typography>
+              <Typography>{strings.PAN}</Typography>
               <Box sx={rightAlignedTextSx}>
-                <Typography>{strings.middleMouse}</Typography>
-                <Typography>{strings.swipe}</Typography>
+                <Typography>{strings.MIDDLE_MOUSE}</Typography>
+                <Typography>{strings.SWIPE}</Typography>
               </Box>
             </Box>
 
             <Divider sx={dividerSx} />
 
             <Box sx={controlRowSx}>
-              <Typography>{strings.look}</Typography>
-              <Typography>{strings.rightMouse}</Typography>
+              <Typography>{strings.LOOK}</Typography>
+              <Typography>{strings.RIGHT_MOUSE}</Typography>
             </Box>
 
             <Divider sx={dividerSx} />
 
             <Box sx={controlRowSx}>
-              <Typography>{strings.zoom}</Typography>
+              <Typography>{strings.ZOOM}</Typography>
               <Box sx={rightAlignedTextSx}>
-                <Typography>{strings.mouseWheel}</Typography>
-                <Typography>{strings.pinch}</Typography>
+                <Typography>{strings.MOUSE_WHEEL}</Typography>
+                <Typography>{strings.PINCH}</Typography>
               </Box>
             </Box>
 
             <Divider sx={dividerSx} />
 
             <Box sx={controlRowSx}>
-              <Typography>{strings.fly}</Typography>
+              <Typography>{strings.FLY}</Typography>
               <Box sx={rightAlignedTextSx}>
                 <Typography>WASD</Typography>
-                <Typography>{strings.arrowKeys}</Typography>
+                <Typography>{strings.ARROW_KEYS}</Typography>
               </Box>
             </Box>
 
             <Divider sx={dividerSx} />
 
             <Box sx={controlRowSx}>
-              <Typography>{strings.flyFaster}</Typography>
-              <Typography>{strings.shift}</Typography>
+              <Typography>{strings.FLY_FASTER}</Typography>
+              <Typography>{strings.SHIFT}</Typography>
             </Box>
 
             <Divider sx={dividerSx} />
 
             <Box sx={controlRowSx}>
-              <Typography>{strings.flySlower}</Typography>
-              <Typography>{strings.ctrl}</Typography>
+              <Typography>{strings.FLY_SLOWER}</Typography>
+              <Typography>{strings.CTRL}</Typography>
             </Box>
 
             <Divider sx={dividerSx} />
 
             <Box sx={controlRowSx}>
-              <Typography>{strings.resetCamera}</Typography>
+              <Typography>{strings.RESET_CAMERA}</Typography>
               <Typography>R</Typography>
             </Box>
 

--- a/src/components/VirtualWalkthrough/SplatControls.tsx
+++ b/src/components/VirtualWalkthrough/SplatControls.tsx
@@ -6,33 +6,17 @@ import { Box, IconButton, useTheme } from '@mui/material';
 import useBoolean from '../../hooks/useBoolean';
 import { useCameraPosition } from '../../hooks/useCameraPosition';
 import { useXr } from '../../hooks/useXr';
+import { useStrings } from '../../strings';
 import { getRgbaFromHex } from '../../utils/color';
 import useDeviceInfo from '../../utils/useDeviceInfo';
 import Button from '../Button/Button';
 import Icon from '../Icon/Icon';
 import { AnnotationProps } from './Annotation';
-import AnnotationEditPane, { AnnotationEditPaneStrings } from './AnnotationEditPane';
-import CameraInfo, { CameraInfoStrings } from './CameraInfo';
-import ControlsInfoPane, { ControlsInfoPaneStrings } from './ControlsInfoPane';
-
-export interface SplatControlsStrings {
-  addAnnotation: string;
-  deselectAnnotation: string;
-  deleteAnnotation: string;
-  ar: string;
-  vr: string;
-  edit: string;
-  freeFly: string;
-  boundedFly: string;
-  cancel: string;
-  save: string;
-  controlsInfoPane: ControlsInfoPaneStrings;
-  cameraInfo: CameraInfoStrings;
-  annotationEditPane: AnnotationEditPaneStrings;
-}
+import AnnotationEditPane from './AnnotationEditPane';
+import CameraInfo from './CameraInfo';
+import ControlsInfoPane from './ControlsInfoPane';
 
 export interface SplatControlsProps {
-  strings: SplatControlsStrings;
   defaultCameraPosition?: [number, number, number];
   defaultCameraFocus?: [number, number, number];
   showAnnotations?: boolean;
@@ -64,7 +48,6 @@ export interface SplatControlsProps {
 }
 
 const SplatControls = ({
-  strings,
   defaultCameraPosition,
   defaultCameraFocus,
   showAnnotations,
@@ -95,6 +78,7 @@ const SplatControls = ({
   onError,
 }: SplatControlsProps) => {
   const theme = useTheme();
+  const strings = useStrings();
   const { isDesktop } = useDeviceInfo();
   const { setCamera, getCameraState } = useCameraPosition();
   const { isXrAvailable, startXr } = useXr({ onError });
@@ -174,13 +158,13 @@ const SplatControls = ({
           }}
         >
           {!hasSelectedAnnotation && onAddAnnotation && (
-            <Button label={strings.addAnnotation} onClick={onAddAnnotation} />
+            <Button label={strings.ADD_ANNOTATION} onClick={onAddAnnotation} />
           )}
           {hasSelectedAnnotation && onDeselectAnnotation && (
-            <Button label={strings.deselectAnnotation} onClick={onDeselectAnnotation} />
+            <Button label={strings.DESELECT_ANNOTATION} onClick={onDeselectAnnotation} />
           )}
           {hasSelectedAnnotation && onDeleteAnnotation && (
-            <Button label={strings.deleteAnnotation} onClick={onDeleteAnnotation} />
+            <Button label={strings.DELETE_ANNOTATION} onClick={onDeleteAnnotation} />
           )}
         </Box>
       )}
@@ -195,14 +179,14 @@ const SplatControls = ({
           pointerEvents: 'auto',
         }}
       >
-        {isXrAvailable('AR') && !isEdit && <Button label={strings.ar} onClick={() => startXr('AR')} />}
-        {isXrAvailable('VR') && !isEdit && <Button label={strings.vr} onClick={() => startXr('VR')} />}
-        {isDesktop && editable && !isEdit && onToggleEdit && <Button label={strings.edit} onClick={handleEdit} />}
+        {isXrAvailable('AR') && !isEdit && <Button label={strings.AR} onClick={() => startXr('AR')} />}
+        {isXrAvailable('VR') && !isEdit && <Button label={strings.VR} onClick={() => startXr('VR')} />}
+        {isDesktop && editable && !isEdit && onToggleEdit && <Button label={strings.EDIT} onClick={handleEdit} />}
         {isDesktop && showFreeFly && !isEdit && onToggleFreeFly && (
-          <Button label={isFreeFly ? strings.boundedFly : strings.freeFly} onClick={onToggleFreeFly} />
+          <Button label={isFreeFly ? strings.BOUNDED_FLY : strings.FREE_FLY} onClick={onToggleFreeFly} />
         )}
-        {isEdit && onCancel && <Button label={strings.cancel} onClick={onCancel} />}
-        {isEdit && onSave && <Button label={strings.save} onClick={onSave} disabled={!canSave} />}
+        {isEdit && onCancel && <Button label={strings.CANCEL} onClick={onCancel} />}
+        {isEdit && onSave && <Button label={strings.SAVE} onClick={onSave} disabled={!canSave} />}
       </Box>
       {onToggleFullScreen && (
         <IconButton
@@ -241,7 +225,6 @@ const SplatControls = ({
       <ControlsInfoPane
         visible={isInfoVisible}
         paneRef={paneRef}
-        strings={strings.controlsInfoPane}
         showAnnotations={showAnnotations}
         onToggleAnnotations={onToggleAnnotations}
         autoRotate={autoRotate}
@@ -252,13 +235,12 @@ const SplatControls = ({
         key={selectedAnnotationIndex}
         visible={isEdit === true && hasSelectedAnnotation === true}
         annotation={selectedAnnotation ?? null}
-        strings={strings.annotationEditPane}
         onUpdate={onAnnotationUpdate}
         onTextFieldFocus={onTextFieldFocus}
         maxImages={maxImagesPerAnnotation}
         onImagesChange={onImagesChange}
       />
-      {isEdit && <CameraInfo strings={strings.cameraInfo} getCameraState={getCameraState} />}
+      {isEdit && <CameraInfo getCameraState={getCameraState} />}
     </Box>
   );
 };

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -16,7 +16,7 @@ import { AutoRotator } from './AutoRotator';
 import BoundaryRing from './BoundaryRing';
 import BoundaryWall from './BoundaryWall';
 import GradientSky from './GradientSky';
-import SplatControls, { SplatControlsStrings } from './SplatControls';
+import SplatControls from './SplatControls';
 import SplatModel from './SplatModel';
 import { TfAnnotationManager } from './TfAnnotationManager';
 import { TfXrNavigation } from './TfXrNavigation';
@@ -51,7 +51,6 @@ export interface VirtualWalkthroughViewerProps {
   scaleFactor?: number;
   annotations: AnnotationProps[];
   onSaveAnnotations: (annotations: AnnotationProps[]) => void | Promise<void>;
-  strings: SplatControlsStrings;
   editable?: boolean;
   showFreeFly?: boolean;
   isFullScreen?: boolean;
@@ -72,7 +71,6 @@ const VirtualWalkthroughViewer = ({
   scaleFactor = 1,
   annotations,
   onSaveAnnotations,
-  strings,
   editable = false,
   showFreeFly = false,
   isFullScreen = false,
@@ -443,7 +441,6 @@ const VirtualWalkthroughViewer = ({
         isFreeFly={isFreeFly}
         onToggleFreeFly={handleToggleFreeFly}
         showFreeFly={showFreeFly}
-        strings={strings}
       />
 
       <AnnotationPanel

--- a/src/stories/AnnotationEditPane.stories.tsx
+++ b/src/stories/AnnotationEditPane.stories.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { Story } from '@storybook/react';
 
 import { AnnotationProps } from '../components/VirtualWalkthrough/Annotation';
-import AnnotationEditPane, { AnnotationEditPaneStrings } from '../components/VirtualWalkthrough/AnnotationEditPane';
+import AnnotationEditPane from '../components/VirtualWalkthrough/AnnotationEditPane';
 
 export default {
   title: 'AnnotationEditPane',
@@ -12,16 +12,6 @@ export default {
 
 const SAMPLE_IMAGE =
   'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120"><rect width="120" height="120" fill="%234f8a5b"/></svg>';
-
-const sampleStrings: AnnotationEditPaneStrings = {
-  editAnnotation: 'Edit annotation',
-  title: 'Title',
-  titleTooltip: 'The heading shown at the top of the annotation panel.',
-  description: 'Description',
-  descriptionTooltip: 'The body text shown below the title.',
-  label: 'Label',
-  labelTooltip: 'An optional short tag shown above the title.',
-};
 
 // Drives the pane with local state so the fields are editable in the story.
 const Template: Story<Partial<React.ComponentProps<typeof AnnotationEditPane>> & { initialImageUrls?: string[] }> = ({
@@ -39,7 +29,6 @@ const Template: Story<Partial<React.ComponentProps<typeof AnnotationEditPane>> &
   return (
     <AnnotationEditPane
       visible
-      strings={sampleStrings}
       {...args}
       annotation={annotation}
       onUpdate={(updates) => setAnnotation((prev) => ({ ...prev, ...updates }))}
@@ -57,17 +46,6 @@ WithImageUpload.args = {
     // eslint-disable-next-line no-console
     console.log('annotation images changed', files);
   },
-  strings: {
-    ...sampleStrings,
-    images: {
-      uploadTitle: 'Images',
-      uploadText: 'Drag and drop images here',
-      uploadDescription: 'JPEG or PNG, up to 3 images',
-      chooseFileText: 'Choose images',
-      replaceFileText: 'Replace image',
-      photoSelectedText: 'Image selected',
-    },
-  },
 };
 
 export const WithExistingImages = Template.bind({});
@@ -77,18 +55,5 @@ WithExistingImages.args = {
   onImagesChange: (files: File[]) => {
     // eslint-disable-next-line no-console
     console.log('annotation images changed', files);
-  },
-  strings: {
-    ...sampleStrings,
-    images: {
-      uploadTitle: 'Images',
-      uploadText: 'Drag and drop images here',
-      uploadDescription: 'JPEG or PNG, up to 3 images',
-      chooseFileText: 'Choose images',
-      replaceFileText: 'Replace image',
-      photoSelectedText: 'Image selected',
-      existingImagesLabel: 'Existing',
-      newImagesLabel: 'New',
-    },
   },
 };

--- a/src/stories/CameraInfo.stories.tsx
+++ b/src/stories/CameraInfo.stories.tsx
@@ -2,17 +2,11 @@ import React from 'react';
 
 import { Story } from '@storybook/react';
 
-import CameraInfo, { CameraInfoStrings, CameraState } from '../components/VirtualWalkthrough/CameraInfo';
+import CameraInfo, { CameraState } from '../components/VirtualWalkthrough/CameraInfo';
 
 export default {
   title: 'CameraInfo',
   component: CameraInfo,
-};
-
-const sampleStrings: CameraInfoStrings = {
-  cameraInfo: 'Camera info',
-  cameraPosition: 'Position',
-  cameraFocusPoint: 'Focus point',
 };
 
 // A static camera state stands in for the live PlayCanvas state that
@@ -35,7 +29,7 @@ const Template: Story<Partial<React.ComponentProps<typeof CameraInfo>>> = (args)
       borderRadius: 8,
     }}
   >
-    <CameraInfo strings={sampleStrings} getCameraState={() => sampleCameraState} {...args} />
+    <CameraInfo getCameraState={() => sampleCameraState} {...args} />
   </div>
 );
 

--- a/src/stories/ControlsInfoPane.stories.tsx
+++ b/src/stories/ControlsInfoPane.stories.tsx
@@ -2,35 +2,11 @@ import React, { useRef } from 'react';
 
 import { Story } from '@storybook/react';
 
-import ControlsInfoPane, { ControlsInfoPaneStrings } from '../components/VirtualWalkthrough/ControlsInfoPane';
+import ControlsInfoPane from '../components/VirtualWalkthrough/ControlsInfoPane';
 
 export default {
   title: 'ControlsInfoPane',
   component: ControlsInfoPane,
-};
-
-const sampleStrings: ControlsInfoPaneStrings = {
-  controls: 'Controls',
-  annotations: 'Annotations',
-  autoRotate: 'Auto rotate',
-  orbit: 'Orbit',
-  leftMouse: 'Left mouse',
-  touchDrag: 'Touch drag',
-  pan: 'Pan',
-  middleMouse: 'Middle mouse',
-  swipe: 'Swipe',
-  look: 'Look',
-  rightMouse: 'Right mouse',
-  zoom: 'Zoom',
-  mouseWheel: 'Mouse wheel',
-  pinch: 'Pinch',
-  fly: 'Fly',
-  arrowKeys: 'Arrow keys',
-  flyFaster: 'Fly faster',
-  shift: 'Shift',
-  flySlower: 'Fly slower',
-  ctrl: 'Ctrl',
-  resetCamera: 'Reset camera',
 };
 
 // Renders the pane inside a positioned "viewer" so its absolute positioning is
@@ -50,7 +26,7 @@ const Template: Story<Partial<React.ComponentProps<typeof ControlsInfoPane>>> = 
         borderRadius: 8,
       }}
     >
-      <ControlsInfoPane visible strings={sampleStrings} paneRef={paneRef} {...args} />
+      <ControlsInfoPane visible paneRef={paneRef} {...args} />
     </div>
   );
 };

--- a/src/stories/VirtualWalkthroughViewer.stories.tsx
+++ b/src/stories/VirtualWalkthroughViewer.stories.tsx
@@ -5,7 +5,6 @@ import { Story } from '@storybook/react';
 
 import { AnnotationProps } from '../components/VirtualWalkthrough/Annotation';
 import Application from '../components/VirtualWalkthrough/Application';
-import { SplatControlsStrings } from '../components/VirtualWalkthrough/SplatControls';
 import VirtualWalkthroughViewer, {
   VirtualWalkthroughViewerProps,
 } from '../components/VirtualWalkthrough/VirtualWalkthroughViewer';
@@ -31,56 +30,6 @@ export default {
 // so the viewer fetches one over the network at story-view time.
 const DEFAULT_SPLAT_SRC =
   'https://dl.dropboxusercontent.com/scl/fi/qc98eudfcnsdvmfgtjryf/7154.sog?rlkey=170i5e1hdwi7iu3i0cnm0afbu&st=9bqpkpph&raw=1';
-
-const sampleStrings: SplatControlsStrings = {
-  addAnnotation: 'Add annotation',
-  deselectAnnotation: 'Deselect annotation',
-  deleteAnnotation: 'Delete annotation',
-  ar: 'AR',
-  vr: 'VR',
-  edit: 'Edit',
-  freeFly: 'Free fly',
-  boundedFly: 'Bounded fly',
-  cancel: 'Cancel',
-  save: 'Save',
-  controlsInfoPane: {
-    controls: 'Controls',
-    annotations: 'Annotations',
-    autoRotate: 'Auto rotate',
-    orbit: 'Orbit',
-    leftMouse: 'Left mouse',
-    touchDrag: 'Touch drag',
-    pan: 'Pan',
-    middleMouse: 'Middle mouse',
-    swipe: 'Swipe',
-    look: 'Look',
-    rightMouse: 'Right mouse',
-    zoom: 'Zoom',
-    mouseWheel: 'Mouse wheel',
-    pinch: 'Pinch',
-    fly: 'Fly',
-    arrowKeys: 'Arrow keys',
-    flyFaster: 'Fly faster',
-    shift: 'Shift',
-    flySlower: 'Fly slower',
-    ctrl: 'Ctrl',
-    resetCamera: 'Reset camera',
-  },
-  cameraInfo: {
-    cameraInfo: 'Camera info',
-    cameraPosition: 'Position',
-    cameraFocusPoint: 'Focus point',
-  },
-  annotationEditPane: {
-    editAnnotation: 'Edit annotation',
-    title: 'Title',
-    titleTooltip: 'A short name for this annotation',
-    description: 'Description',
-    descriptionTooltip: 'Details shown when the annotation is opened',
-    label: 'Label',
-    labelTooltip: 'Optional short label shown on the hotspot',
-  },
-};
 
 const sampleAnnotations: AnnotationProps[] = [
   {
@@ -124,7 +73,6 @@ const Template: Story<Partial<VirtualWalkthroughViewerProps>> = (args) => (
         splatSrc={DEFAULT_SPLAT_SRC}
         annotations={sampleAnnotations}
         onSaveAnnotations={action('onSaveAnnotations')}
-        strings={sampleStrings}
         editable
         showFreeFly
         skyColor={'#4286DC'}

--- a/src/virtualWalkthrough.ts
+++ b/src/virtualWalkthrough.ts
@@ -30,10 +30,8 @@ import { WalkthroughCamera } from './components/VirtualWalkthrough/walkthrough-c
 import { useDevicePerformance } from './hooks/useDevicePerformance';
 
 export type { AnnotationProps, AnnotationIconType } from './components/VirtualWalkthrough/Annotation';
-export type { AnnotationEditPaneStrings } from './components/VirtualWalkthrough/AnnotationEditPane';
-export type { CameraInfoStrings, CameraState } from './components/VirtualWalkthrough/CameraInfo';
-export type { ControlsInfoPaneStrings } from './components/VirtualWalkthrough/ControlsInfoPane';
-export type { SplatControlsProps, SplatControlsStrings } from './components/VirtualWalkthrough/SplatControls';
+export type { CameraState } from './components/VirtualWalkthrough/CameraInfo';
+export type { SplatControlsProps } from './components/VirtualWalkthrough/SplatControls';
 export type { BoundaryRingGeometry, BoundaryRingGeometryParams } from './components/VirtualWalkthrough/boundary-ring';
 export type { GroundPlane } from './components/VirtualWalkthrough/groundPlane';
 export type { BoundaryRingProps } from './components/VirtualWalkthrough/BoundaryRing';


### PR DESCRIPTION
Drop the strings prop from VirtualWalkthroughViewer and the four nested
*Strings interfaces. 

Breaking change for consumers: the removed types were exported. This is a major version update because of this.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>