### PR TITLE
Adjust XR render tuning to decrease lag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "5.0.0",
+  "version": "5.0.1-rc.0",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terraware/web-components",
-  "version": "5.0.1-rc.0",
+  "version": "5.0.1-rc.1",
   "author": "Terraformation Inc.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/components/VirtualWalkthrough/SplatModel.tsx
+++ b/src/components/VirtualWalkthrough/SplatModel.tsx
@@ -2,7 +2,7 @@ import React, { memo, useEffect } from 'react';
 
 import { Entity } from '@playcanvas/react';
 import { GSplat } from '@playcanvas/react/components';
-import { useSplat } from '@playcanvas/react/hooks';
+import { useApp, useSplat } from '@playcanvas/react/hooks';
 
 import BlockingSpinner from './BlockingSpinner';
 import SplatCrop from './SplatCrop';
@@ -30,6 +30,16 @@ export interface SplatModelProps {
   cropFade?: boolean;
   cropFadeDistance?: number;
   revealRain?: boolean;
+  /**
+   * Maximum allowable budget for splat rendering operations. Only applies to streamed sog models.
+   * A value of 0 means no limit. Left at the engine's default when omitted.
+   */
+  splatBudget?: number;
+  /**
+   * Caps the device pixel ratio the scene renders at, trading sharpness for fill rate on high-DPI
+   * displays. Left at the engine's default when omitted.
+   */
+  maxPixelRatio?: number;
   onError?: (error: Error) => void;
 }
 
