### PR TITLE
Fix publish rc on node 24

### DIFF
--- a/.github/workflows/publish-rc.yaml
+++ b/.github/workflows/publish-rc.yaml
@@ -80,6 +80,6 @@ jobs:
 
       - name: Publish npm package
         if: env.UPDATE_NPM_PACKAGE == 'true'
-        run: cd dist && npm publish --scope @terraware
+        run: cd dist && npm publish --scope @terraware --tag rc
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_AUTH_TOKEN }}


### PR DESCRIPTION
npm 11 now explicitly blocks non explicit tag publishing. Set this to rc to fix.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>