### PR TITLE
Add ability to auto-start VR

### DIFF
--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useTheme } from '@mui/material';
 import { Entity } from '@playcanvas/react';
@@ -76,6 +76,12 @@ export interface VirtualWalkthroughViewerProps {
    * `rotation`, `scaleFactor` and `revealRain` — take precedence over anything set here.
    */
   splatModelProps?: Partial<SplatModelProps>;
+  /**
+   * Requests a VR session when this goes from false to true, and when the viewer mounts with it
+   * already true. Never re-requests on its own, so exiting VR leaves the user out. Browsers only
+   * grant an immersive session inside a user gesture, so the caller must raise this from a click.
+   */
+  autoStartVr?: boolean;
   annotations: AnnotationProps[];
   onSaveAnnotations: (annotations: AnnotationProps[]) => void | Promise<void>;
   editable?: boolean;
@@ -97,6 +103,7 @@ const VirtualWalkthroughViewer = ({
   averageCameraHeight = 0,
   scaleFactor = 1,
   splatModelProps,
+  autoStartVr = false,
   annotations,
   onSaveAnnotations,
   editable = false,
@@ -120,8 +127,31 @@ const VirtualWalkthroughViewer = ({
   const [viewingAnnotation, setViewingAnnotation] = useState<AnnotationProps | null>(null);
   const [viewingAnnotationIndex, setViewingAnnotationIndex] = useState(-1);
   const [viewedScreenPos, setViewedScreenPos] = useState<{ x: number; y: number; size?: number } | null>(null);
-  const { isCurrentlyInXr, isCurrentlyInVr, isCurrentlyInAr } = useXr();
+  const handleXrError = useCallback((error: Error) => {
+    console.warn('Failed to start the requested VR session', error);
+  }, []);
+  const { isCurrentlyInXr, isCurrentlyInVr, isCurrentlyInAr, isXrAvailable, startXr } = useXr({
+    onError: handleXrError,
+  });
   useXrRenderTuning();
+
+  const autoStartRequested = useRef(false);
+
+  // Edge-triggered so that ending a session doesn't pull the user straight back into one. The ref
+  // is written before the early returns, so lowering the prop re-arms the next rising edge.
+  useEffect(() => {
+    const isRisingEdge = autoStartVr && !autoStartRequested.current;
+    autoStartRequested.current = autoStartVr;
+    if (!isRisingEdge || isCurrentlyInXr) {
+      return;
+    }
+    if (!isXrAvailable('VR')) {
+      console.warn('A VR session was requested, but this device reports no immersive VR support');
+
+      return;
+    }
+    startXr('VR');
+  }, [autoStartVr, isCurrentlyInXr, isXrAvailable, startXr]);
 
   const sceneBoundsRadius = useMemo(() => {
     if (sceneBounds?.m !== undefined) {

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -84,8 +84,7 @@ export interface VirtualWalkthroughViewerProps {
   autoStartVr?: boolean;
   /**
    * Called whenever the viewer ends up out of XR: when a session ends, and when one was requested
-   * but couldn't be started, in which case the error says why. A headset gives no view of the
-   * console, so this is a caller's only account of a failure.
+   * but couldn't be started, in which case the error says why.
    */
   onXrExit?: (error?: Error) => void;
   annotations: AnnotationProps[];

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -84,6 +84,8 @@ export interface VirtualWalkthroughViewerProps {
   autoStartVr?: boolean;
   /** Called when a session can't be started, which is otherwise only visible in the console. */
   onXrError?: (error: Error) => void;
+  /** Called when an XR session ends, whether the user left it or the headset did. */
+  onXrExit?: () => void;
   annotations: AnnotationProps[];
   onSaveAnnotations: (annotations: AnnotationProps[]) => void | Promise<void>;
   editable?: boolean;
@@ -107,6 +109,7 @@ const VirtualWalkthroughViewer = ({
   splatModelProps,
   autoStartVr = false,
   onXrError,
+  onXrExit,
   annotations,
   onSaveAnnotations,
   editable = false,
@@ -159,6 +162,17 @@ const VirtualWalkthroughViewer = ({
     }
     startXr('VR');
   }, [autoStartVr, isCurrentlyInXr, isXrAvailable, startXr, reportXrError]);
+
+  const wasInXr = useRef(false);
+
+  // Edge-detected rather than reported whenever the viewer is out of XR, which would fire on mount
+  // and tell a caller a session had ended before one ever began.
+  useEffect(() => {
+    if (wasInXr.current && !isCurrentlyInXr) {
+      onXrExit?.();
+    }
+    wasInXr.current = isCurrentlyInXr;
+  }, [isCurrentlyInXr, onXrExit]);
 
   const sceneBoundsRadius = useMemo(() => {
     if (sceneBounds?.m !== undefined) {

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -82,10 +82,12 @@ export interface VirtualWalkthroughViewerProps {
    * grant an immersive session inside a user gesture, so the caller must raise this from a click.
    */
   autoStartVr?: boolean;
-  /** Called when a session can't be started, which is otherwise only visible in the console. */
-  onXrError?: (error: Error) => void;
-  /** Called when an XR session ends, whether the user left it or the headset did. */
-  onXrExit?: () => void;
+  /**
+   * Called whenever the viewer ends up out of XR: when a session ends, and when one was requested
+   * but couldn't be started, in which case the error says why. A headset gives no view of the
+   * console, so this is a caller's only account of a failure.
+   */
+  onXrExit?: (error?: Error) => void;
   annotations: AnnotationProps[];
   onSaveAnnotations: (annotations: AnnotationProps[]) => void | Promise<void>;
   editable?: boolean;
@@ -108,7 +110,6 @@ const VirtualWalkthroughViewer = ({
   scaleFactor = 1,
   splatModelProps,
   autoStartVr = false,
-  onXrError,
   onXrExit,
   annotations,
   onSaveAnnotations,
@@ -136,9 +137,9 @@ const VirtualWalkthroughViewer = ({
   const reportXrError = useCallback(
     (error: Error) => {
       console.warn(error.message, error);
-      onXrError?.(error);
+      onXrExit?.(error);
     },
-    [onXrError]
+    [onXrExit]
   );
   const { isCurrentlyInXr, isCurrentlyInVr, isCurrentlyInAr, isXrAvailable, startXr } = useXr({
     onError: reportXrError,

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -530,6 +530,7 @@ const VirtualWalkthroughViewer = ({
         isFreeFly={isFreeFly}
         onToggleFreeFly={handleToggleFreeFly}
         showFreeFly={showFreeFly}
+        onError={reportXrError}
       />
 
       <AnnotationPanel

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -82,6 +82,8 @@ export interface VirtualWalkthroughViewerProps {
    * grant an immersive session inside a user gesture, so the caller must raise this from a click.
    */
   autoStartVr?: boolean;
+  /** Called when a session can't be started, which is otherwise only visible in the console. */
+  onXrError?: (error: Error) => void;
   annotations: AnnotationProps[];
   onSaveAnnotations: (annotations: AnnotationProps[]) => void | Promise<void>;
   editable?: boolean;
@@ -104,6 +106,7 @@ const VirtualWalkthroughViewer = ({
   scaleFactor = 1,
   splatModelProps,
   autoStartVr = false,
+  onXrError,
   annotations,
   onSaveAnnotations,
   editable = false,
@@ -127,11 +130,15 @@ const VirtualWalkthroughViewer = ({
   const [viewingAnnotation, setViewingAnnotation] = useState<AnnotationProps | null>(null);
   const [viewingAnnotationIndex, setViewingAnnotationIndex] = useState(-1);
   const [viewedScreenPos, setViewedScreenPos] = useState<{ x: number; y: number; size?: number } | null>(null);
-  const handleXrError = useCallback((error: Error) => {
-    console.warn('Failed to start the requested VR session', error);
-  }, []);
+  const reportXrError = useCallback(
+    (error: Error) => {
+      console.warn(error.message, error);
+      onXrError?.(error);
+    },
+    [onXrError]
+  );
   const { isCurrentlyInXr, isCurrentlyInVr, isCurrentlyInAr, isXrAvailable, startXr } = useXr({
-    onError: handleXrError,
+    onError: reportXrError,
   });
   useXrRenderTuning();
 
@@ -146,12 +153,12 @@ const VirtualWalkthroughViewer = ({
       return;
     }
     if (!isXrAvailable('VR')) {
-      console.warn('A VR session was requested, but this device reports no immersive VR support');
+      reportXrError(new Error('A VR session was requested, but this device reports no immersive VR support'));
 
       return;
     }
     startXr('VR');
-  }, [autoStartVr, isCurrentlyInXr, isXrAvailable, startXr]);
+  }, [autoStartVr, isCurrentlyInXr, isXrAvailable, startXr, reportXrError]);
 
   const sceneBoundsRadius = useMemo(() => {
     if (sceneBounds?.m !== undefined) {

--- a/src/hooks/useXr.test.tsx
+++ b/src/hooks/useXr.test.tsx
@@ -1,0 +1,33 @@
+import { renderHook } from '@testing-library/react';
+import { XRTYPE_VR } from 'playcanvas';
+
+import { useXr } from './useXr';
+
+const mockApp = {
+  xr: {
+    active: false,
+    type: null,
+    isAvailable: (type: string) => type === XRTYPE_VR,
+    on: jest.fn(),
+    off: jest.fn(),
+  },
+  root: { findComponent: jest.fn() },
+};
+
+// Virtual: jest's resolver doesn't follow the package's subpath exports.
+jest.mock('@playcanvas/react/hooks', () => ({ useApp: () => mockApp }), { virtual: true });
+
+describe('useXr', () => {
+  it('reports availability on the first render, before any effect has run', () => {
+    const reported: boolean[] = [];
+
+    renderHook(() => {
+      const { isXrAvailable } = useXr();
+      reported.push(isXrAvailable('VR'));
+    });
+
+    // Callers that act in a mount effect — starting a session the moment the viewer appears — read
+    // this value before a state update from another effect could reach them.
+    expect(reported[0]).toBe(true);
+  });
+});

--- a/src/hooks/useXr.ts
+++ b/src/hooks/useXr.ts
@@ -25,7 +25,12 @@ const XR_FRAMEBUFFER_SCALE_FACTOR = 1;
 
 export const useXr = ({ onError }: UseXrOptions = {}) => {
   const app = useApp();
-  const [available, setAvailable] = useState<Record<XrType, boolean>>({ VR: false, AR: false });
+  // Seeded from the manager rather than defaulting to unavailable, so a caller acting in a mount
+  // effect isn't told VR is unsupported while the effect below is still waiting to run.
+  const [available, setAvailable] = useState<Record<XrType, boolean>>(() => ({
+    VR: app.xr?.isAvailable(XRTYPE_VR) ?? false,
+    AR: app.xr?.isAvailable(XRTYPE_AR) ?? false,
+  }));
   // `type` is set as soon as a session is requested, so gate on `active` to ignore pending sessions.
   const [currentXrType, setCurrentXrType] = useState<string | null>(app.xr?.active ? app.xr.type : null);
 

--- a/src/stories/VirtualWalkthroughViewer.stories.tsx
+++ b/src/stories/VirtualWalkthroughViewer.stories.tsx
@@ -124,7 +124,17 @@ const AutoStartVrTemplate: Story<Partial<VirtualWalkthroughViewerProps>> = (args
         />
       </div>
       <Application style={{ width: '100%', height: '100%' }}>
-        {mountCount > 0 && <VirtualWalkthroughViewer key={mountCount} {...sceneArgs} autoStartVr {...args} />}
+        {mountCount > 0 && (
+          <VirtualWalkthroughViewer
+            key={mountCount}
+            {...sceneArgs}
+            autoStartVr
+            // Alerted rather than logged: the console isn't reachable from inside a headset.
+            // eslint-disable-next-line no-alert
+            onXrError={(error) => window.alert(error.message)}
+            {...args}
+          />
+        )}
       </Application>
     </div>
   );

--- a/src/stories/VirtualWalkthroughViewer.stories.tsx
+++ b/src/stories/VirtualWalkthroughViewer.stories.tsx
@@ -106,41 +106,34 @@ export const Default = Template.bind({});
 
 // The scene starts empty: the button mounts the viewer with autoStartVr already
 // set, so this exercises the mount-time path rather than a prop change on a
-// viewer that is already running. Leaving the session unmounts it again, so the
-// story returns to the button rather than to a viewer running on the desktop.
+// viewer that is already running. Leaving the session takes the viewer back down,
+// as does failing to start one, so the story always returns to the button rather
+// than to a viewer running on the desktop.
 //
 // The click is also what makes the session possible at all — browsers only grant
 // one inside a user gesture, and selecting a story is a click in Storybook's
 // manager frame, which leaves the preview iframe without one.
 const AutoStartVrTemplate: Story<Partial<VirtualWalkthroughViewerProps>> = (args) => {
-  // Counted rather than a flag so that a click after a session failed to start
-  // remounts the viewer and tries again, instead of leaving the story stuck with
-  // a mounted viewer and a button that does nothing.
-  const [mountCount, setMountCount] = useState(0);
+  const [isMounted, setIsMounted] = useState(false);
 
-  const handleXrExit = useCallback(() => setMountCount(0), []);
+  const handleXrExit = useCallback((error?: Error) => {
+    setIsMounted(false);
+    if (error) {
+      // Alerted rather than logged: a headset gives no view of the console.
+      // eslint-disable-next-line no-alert
+      window.alert(error.message);
+    }
+  }, []);
 
   return (
     <div style={containerStyle}>
       <div style={{ position: 'absolute', top: 16, left: 16, zIndex: 1001 }}>
-        <Button
-          label={mountCount === 0 ? 'Start in VR' : 'Retry in VR'}
-          onClick={() => setMountCount((count) => count + 1)}
-        />
+        <Button label='Start in VR' onClick={() => setIsMounted(true)} />
       </div>
       <Application style={{ width: '100%', height: '100%' }}>
-        {mountCount > 0 && (
-          <VirtualWalkthroughViewer
-            key={mountCount}
-            {...sceneArgs}
-            autoStartVr
-            // Alerted rather than logged: the console isn't reachable from inside a headset.
-            // eslint-disable-next-line no-alert
-            onXrError={(error) => window.alert(error.message)}
-            onXrExit={handleXrExit}
-            {...args}
-          />
-        )}
+        {/* args first: the preview config turns every on[A-Z] prop into an action
+            spy and passes it in, which would otherwise replace the wiring below. */}
+        {isMounted && <VirtualWalkthroughViewer {...sceneArgs} {...args} autoStartVr onXrExit={handleXrExit} />}
       </Application>
     </div>
   );

--- a/src/stories/VirtualWalkthroughViewer.stories.tsx
+++ b/src/stories/VirtualWalkthroughViewer.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { action } from '@storybook/addon-actions';
 import { Story } from '@storybook/react';
@@ -9,7 +9,6 @@ import Application from '../components/VirtualWalkthrough/Application';
 import VirtualWalkthroughViewer, {
   VirtualWalkthroughViewerProps,
 } from '../components/VirtualWalkthrough/VirtualWalkthroughViewer';
-import { useXr } from '../hooks/useXr';
 
 export default {
   title: 'VirtualWalkthroughViewer',
@@ -105,23 +104,6 @@ const Template: Story<Partial<VirtualWalkthroughViewerProps>> = (args) => (
 
 export const Default = Template.bind({});
 
-// The XR manager is only reachable from inside the PlayCanvas <Application>, which
-// the story itself sits outside of. This sibling of the viewer reports the session
-// ending so the story can take the viewer back down.
-const XrExitReporter = ({ onExit }: { onExit: () => void }) => {
-  const { isCurrentlyInXr } = useXr();
-  const wasInXr = useRef(false);
-
-  useEffect(() => {
-    if (wasInXr.current && !isCurrentlyInXr) {
-      onExit();
-    }
-    wasInXr.current = isCurrentlyInXr;
-  }, [isCurrentlyInXr, onExit]);
-
-  return null;
-};
-
 // The scene starts empty: the button mounts the viewer with autoStartVr already
 // set, so this exercises the mount-time path rather than a prop change on a
 // viewer that is already running. Leaving the session unmounts it again, so the
@@ -148,18 +130,16 @@ const AutoStartVrTemplate: Story<Partial<VirtualWalkthroughViewerProps>> = (args
       </div>
       <Application style={{ width: '100%', height: '100%' }}>
         {mountCount > 0 && (
-          <>
-            <XrExitReporter onExit={handleXrExit} />
-            <VirtualWalkthroughViewer
-              key={mountCount}
-              {...sceneArgs}
-              autoStartVr
-              // Alerted rather than logged: the console isn't reachable from inside a headset.
-              // eslint-disable-next-line no-alert
-              onXrError={(error) => window.alert(error.message)}
-              {...args}
-            />
-          </>
+          <VirtualWalkthroughViewer
+            key={mountCount}
+            {...sceneArgs}
+            autoStartVr
+            // Alerted rather than logged: the console isn't reachable from inside a headset.
+            // eslint-disable-next-line no-alert
+            onXrError={(error) => window.alert(error.message)}
+            onXrExit={handleXrExit}
+            {...args}
+          />
         )}
       </Application>
     </div>

--- a/src/stories/VirtualWalkthroughViewer.stories.tsx
+++ b/src/stories/VirtualWalkthroughViewer.stories.tsx
@@ -104,14 +104,7 @@ const Template: Story<Partial<VirtualWalkthroughViewerProps>> = (args) => (
 
 export const Default = Template.bind({});
 
-// The scene starts empty: the button mounts the viewer with autoStartVr already
-// set, so this exercises the mount-time path rather than a prop change on a
-// viewer that is already running. Leaving the session takes the viewer back down,
-// as does failing to start one, so the story always returns to the button rather
-// than to a viewer running on the desktop.
-//
-// The click is also what makes the session possible at all — browsers only grant
-// one inside a user gesture, and selecting a story is a click in Storybook's
+// Browsers only grant a session from a user gesture, and selecting a story is a click in Storybook's
 // manager frame, which leaves the preview iframe without one.
 const AutoStartVrTemplate: Story<Partial<VirtualWalkthroughViewerProps>> = (args) => {
   const [isMounted, setIsMounted] = useState(false);
@@ -119,7 +112,6 @@ const AutoStartVrTemplate: Story<Partial<VirtualWalkthroughViewerProps>> = (args
   const handleXrExit = useCallback((error?: Error) => {
     setIsMounted(false);
     if (error) {
-      // Alerted rather than logged: a headset gives no view of the console.
       // eslint-disable-next-line no-alert
       window.alert(error.message);
     }
@@ -131,8 +123,6 @@ const AutoStartVrTemplate: Story<Partial<VirtualWalkthroughViewerProps>> = (args
         <Button label='Start in VR' onClick={() => setIsMounted(true)} />
       </div>
       <Application style={{ width: '100%', height: '100%' }}>
-        {/* args first: the preview config turns every on[A-Z] prop into an action
-            spy and passes it in, which would otherwise replace the wiring below. */}
         {isMounted && <VirtualWalkthroughViewer {...sceneArgs} {...args} autoStartVr onXrExit={handleXrExit} />}
       </Application>
     </div>

--- a/src/stories/VirtualWalkthroughViewer.stories.tsx
+++ b/src/stories/VirtualWalkthroughViewer.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { action } from '@storybook/addon-actions';
 import { Story } from '@storybook/react';
@@ -9,6 +9,7 @@ import Application from '../components/VirtualWalkthrough/Application';
 import VirtualWalkthroughViewer, {
   VirtualWalkthroughViewerProps,
 } from '../components/VirtualWalkthrough/VirtualWalkthroughViewer';
+import { useXr } from '../hooks/useXr';
 
 export default {
   title: 'VirtualWalkthroughViewer',
@@ -104,36 +105,61 @@ const Template: Story<Partial<VirtualWalkthroughViewerProps>> = (args) => (
 
 export const Default = Template.bind({});
 
+// The XR manager is only reachable from inside the PlayCanvas <Application>, which
+// the story itself sits outside of. This sibling of the viewer reports the session
+// ending so the story can take the viewer back down.
+const XrExitReporter = ({ onExit }: { onExit: () => void }) => {
+  const { isCurrentlyInXr } = useXr();
+  const wasInXr = useRef(false);
+
+  useEffect(() => {
+    if (wasInXr.current && !isCurrentlyInXr) {
+      onExit();
+    }
+    wasInXr.current = isCurrentlyInXr;
+  }, [isCurrentlyInXr, onExit]);
+
+  return null;
+};
+
 // The scene starts empty: the button mounts the viewer with autoStartVr already
 // set, so this exercises the mount-time path rather than a prop change on a
-// viewer that is already running. Clicking again remounts it, which re-arms the
-// rising edge without tearing down the WebGL canvas around it.
+// viewer that is already running. Leaving the session unmounts it again, so the
+// story returns to the button rather than to a viewer running on the desktop.
 //
 // The click is also what makes the session possible at all — browsers only grant
 // one inside a user gesture, and selecting a story is a click in Storybook's
 // manager frame, which leaves the preview iframe without one.
 const AutoStartVrTemplate: Story<Partial<VirtualWalkthroughViewerProps>> = (args) => {
+  // Counted rather than a flag so that a click after a session failed to start
+  // remounts the viewer and tries again, instead of leaving the story stuck with
+  // a mounted viewer and a button that does nothing.
   const [mountCount, setMountCount] = useState(0);
+
+  const handleXrExit = useCallback(() => setMountCount(0), []);
 
   return (
     <div style={containerStyle}>
       <div style={{ position: 'absolute', top: 16, left: 16, zIndex: 1001 }}>
         <Button
-          label={mountCount === 0 ? 'Start in VR' : 'Restart in VR'}
+          label={mountCount === 0 ? 'Start in VR' : 'Retry in VR'}
           onClick={() => setMountCount((count) => count + 1)}
         />
       </div>
       <Application style={{ width: '100%', height: '100%' }}>
         {mountCount > 0 && (
-          <VirtualWalkthroughViewer
-            key={mountCount}
-            {...sceneArgs}
-            autoStartVr
-            // Alerted rather than logged: the console isn't reachable from inside a headset.
-            // eslint-disable-next-line no-alert
-            onXrError={(error) => window.alert(error.message)}
-            {...args}
-          />
+          <>
+            <XrExitReporter onExit={handleXrExit} />
+            <VirtualWalkthroughViewer
+              key={mountCount}
+              {...sceneArgs}
+              autoStartVr
+              // Alerted rather than logged: the console isn't reachable from inside a headset.
+              // eslint-disable-next-line no-alert
+              onXrError={(error) => window.alert(error.message)}
+              {...args}
+            />
+          </>
         )}
       </Application>
     </div>

--- a/src/stories/VirtualWalkthroughViewer.stories.tsx
+++ b/src/stories/VirtualWalkthroughViewer.stories.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { action } from '@storybook/addon-actions';
 import { Story } from '@storybook/react';
 
+import Button from '../components/Button/Button';
 import { AnnotationProps } from '../components/VirtualWalkthrough/Annotation';
 import Application from '../components/VirtualWalkthrough/Application';
 import VirtualWalkthroughViewer, {
@@ -62,34 +63,71 @@ const sampleAnnotations: AnnotationProps[] = [
   },
 ];
 
+const sceneArgs: VirtualWalkthroughViewerProps = {
+  splatSrc: DEFAULT_SPLAT_SRC,
+  annotations: sampleAnnotations,
+  onSaveAnnotations: action('onSaveAnnotations'),
+  editable: true,
+  showFreeFly: true,
+  skyColor: '#4286DC',
+  groundColor: '#98932E',
+  groundPlane: [
+    [-2.25, -1.5, 0],
+    [12, -1.5, -1.5],
+    [-4.5, -1.5, -15],
+  ],
+  sceneBounds: { x: 0, y: -1.5, z: -1.5, m: 15 },
+  averageCameraHeight: 3,
+  cameraPosition: [5, 0.1, -3],
+  scaleFactor: 15,
+};
+
+const containerStyle = {
+  position: 'relative' as const,
+  width: '95%',
+  height: '100%',
+  overflow: 'hidden',
+  borderRadius: 8,
+};
+
 // The viewer renders PlayCanvas scene-graph elements and calls useApp(), so it
 // must be mounted inside the PlayCanvas <Application> (which provides the WebGL
 // canvas). The story runs in Storybook's real browser, so WebGL works as it
 // does in the consuming app.
 const Template: Story<Partial<VirtualWalkthroughViewerProps>> = (args) => (
-  <div style={{ position: 'relative', width: '95%', height: '100%', overflow: 'hidden', borderRadius: 8 }}>
+  <div style={containerStyle}>
     <Application style={{ width: '100%', height: '100%' }}>
-      <VirtualWalkthroughViewer
-        splatSrc={DEFAULT_SPLAT_SRC}
-        annotations={sampleAnnotations}
-        onSaveAnnotations={action('onSaveAnnotations')}
-        editable
-        showFreeFly
-        skyColor={'#4286DC'}
-        groundColor={'#98932E'}
-        groundPlane={[
-          [-2.25, -1.5, 0],
-          [12, -1.5, -1.5],
-          [-4.5, -1.5, -15],
-        ]}
-        sceneBounds={{ x: 0, y: -1.5, z: -1.5, m: 15 }}
-        averageCameraHeight={3}
-        cameraPosition={[5, 0.1, -3]}
-        scaleFactor={15}
-        {...args}
-      />
+      <VirtualWalkthroughViewer {...sceneArgs} {...args} />
     </Application>
   </div>
 );
 
 export const Default = Template.bind({});
+
+// The scene starts empty: the button mounts the viewer with autoStartVr already
+// set, so this exercises the mount-time path rather than a prop change on a
+// viewer that is already running. Clicking again remounts it, which re-arms the
+// rising edge without tearing down the WebGL canvas around it.
+//
+// The click is also what makes the session possible at all — browsers only grant
+// one inside a user gesture, and selecting a story is a click in Storybook's
+// manager frame, which leaves the preview iframe without one.
+const AutoStartVrTemplate: Story<Partial<VirtualWalkthroughViewerProps>> = (args) => {
+  const [mountCount, setMountCount] = useState(0);
+
+  return (
+    <div style={containerStyle}>
+      <div style={{ position: 'absolute', top: 16, left: 16, zIndex: 1001 }}>
+        <Button
+          label={mountCount === 0 ? 'Start in VR' : 'Restart in VR'}
+          onClick={() => setMountCount((count) => count + 1)}
+        />
+      </div>
+      <Application style={{ width: '100%', height: '100%' }}>
+        {mountCount > 0 && <VirtualWalkthroughViewer key={mountCount} {...sceneArgs} autoStartVr {...args} />}
+      </Application>
+    </div>
+  );
+};
+
+export const AutoStartVr = AutoStartVrTemplate.bind({});


### PR DESCRIPTION
Some use cases might make more sense to have an app auto transition from whatever the app is doing into an immersive VR session, rather than having the user click the VR button once the model is visible. 
Add this as a prop that can be modified by the parent to turn VR on/off, or set to true by the parent to mount it in VR already.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>