@@ -44,12 +54,28 @@ const SplatModel = ({
   cropFade = false,
   cropFadeDistance = 0.5,
   revealRain = false,
+  splatBudget,
+  maxPixelRatio,
   onError,
 }: SplatModelProps) => {
+  const app = useApp();
+
   // The loader selects its parser from this filename rather than from splatSrc, so it has to name the
   // format we are actually loading. See splatFormat.ts.
   const filename = splatLoaderFilename(splatFormat ?? detectSplatFormat(splatSrc));
   const { asset, loading, error } = useSplat(splatSrc, { file: { filename } });
+
+  useEffect(() => {
+    if (!app) {
+      return;
+    }
+    if (splatBudget !== undefined) {
+      app.scene.gsplat.splatBudget = splatBudget;
+    }
+    if (maxPixelRatio !== undefined) {
+      app.graphicsDevice.maxPixelRatio = maxPixelRatio;
+    }
+  }, [app, splatBudget, maxPixelRatio]);
 
   useEffect(() => {
     if (error) {

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -27,6 +27,7 @@ import XrGazeDwell from './XrGazeDwell';
 import XrPointerRay from './XrPointerRay';
 import { XrStartPose } from './XrStartPose';
 import { SplatFormat } from './splatFormat';
+import { useXrRenderTuning } from './useXrRenderTuning';
 import { WalkthroughCamera } from './walkthrough-camera';
 import { rayHitsInteractiveUi } from './xr-interactive-ui';
 
@@ -113,6 +114,7 @@ const VirtualWalkthroughViewer = ({
   const [viewingAnnotationIndex, setViewingAnnotationIndex] = useState(-1);
   const [viewedScreenPos, setViewedScreenPos] = useState<{ x: number; y: number; size?: number } | null>(null);
   const { isCurrentlyInXr, isCurrentlyInVr, isCurrentlyInAr } = useXr();
+  useXrRenderTuning();
 
   const sceneBoundsRadius = useMemo(() => {
     if (sceneBounds?.m !== undefined) {

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -17,7 +17,7 @@ import BoundaryRing from './BoundaryRing';
 import BoundaryWall from './BoundaryWall';
 import GradientSky from './GradientSky';
 import SplatControls from './SplatControls';
-import SplatModel from './SplatModel';
+import SplatModel, { SplatModelProps } from './SplatModel';
 import { TfAnnotationManager } from './TfAnnotationManager';
 import { TfXrNavigation } from './TfXrNavigation';
 import VrAnnotationPanel from './VrAnnotationPanel';
@@ -70,6 +70,12 @@ export interface VirtualWalkthroughViewerProps {
    * entity alone — every other coordinate this component takes is already world-space.
    */
   scaleFactor?: number;
+  /**
+   * Overrides passed through to the splat model, for tuning things like `splatBudget` and
+   * `maxPixelRatio`. The props this component drives itself — `splatSrc`, `splatFormat`,
+   * `rotation`, `scaleFactor` and `revealRain` — take precedence over anything set here.
+   */
+  splatModelProps?: Partial<SplatModelProps>;
   annotations: AnnotationProps[];
   onSaveAnnotations: (annotations: AnnotationProps[]) => void | Promise<void>;
   editable?: boolean;
@@ -90,6 +96,7 @@ const VirtualWalkthroughViewer = ({
   groundColor,
   averageCameraHeight = 0,
   scaleFactor = 1,
+  splatModelProps,
   annotations,
   onSaveAnnotations,
   editable = false,
@@ -319,6 +326,7 @@ const VirtualWalkthroughViewer = ({
     () => (
       <SplatModel
         key='splat'
+        {...splatModelProps}
         splatSrc={splatSrc}
         splatFormat={splatFormat}
         rotation={[-180, 0, 0]}
@@ -326,7 +334,7 @@ const VirtualWalkthroughViewer = ({
         revealRain={isHighPerformance}
       />
     ),
-    [isHighPerformance, splatSrc, splatFormat, scaleFactor]
+    [isHighPerformance, splatSrc, splatFormat, scaleFactor, splatModelProps]
   );
 
   return (

--- a/src/components/VirtualWalkthrough/useXrRenderTuning.ts
+++ b/src/components/VirtualWalkthrough/useXrRenderTuning.ts
@@ -1,0 +1,50 @@
+import { useEffect } from 'react';
+
+import { useApp } from '@playcanvas/react/hooks';
+
+import { GsplatTuningParams, XR_FIXED_FOVEATION, applyGsplatTuning, restoreGsplatTuning } from './xr-render-tuning';
+
+/**
+ * Holds the XR render settings in place for the duration of a session.
+ *
+ * Call this once per application. The gsplat settings it writes are scene-global, so a second
+ * caller would capture the first caller's tuned values as the state to restore, and the scene would
+ * come out of the session still tuned.
+ */
+export const useXrRenderTuning = () => {
+  const app = useApp();
+
+  useEffect(() => {
+    const xr = app.xr;
+    if (!xr) {
+      return;
+    }
+
+    let previous: GsplatTuningParams | null = null;
+
+    const restore = () => {
+      if (previous) {
+        restoreGsplatTuning(app.scene.gsplat, previous);
+        previous = null;
+      }
+    };
+
+    const handleStart = () => {
+      previous = applyGsplatTuning(app.scene.gsplat);
+      // Only settable on an active session, so it cannot go in the start options alongside
+      // framebufferScaleFactor. A no-op when the presentation layer doesn't support it.
+      xr.fixedFoveation = XR_FIXED_FOVEATION;
+    };
+
+    xr.on('start', handleStart);
+    xr.on('end', restore);
+
+    return () => {
+      xr.off('start', handleStart);
+      xr.off('end', restore);
+      restore();
+    };
+  }, [app]);
+};
+
+export default useXrRenderTuning;

--- a/src/components/VirtualWalkthrough/useXrRenderTuning.ts
+++ b/src/components/VirtualWalkthrough/useXrRenderTuning.ts
@@ -30,7 +30,11 @@ export const useXrRenderTuning = () => {
     };
 
     const handleStart = () => {
-      previous = applyGsplatTuning(app.scene.gsplat);
+      // Guards against capturing already-tuned values as the restore target if `start` ever
+      // fires again before a matching `end`.
+      if (!previous) {
+        previous = applyGsplatTuning(app.scene.gsplat);
+      }
       // Only settable on an active session, so it cannot go in the start options alongside
       // framebufferScaleFactor. A no-op when the presentation layer doesn't support it.
       xr.fixedFoveation = XR_FIXED_FOVEATION;

--- a/src/components/VirtualWalkthrough/xr-render-tuning.test.ts
+++ b/src/components/VirtualWalkthrough/xr-render-tuning.test.ts
@@ -1,0 +1,51 @@
+import { XR_GSPLAT_TUNING, applyGsplatTuning, restoreGsplatTuning } from './xr-render-tuning';
+
+// The PlayCanvas defaults these settings hold outside an XR session.
+const defaultParams = () => ({
+  radialSorting: false,
+  alphaClipForward: 1 / 255,
+  minPixelSize: 2,
+});
+
+describe('applyGsplatTuning', () => {
+  it('writes every tuned value onto the params', () => {
+    const params = defaultParams();
+
+    applyGsplatTuning(params);
+
+    expect(params).toEqual(XR_GSPLAT_TUNING);
+  });
+
+  it('returns the values the params held before tuning', () => {
+    const params = defaultParams();
+
+    expect(applyGsplatTuning(params)).toEqual(defaultParams());
+  });
+
+  it('returns a snapshot that later mutation of the params cannot change', () => {
+    const params = defaultParams();
+
+    const previous = applyGsplatTuning(params);
+    params.minPixelSize = 99;
+
+    expect(previous.minPixelSize).toBe(2);
+  });
+});
+
+describe('restoreGsplatTuning', () => {
+  it('returns tuned params to their pre-apply state', () => {
+    const params = defaultParams();
+
+    restoreGsplatTuning(params, applyGsplatTuning(params));
+
+    expect(params).toEqual(defaultParams());
+  });
+
+  it('restores the pre-apply values rather than the library defaults', () => {
+    const params = { radialSorting: true, alphaClipForward: 0.5, minPixelSize: 7 };
+
+    restoreGsplatTuning(params, applyGsplatTuning(params));
+
+    expect(params).toEqual({ radialSorting: true, alphaClipForward: 0.5, minPixelSize: 7 });
+  });
+});

--- a/src/components/VirtualWalkthrough/xr-render-tuning.ts
+++ b/src/components/VirtualWalkthrough/xr-render-tuning.ts
@@ -31,8 +31,8 @@ export interface GsplatTuningParams {
  */
 export const XR_GSPLAT_TUNING: GsplatTuningParams = {
   radialSorting: true,
-  alphaClipForward: 0.05,
-  minPixelSize: 3,
+  alphaClipForward: 0.1,
+  minPixelSize: 1,
 };
 
 /**

--- a/src/components/VirtualWalkthrough/xr-render-tuning.ts
+++ b/src/components/VirtualWalkthrough/xr-render-tuning.ts
@@ -1,0 +1,60 @@
+/**
+ * Render settings applied for the duration of an XR session. Splats rasterize as alpha-blended
+ * quads with no early-z rejection, which makes a headset's stereo pixel throughput the binding
+ * constraint on framerate long before splat count is.
+ */
+
+/**
+ * Peripheral back-buffer resolution reduction, 0 (off) to 1 (strongest). Ineffective while MSAA is
+ * on, which is one reason the application requests `antialias: false`.
+ */
+export const XR_FIXED_FOVEATION = 1;
+
+/**
+ * The subset of `GSplatParams` this module writes. Structural rather than the PlayCanvas type so
+ * the logic can be exercised against a plain object.
+ */
+export interface GsplatTuningParams {
+  radialSorting: boolean;
+  alphaClipForward: number;
+  minPixelSize: number;
+}
+
+/**
+ * `radialSorting` orders splats by distance from the camera rather than by depth along its forward
+ * axis, which is the more accurate ordering when the camera rotates rather than translates. Sorting
+ * runs on a worker and so lags the view by at least a frame; head rotation dominates in a headset,
+ * where that lag is what reads as swimming.
+ *
+ * The other two trade fidelity for fill rate: `alphaClipForward` drops near-transparent splats from
+ * the forward pass, and `minPixelSize` drops splats that project to less than a few pixels.
+ */
+export const XR_GSPLAT_TUNING: GsplatTuningParams = {
+  radialSorting: true,
+  alphaClipForward: 0.05,
+  minPixelSize: 3,
+};
+
+/**
+ * Applies the XR settings, returning the values that were replaced so they can be restored when the
+ * session ends. These live on the scene, so leaving them tuned would degrade desktop rendering.
+ */
+export const applyGsplatTuning = (params: GsplatTuningParams): GsplatTuningParams => {
+  const previous: GsplatTuningParams = {
+    radialSorting: params.radialSorting,
+    alphaClipForward: params.alphaClipForward,
+    minPixelSize: params.minPixelSize,
+  };
+
+  params.radialSorting = XR_GSPLAT_TUNING.radialSorting;
+  params.alphaClipForward = XR_GSPLAT_TUNING.alphaClipForward;
+  params.minPixelSize = XR_GSPLAT_TUNING.minPixelSize;
+
+  return previous;
+};
+
+export const restoreGsplatTuning = (params: GsplatTuningParams, previous: GsplatTuningParams): void => {
+  params.radialSorting = previous.radialSorting;
+  params.alphaClipForward = previous.alphaClipForward;
+  params.minPixelSize = previous.minPixelSize;
+};

--- a/src/hooks/useXr.ts
+++ b/src/hooks/useXr.ts
@@ -15,8 +15,10 @@ const XR_TYPES: Record<XrType, string> = {
 };
 
 /**
- * Resolution the headset's framebuffer is rendered at, relative to its native scale. Splat
- * rendering in stereo is fill-rate bound, so this is the largest single lever on XR framerate.
+ * Factor PlayCanvas applies on top of the device pixel ratio to compute the headset's
+ * framebuffer resolution: `app.graphicsDevice.maxPixelRatio / window.devicePixelRatio *
+ * XR_FRAMEBUFFER_SCALE_FACTOR`. Splat rendering in stereo is fill-rate bound, so this (and
+ * `maxPixelRatio`, which also multiplies XR resolution) is the largest lever on XR framerate.
  * Read once when the session starts and fixed for its lifetime.
  */
 const XR_FRAMEBUFFER_SCALE_FACTOR = 0.7;

--- a/src/hooks/useXr.ts
+++ b/src/hooks/useXr.ts
@@ -14,6 +14,13 @@ const XR_TYPES: Record<XrType, string> = {
   AR: XRTYPE_AR,
 };
 
+/**
+ * Resolution the headset's framebuffer is rendered at, relative to its native scale. Splat
+ * rendering in stereo is fill-rate bound, so this is the largest single lever on XR framerate.
+ * Read once when the session starts and fixed for its lifetime.
+ */
+const XR_FRAMEBUFFER_SCALE_FACTOR = 0.7;
+
 export const useXr = ({ onError }: UseXrOptions = {}) => {
   const app = useApp();
   const [available, setAvailable] = useState<Record<XrType, boolean>>({ VR: false, AR: false });
@@ -64,6 +71,7 @@ export const useXr = ({ onError }: UseXrOptions = {}) => {
     (type: XrType) => {
       const camera = app.root.findComponent('camera') as CameraComponent;
       app.xr?.start(camera, XR_TYPES[type], XRSPACE_LOCALFLOOR, {
+        framebufferScaleFactor: XR_FRAMEBUFFER_SCALE_FACTOR,
         callback: (err: Error | null) => {
           if (err) {
             onError?.(err);

--- a/src/hooks/useXr.ts
+++ b/src/hooks/useXr.ts
@@ -21,7 +21,7 @@ const XR_TYPES: Record<XrType, string> = {
  * `maxPixelRatio`, which also multiplies XR resolution) is the largest lever on XR framerate.
  * Read once when the session starts and fixed for its lifetime.
  */
-const XR_FRAMEBUFFER_SCALE_FACTOR = 0.7;
+const XR_FRAMEBUFFER_SCALE_FACTOR = 1;
 
 export const useXr = ({ onError }: UseXrOptions = {}) => {
   const app = useApp();


### PR DESCRIPTION
XR (and VR especially) struggles in a headset on its own. Add some (hardcoded) adjustment to help with this issue.
Also expose splatBudget and maxPixelRatio to help per model.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>