### PR TITLE
Change progress pie to shader

### DIFF
--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -423,12 +423,7 @@ const VirtualWalkthroughViewer = ({
             annotationIndex={viewingAnnotationIndex}
           />
         )}
-        {/* Mounted outside any session, like the exit button above: its pie registers with a render
-            layer on the transition into a session, which an entity created mid-session never gets.
-            The script idles on its own while there is no session. */}
         <XrGazeDwell activeIndex={viewingAnnotationIndex} />
-        {/* Teleport is off in AR, where it can be disorienting, and while an annotation panel is open,
-            so the trigger can operate the panel and click out to dismiss it. */}
         {/* Number props rather than a Vec3: @playcanvas/react's memo() comparator stops at the
             first prop with an .equals() method, so a Vec3 would stop the ones after it updating. */}
         <Script

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -423,10 +423,9 @@ const VirtualWalkthroughViewer = ({
             annotationIndex={viewingAnnotationIndex}
           />
         )}
-        {/* Mounted for every session rather than only inside one, like the exit button above. Its
-            pie registers with a render layer when the session starts, and an entity that only comes
-            into existence once a session is already running misses that point entirely. The script
-            idles on its own while there is no session. */}
+        {/* Mounted outside any session, like the exit button above: its pie registers with a render
+            layer on the transition into a session, which an entity created mid-session never gets.
+            The script idles on its own while there is no session. */}
         <XrGazeDwell activeIndex={viewingAnnotationIndex} />
         {/* Teleport is off in AR, where it can be disorienting, and while an annotation panel is open,
             so the trigger can operate the panel and click out to dismiss it. */}

--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -423,7 +423,11 @@ const VirtualWalkthroughViewer = ({
             annotationIndex={viewingAnnotationIndex}
           />
         )}
-        {isCurrentlyInXr && <XrGazeDwell activeIndex={viewingAnnotationIndex} />}
+        {/* Mounted for every session rather than only inside one, like the exit button above. Its
+            pie registers with a render layer when the session starts, and an entity that only comes
+            into existence once a session is already running misses that point entirely. The script
+            idles on its own while there is no session. */}
+        <XrGazeDwell activeIndex={viewingAnnotationIndex} />
         {/* Teleport is off in AR, where it can be disorienting, and while an annotation panel is open,
             so the trigger can operate the panel and click out to dismiss it. */}
         {/* Number props rather than a Vec3: @playcanvas/react's memo() comparator stops at the

--- a/src/components/VirtualWalkthrough/xr-gaze-dwell.ts
+++ b/src/components/VirtualWalkthrough/xr-gaze-dwell.ts
@@ -1,16 +1,11 @@
 import {
-  ADDRESS_CLAMP_TO_EDGE,
-  BLEND_NORMAL,
-  CULLFACE_NONE,
-  Color,
   Entity,
-  FILTER_LINEAR,
   LAYERID_IMMEDIATE,
   Mesh,
   MeshInstance,
   Quat,
   Script,
-  StandardMaterial,
+  ShaderMaterial,
   Texture,
   Vec3,
   XRTYPE_VR,
@@ -19,7 +14,8 @@ import {
 import { HOTSPOT_HALF_EXTENT, collectAnnotationHitCandidates } from './xr-annotation-candidates';
 import { nearestAnnotationHit } from './xr-annotation-targeting';
 import { DwellState, INITIAL_DWELL_STATE, advanceDwell } from './xr-gaze-dwell-state';
-import { drawProgressPie } from './xr-progress-pie';
+import { pieShaderProgress } from './xr-progress-pie';
+import { createProgressPieMaterial, emptyMaskTexture, progressPieQuadMesh } from './xr-progress-pie-material';
 
 /** Multiplier on the hotspot's world radius for gaze targeting. */
 const GAZE_HIT_RADIUS_PAD = 5;
@@ -29,9 +25,6 @@ const DWELL_SECONDS = 1.25;
 
 /** Progress-pie quad radius as a multiple of the hotspot's rendered half-extent (covers the hotspot). */
 const PIE_RADIUS_SCALE = 1.25;
-
-/** Progress-pie texture resolution. */
-const PIE_TEXTURE_SIZE = 128;
 
 const LOCAL_FORWARD = new Vec3(0, 0, -1);
 
@@ -45,11 +38,9 @@ export class XrGazeDwell extends Script {
   private _dwell: DwellState = INITIAL_DWELL_STATE;
 
   private _pieEntity?: Entity;
-  private _pieCanvas?: HTMLCanvasElement;
-  private _pieTexture?: Texture;
-  private _pieMaterial?: StandardMaterial;
+  private _pieMaterial?: ShaderMaterial;
   private _pieMesh?: Mesh;
-  private _drawnProgress = -1;
+  private _pieMask?: Texture;
 
   private _headPos = new Vec3();
   private _headRot = new Quat();
@@ -60,37 +51,14 @@ export class XrGazeDwell extends Script {
   private _isVrActive = () => this.app.xr?.active === true && this.app.xr?.type === XRTYPE_VR;
 
   initialize() {
-    this._pieCanvas = document.createElement('canvas');
-    this._pieCanvas.width = PIE_TEXTURE_SIZE;
-    this._pieCanvas.height = PIE_TEXTURE_SIZE;
-
-    this._pieTexture = new Texture(this.app.graphicsDevice, {
-      name: 'xr-gaze-dwell-pie',
-      width: PIE_TEXTURE_SIZE,
-      height: PIE_TEXTURE_SIZE,
-      addressU: ADDRESS_CLAMP_TO_EDGE,
-      addressV: ADDRESS_CLAMP_TO_EDGE,
-      minFilter: FILTER_LINEAR,
-      magFilter: FILTER_LINEAR,
-      mipmaps: true,
+    this._pieMask = emptyMaskTexture(this.app.graphicsDevice);
+    this._pieMaterial = createProgressPieMaterial({
+      uniqueName: 'xr-gaze-dwell-pie',
+      maskMap: this._pieMask,
     });
-    this._pieTexture.setSource(this._pieCanvas);
 
-    const material = new StandardMaterial();
-    material.useLighting = false;
-    material.emissive = new Color(1, 1, 1);
-    material.emissiveMap = this._pieTexture;
-    material.opacityMap = this._pieTexture;
-    material.opacityMapChannel = 'a';
-    material.blendType = BLEND_NORMAL;
-    material.depthTest = false;
-    material.depthWrite = false;
-    material.cull = CULLFACE_NONE;
-    material.update();
-    this._pieMaterial = material;
-
-    this._pieMesh = this._createQuad();
-    const meshInstance = new MeshInstance(this._pieMesh, material);
+    this._pieMesh = progressPieQuadMesh(this.app.graphicsDevice, HOTSPOT_HALF_EXTENT);
+    const meshInstance = new MeshInstance(this._pieMesh, this._pieMaterial);
 
     this._pieEntity = new Entity('xr-gaze-dwell-pie');
     this._pieEntity.addComponent('render', { meshInstances: [meshInstance], layers: [LAYERID_IMMEDIATE] });
@@ -98,28 +66,47 @@ export class XrGazeDwell extends Script {
     this.entity.addChild(this._pieEntity);
   }
 
-  private _createQuad(): Mesh {
-    const h = HOTSPOT_HALF_EXTENT;
-    const mesh = new Mesh(this.app.graphicsDevice);
-    mesh.setPositions([-h, -h, 0, h, -h, 0, h, h, 0, -h, h, 0]);
-    mesh.setNormals([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1]);
-    mesh.setUvs(0, [0, 1, 1, 1, 1, 0, 0, 0]);
-    mesh.setIndices([0, 1, 2, 0, 2, 3]);
-    mesh.update();
+  update(dt: number) {
+    if (!this._pieEntity || !this._pieMaterial) {
+      return;
+    }
+    if (!this._isVrActive() || !this._trackHead()) {
+      this._dwell = INITIAL_DWELL_STATE;
+      this._pieEntity.enabled = false;
 
-    return mesh;
-  }
-
-  /** Redraws the pie fill for the given dwell progress (0..1) onto the texture canvas. */
-  private _drawPie(progress: number) {
-    const ctx = this._pieCanvas?.getContext('2d');
-    if (!ctx) {
       return;
     }
 
-    ctx.clearRect(0, 0, PIE_TEXTURE_SIZE, PIE_TEXTURE_SIZE);
-    drawProgressPie(ctx, PIE_TEXTURE_SIZE, progress);
-    this._pieTexture?.upload();
+    // Enabled for the whole session rather than only while a sweep runs. A mesh instance compiles
+    // its shader variant the first time it is drawn, and that variant is cached against the camera
+    // it was drawn for, so the quad has to be drawn by the XR camera to be of any use. Holding it
+    // enabled from the first XR frame puts the compile in the session-start transition instead of on
+    // the frame a pie first appears. At zero progress every fragment discards, so it costs nothing
+    // visible in between.
+    this._pieEntity.enabled = true;
+
+    const activeName = `annotation-${this.activeIndex}`;
+    const candidates = collectAnnotationHitCandidates(this.app, GAZE_HIT_RADIUS_PAD).filter(
+      (candidate) => candidate.entity.name !== activeName
+    );
+    this._headRot.transformVector(LOCAL_FORWARD, this._forward);
+    const target = nearestAnnotationHit(this._headPos, this._forward, candidates);
+
+    const result = advanceDwell(this._dwell, target, dt, DWELL_SECONDS);
+    this._dwell = result.state;
+
+    const progress = pieShaderProgress(result.progress);
+    this._pieMaterial.setParameter('uProgress', progress);
+    if (progress > 0 && target !== null) {
+      this._placePie(candidates[target].entity);
+    }
+
+    if (result.justOpened && target !== null) {
+      const { entity, script } = candidates[target];
+      const camera = this.app.root.findByName('camera') as any;
+      const screen = camera?.camera?.worldToScreen(entity.getPosition());
+      script.onVrOpenCallback(screen?.x ?? 0, screen?.y ?? 0);
+    }
   }
 
   private _trackHead(): boolean {
@@ -138,65 +125,19 @@ export class XrGazeDwell extends Script {
     return true;
   }
 
-  update(dt: number) {
+  /** Sits the pie on the hotspot, square to the head. */
+  private _placePie(entity: any) {
     if (!this._pieEntity) {
       return;
-    }
-    if (!this._isVrActive() || !this._trackHead()) {
-      this._dwell = INITIAL_DWELL_STATE;
-      this._hidePie();
-
-      return;
-    }
-
-    const activeName = `annotation-${this.activeIndex}`;
-    const candidates = collectAnnotationHitCandidates(this.app, GAZE_HIT_RADIUS_PAD).filter(
-      (candidate) => candidate.entity.name !== activeName
-    );
-    this._headRot.transformVector(LOCAL_FORWARD, this._forward);
-    const target = nearestAnnotationHit(this._headPos, this._forward, candidates);
-
-    const result = advanceDwell(this._dwell, target, dt, DWELL_SECONDS);
-    this._dwell = result.state;
-
-    if (target !== null && result.progress > 0 && result.progress < 1) {
-      this._showPie(candidates[target].entity, result.progress);
-    } else {
-      this._hidePie();
-    }
-
-    if (result.justOpened && target !== null) {
-      const { entity, script } = candidates[target];
-      const camera = this.app.root.findByName('camera') as any;
-      const screen = camera?.camera?.worldToScreen(entity.getPosition());
-      script.onVrOpenCallback(screen?.x ?? 0, screen?.y ?? 0);
-    }
-  }
-
-  private _showPie(entity: any, progress: number) {
-    if (!this._pieEntity) {
-      return;
-    }
-    if (Math.abs(progress - this._drawnProgress) > 0.001) {
-      this._drawnProgress = progress;
-      this._drawPie(progress);
     }
 
     // The unit quad has half-extent HOTSPOT_HALF_EXTENT, so scale it to reach the desired world size.
     entity.getWorldTransform().getScale(this._scratchScale);
     const scale = this._scratchScale.x * PIE_RADIUS_SCALE;
 
-    this._pieEntity.enabled = true;
     this._pieEntity.setLocalScale(scale, scale, scale);
     this._pieEntity.setPosition(entity.getPosition());
     this._pieEntity.setRotation(this._headRot);
-  }
-
-  private _hidePie() {
-    if (this._pieEntity && this._pieEntity.enabled) {
-      this._pieEntity.enabled = false;
-      this._drawnProgress = -1;
-    }
   }
 
   destroy() {
@@ -209,9 +150,9 @@ export class XrGazeDwell extends Script {
     }
     this._pieMesh?.destroy();
     this._pieMaterial?.destroy();
-    this._pieTexture?.destroy();
+    this._pieMask?.destroy();
     this._pieMesh = undefined;
     this._pieMaterial = undefined;
-    this._pieTexture = undefined;
+    this._pieMask = undefined;
   }
 }

--- a/src/components/VirtualWalkthrough/xr-gaze-dwell.ts
+++ b/src/components/VirtualWalkthrough/xr-gaze-dwell.ts
@@ -60,6 +60,12 @@ export class XrGazeDwell extends Script {
     this._pieMesh = progressPieQuadMesh(this.app.graphicsDevice, HOTSPOT_HALF_EXTENT);
     const meshInstance = new MeshInstance(this._pieMesh, this._pieMaterial);
 
+    // Never frustum-culled. The quad is not positioned until a sweep actually starts, so until then
+    // it sits unplaced at the origin, where culling would drop it from the render list entirely and
+    // the shader compile it is being kept enabled for would never happen. One always-submitted quad
+    // that discards every fragment is cheaper than that compile landing mid-gaze.
+    meshInstance.cull = false;
+
     this._pieEntity = new Entity('xr-gaze-dwell-pie');
     this._pieEntity.addComponent('render', { meshInstances: [meshInstance], layers: [LAYERID_IMMEDIATE] });
     this._pieEntity.enabled = false;

--- a/src/components/VirtualWalkthrough/xr-gaze-dwell.ts
+++ b/src/components/VirtualWalkthrough/xr-gaze-dwell.ts
@@ -51,12 +51,10 @@ export class XrGazeDwell extends Script {
   private _isVrActive = () => this.app.xr?.active === true && this.app.xr?.type === XRTYPE_VR;
 
   /**
-   * The pie's visibility is driven from the session events rather than from `update`, because a
-   * render component only registers its mesh instances with a layer on a false-to-true transition.
-   * Flipping it opportunistically mid-frame can land that registration while the session is still
-   * assembling its layers, and because the flag then stays true the component never retries, leaving
-   * the pie silently absent for the rest of the session. Session start is a defined point where the
-   * layers exist, and the matching end event restores the transition for the next session.
+   * A render component hands its mesh instances to a layer only when it flips from disabled to
+   * enabled, and hands over nothing if the layer cannot be resolved yet. The session events are the
+   * points where the layers are known to exist, so the pie flips there: start registers it, and end
+   * restores the transition for the next session.
    */
   private _onXrStart = () => {
     this._dwell = INITIAL_DWELL_STATE;
@@ -85,10 +83,10 @@ export class XrGazeDwell extends Script {
     this._pieMesh = progressPieQuadMesh(this.app.graphicsDevice, HOTSPOT_HALF_EXTENT);
     const meshInstance = new MeshInstance(this._pieMesh, this._pieMaterial);
 
-    // Never frustum-culled. The quad is not positioned until a sweep actually starts, so until then
-    // it sits unplaced at the origin, where culling would drop it from the render list entirely and
-    // the shader compile it is being kept enabled for would never happen. One always-submitted quad
-    // that discards every fragment is cheaper than that compile landing mid-gaze.
+    // Never frustum-culled. The quad only takes a position once a sweep starts, and until then sits
+    // at the origin where culling would drop it from the render list - taking the shader compile it
+    // stays enabled for along with it. An always-submitted quad that discards every fragment costs
+    // less than that compile landing mid-gaze.
     meshInstance.cull = false;
 
     this._pieEntity = new Entity('xr-gaze-dwell-pie');

--- a/src/components/VirtualWalkthrough/xr-gaze-dwell.ts
+++ b/src/components/VirtualWalkthrough/xr-gaze-dwell.ts
@@ -50,6 +50,31 @@ export class XrGazeDwell extends Script {
 
   private _isVrActive = () => this.app.xr?.active === true && this.app.xr?.type === XRTYPE_VR;
 
+  /**
+   * The pie's visibility is driven from the session events rather than from `update`, because a
+   * render component only registers its mesh instances with a layer on a false-to-true transition.
+   * Flipping it opportunistically mid-frame can land that registration while the session is still
+   * assembling its layers, and because the flag then stays true the component never retries, leaving
+   * the pie silently absent for the rest of the session. Session start is a defined point where the
+   * layers exist, and the matching end event restores the transition for the next session.
+   */
+  private _onXrStart = () => {
+    this._dwell = INITIAL_DWELL_STATE;
+    this._setPieEnabled(this._isVrActive());
+  };
+
+  private _onXrEnd = () => {
+    this._dwell = INITIAL_DWELL_STATE;
+    this._pieMaterial?.setParameter('uProgress', 0);
+    this._setPieEnabled(false);
+  };
+
+  private _setPieEnabled(enabled: boolean) {
+    if (this._pieEntity) {
+      this._pieEntity.enabled = enabled;
+    }
+  }
+
   initialize() {
     this._pieMask = emptyMaskTexture(this.app.graphicsDevice);
     this._pieMaterial = createProgressPieMaterial({
@@ -70,6 +95,12 @@ export class XrGazeDwell extends Script {
     this._pieEntity.addComponent('render', { meshInstances: [meshInstance], layers: [LAYERID_IMMEDIATE] });
     this._pieEntity.enabled = false;
     this.entity.addChild(this._pieEntity);
+
+    // Both orders happen: the walkthrough can mount into a session that has already started (as it
+    // does when VR is entered from outside the canvas), or mount first and wait for one.
+    this._setPieEnabled(this._isVrActive());
+    this.app.xr?.on('start', this._onXrStart);
+    this.app.xr?.on('end', this._onXrEnd);
   }
 
   update(dt: number) {
@@ -78,18 +109,10 @@ export class XrGazeDwell extends Script {
     }
     if (!this._isVrActive() || !this._trackHead()) {
       this._dwell = INITIAL_DWELL_STATE;
-      this._pieEntity.enabled = false;
+      this._pieMaterial.setParameter('uProgress', 0);
 
       return;
     }
-
-    // Enabled for the whole session rather than only while a sweep runs. A mesh instance compiles
-    // its shader variant the first time it is drawn, and that variant is cached against the camera
-    // it was drawn for, so the quad has to be drawn by the XR camera to be of any use. Holding it
-    // enabled from the first XR frame puts the compile in the session-start transition instead of on
-    // the frame a pie first appears. At zero progress every fragment discards, so it costs nothing
-    // visible in between.
-    this._pieEntity.enabled = true;
 
     const activeName = `annotation-${this.activeIndex}`;
     const candidates = collectAnnotationHitCandidates(this.app, GAZE_HIT_RADIUS_PAD).filter(
@@ -147,6 +170,8 @@ export class XrGazeDwell extends Script {
   }
 
   destroy() {
+    this.app.xr?.off('start', this._onXrStart);
+    this.app.xr?.off('end', this._onXrEnd);
     if (this._pieEntity) {
       if (this._pieEntity.render) {
         this._pieEntity.render.meshInstances = [];

--- a/src/components/VirtualWalkthrough/xr-progress-pie-material.ts
+++ b/src/components/VirtualWalkthrough/xr-progress-pie-material.ts
@@ -1,6 +1,8 @@
 import {
+  ADDRESS_CLAMP_TO_EDGE,
   BLEND_NORMAL,
   CULLFACE_NONE,
+  FILTER_NEAREST,
   GraphicsDevice,
   Mesh,
   PIXELFORMAT_RGBA8,
@@ -119,7 +121,13 @@ export const progressPieQuadMesh = (device: GraphicsDevice, halfExtent: number):
   return mesh;
 };
 
-/** A single transparent texel, for pies that carry no static artwork of their own. */
+/**
+ * A single transparent texel, for pies that carry no static artwork of their own.
+ *
+ * The filters are set explicitly because the default minification filter samples a mipmap chain,
+ * which a single-level texture does not have. That combination is incomplete in WebGL, and what a
+ * shader reads from an incomplete texture is not something to rely on.
+ */
 export const emptyMaskTexture = (device: GraphicsDevice): Texture => {
   const texture = new Texture(device, {
     name: 'xr-progress-pie-empty-mask',
@@ -127,6 +135,10 @@ export const emptyMaskTexture = (device: GraphicsDevice): Texture => {
     height: 1,
     format: PIXELFORMAT_RGBA8,
     mipmaps: false,
+    minFilter: FILTER_NEAREST,
+    magFilter: FILTER_NEAREST,
+    addressU: ADDRESS_CLAMP_TO_EDGE,
+    addressV: ADDRESS_CLAMP_TO_EDGE,
   });
   const pixels = texture.lock();
   pixels.set([0, 0, 0, 0]);

--- a/src/components/VirtualWalkthrough/xr-progress-pie-material.ts
+++ b/src/components/VirtualWalkthrough/xr-progress-pie-material.ts
@@ -1,0 +1,180 @@
+import {
+  BLEND_NORMAL,
+  CULLFACE_NONE,
+  GraphicsDevice,
+  Mesh,
+  PIXELFORMAT_RGBA8,
+  SEMANTIC_POSITION,
+  SEMANTIC_TEXCOORD0,
+  ShaderMaterial,
+  Texture,
+} from 'playcanvas';
+
+/** Pie radius as a fraction of the quad's half-extent. Matches the canvas-drawn artwork it replaces. */
+const PIE_RADIUS = 0.92;
+
+// GLSL only, for the same reason as BoundaryWallScript: @playcanvas/react's Application defaults to
+// deviceTypes [DEVICETYPE_WEBGL2], so WGSL variants would never be compiled here.
+const pieVertexGLSL = /* glsl */ `
+    attribute vec3 vertex_position;
+    attribute vec2 aUv0;
+
+    uniform mat4 matrix_model;
+    uniform mat4 matrix_viewProjection;
+
+    varying vec2 uv0;
+
+    void main(void) {
+        uv0 = aUv0;
+        gl_Position = matrix_viewProjection * matrix_model * vec4(vertex_position, 1.0);
+    }
+`;
+
+/**
+ * Draws the progress sweep analytically from a uniform, so animating it costs one uniform write per
+ * frame rather than repainting a canvas and re-uploading a texture.
+ *
+ * `uMaskMap` carries whatever static artwork sits around the pie, baked once by the caller: red is
+ * a mask for a backing disc drawn under the sweep, green a mask for a glyph drawn over it. Callers
+ * with no such artwork bind a transparent pixel and get the bare pie.
+ */
+const pieFragmentGLSL = /* glsl */ `
+    uniform float uProgress;
+    uniform vec3 uTrackColor;
+    uniform float uTrackAlpha;
+    uniform vec3 uWedgeColor;
+    uniform float uWedgeAlpha;
+    uniform vec3 uDiscColor;
+    uniform float uDiscAlpha;
+    uniform vec3 uGlyphColor;
+    uniform sampler2D uMaskMap;
+
+    varying vec2 uv0;
+
+    const float PI = 3.14159265359;
+    const float TWO_PI = 6.28318530718;
+    const float HALF_PI = 1.57079632679;
+    const float PIE_RADIUS = ${PIE_RADIUS};
+
+    /** Source-over composite of a straight-alpha source onto a straight-alpha destination. */
+    vec4 over(vec4 dst, vec4 src) {
+        float a = src.a + dst.a * (1.0 - src.a);
+        if (a <= 0.0) {
+            return vec4(0.0);
+        }
+
+        return vec4((src.rgb * src.a + dst.rgb * dst.a * (1.0 - src.a)) / a, a);
+    }
+
+    void main(void) {
+        // The quad's UVs run y-down (v = 0 along the top edge), so centring them gives a coordinate
+        // system matching the 2D canvas this replaces: +y downward, angles increasing clockwise.
+        vec2 p = uv0 * 2.0 - 1.0;
+        float d = length(p);
+
+        // Derivatives are undefined in non-uniform control flow, so every fwidth runs before the
+        // discard at the end.
+        float radiusFeather = fwidth(d);
+        float insideDisc = 1.0 - smoothstep(PIE_RADIUS - radiusFeather, PIE_RADIUS + radiusFeather, d);
+
+        // Fraction of a full turn, measured clockwise from 12 o'clock.
+        float turn = mod(atan(p.y, p.x) + HALF_PI + TWO_PI, TWO_PI) / TWO_PI;
+
+        // Signed arc-length to the sweep's leading edge, which is smooth either side of that edge and
+        // so antialiases cleanly. It jumps at the 12 o'clock seam, where fwidth would blow up and
+        // wash the edge out to half coverage, so the feather is capped to keep the smoothstep
+        // saturated there instead.
+        float edgeDistance = (turn - uProgress) * TWO_PI * d;
+        float edgeFeather = min(fwidth(edgeDistance), 0.05);
+        float swept = 1.0 - smoothstep(-edgeFeather, edgeFeather, edgeDistance);
+
+        // A pie at zero progress is not started, and should not show even its track.
+        float pie = insideDisc * step(0.0001, uProgress);
+
+        vec4 mask = texture2D(uMaskMap, uv0);
+
+        vec4 color = over(vec4(0.0), vec4(uDiscColor, uDiscAlpha * mask.r));
+        color = over(color, vec4(uTrackColor, uTrackAlpha * pie));
+        color = over(color, vec4(uWedgeColor, uWedgeAlpha * pie * swept));
+        color = over(color, vec4(uGlyphColor, mask.g));
+
+        if (color.a <= 0.0) {
+            discard;
+        }
+
+        gl_FragColor = color;
+    }
+`;
+
+/** A camera-facing unit quad with y-down UVs, sized to `halfExtent` in local units. */
+export const progressPieQuadMesh = (device: GraphicsDevice, halfExtent: number): Mesh => {
+  const h = halfExtent;
+  const mesh = new Mesh(device);
+  mesh.setPositions([-h, -h, 0, h, -h, 0, h, h, 0, -h, h, 0]);
+  mesh.setNormals([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1]);
+  mesh.setUvs(0, [0, 1, 1, 1, 1, 0, 0, 0]);
+  mesh.setIndices([0, 1, 2, 0, 2, 3]);
+  mesh.update();
+
+  return mesh;
+};
+
+/** A single transparent texel, for pies that carry no static artwork of their own. */
+export const emptyMaskTexture = (device: GraphicsDevice): Texture => {
+  const texture = new Texture(device, {
+    name: 'xr-progress-pie-empty-mask',
+    width: 1,
+    height: 1,
+    format: PIXELFORMAT_RGBA8,
+    mipmaps: false,
+  });
+  const pixels = texture.lock();
+  pixels.set([0, 0, 0, 0]);
+  texture.unlock();
+
+  return texture;
+};
+
+export interface ProgressPieMaterialOptions {
+  uniqueName: string;
+  /** Static artwork baked once: red masks a disc under the sweep, green a glyph over it. */
+  maskMap: Texture;
+  discColor?: [number, number, number];
+  discAlpha?: number;
+}
+
+/**
+ * Material for a progress pie. Everything that animates rides on the `uProgress` uniform, so a
+ * running sweep never touches the canvas or the texture upload path.
+ */
+export const createProgressPieMaterial = ({
+  uniqueName,
+  maskMap,
+  discColor = [0.08, 0.08, 0.08],
+  discAlpha = 0,
+}: ProgressPieMaterialOptions): ShaderMaterial => {
+  const material = new ShaderMaterial({
+    uniqueName,
+    vertexGLSL: pieVertexGLSL,
+    fragmentGLSL: pieFragmentGLSL,
+    attributes: { vertex_position: SEMANTIC_POSITION, aUv0: SEMANTIC_TEXCOORD0 },
+  });
+
+  material.blendType = BLEND_NORMAL;
+  material.cull = CULLFACE_NONE;
+  material.depthTest = false;
+  material.depthWrite = false;
+
+  material.setParameter('uProgress', 0);
+  material.setParameter('uTrackColor', [1, 1, 1]);
+  material.setParameter('uTrackAlpha', 0.18);
+  material.setParameter('uWedgeColor', [64 / 255, 200 / 255, 1]);
+  material.setParameter('uWedgeAlpha', 0.85);
+  material.setParameter('uDiscColor', discColor);
+  material.setParameter('uDiscAlpha', discAlpha);
+  material.setParameter('uGlyphColor', [1, 1, 1]);
+  material.setParameter('uMaskMap', maskMap);
+  material.update();
+
+  return material;
+};

--- a/src/components/VirtualWalkthrough/xr-progress-pie-material.ts
+++ b/src/components/VirtualWalkthrough/xr-progress-pie-material.ts
@@ -12,7 +12,7 @@ import {
   Texture,
 } from 'playcanvas';
 
-/** Pie radius as a fraction of the quad's half-extent. Matches the canvas-drawn artwork it replaces. */
+/** Pie radius as a fraction of the quad's half-extent. */
 const PIE_RADIUS = 0.92;
 
 // GLSL only, for the same reason as BoundaryWallScript: @playcanvas/react's Application defaults to
@@ -33,8 +33,8 @@ const pieVertexGLSL = /* glsl */ `
 `;
 
 /**
- * Draws the progress sweep analytically from a uniform, so animating it costs one uniform write per
- * frame rather than repainting a canvas and re-uploading a texture.
+ * Draws the progress sweep analytically from `uProgress`, so animating it costs one uniform write
+ * per frame.
  *
  * `uMaskMap` carries whatever static artwork sits around the pie, baked once by the caller: red is
  * a mask for a backing disc drawn under the sweep, green a mask for a glyph drawn over it. Callers
@@ -70,7 +70,7 @@ const pieFragmentGLSL = /* glsl */ `
 
     void main(void) {
         // The quad's UVs run y-down (v = 0 along the top edge), so centring them gives a coordinate
-        // system matching the 2D canvas this replaces: +y downward, angles increasing clockwise.
+        // system with +y downward and angles increasing clockwise.
         vec2 p = uv0 * 2.0 - 1.0;
         float d = length(p);
 
@@ -157,7 +157,7 @@ export interface ProgressPieMaterialOptions {
 
 /**
  * Material for a progress pie. Everything that animates rides on the `uProgress` uniform, so a
- * running sweep never touches the canvas or the texture upload path.
+ * running sweep costs one uniform write per frame and no texture work at all.
  */
 export const createProgressPieMaterial = ({
   uniqueName,

--- a/src/components/VirtualWalkthrough/xr-progress-pie.test.ts
+++ b/src/components/VirtualWalkthrough/xr-progress-pie.test.ts
@@ -1,4 +1,4 @@
-import { drawProgressPie } from './xr-progress-pie';
+import { drawProgressPie, pieShaderProgress } from './xr-progress-pie';
 
 const TRACK_FILL = 'rgba(255, 255, 255, 0.18)';
 const WEDGE_FILL = 'rgba(64, 200, 255, 0.85)';
@@ -63,5 +63,19 @@ describe('drawProgressPie', () => {
     drawProgressPie(ctx, 256, 0);
 
     expect(arcs[0].radius).toBeCloseTo(128 * 0.92);
+  });
+});
+
+describe('pieShaderProgress', () => {
+  it('passes an in-flight progress through unchanged', () => {
+    expect(pieShaderProgress(0.4)).toBeCloseTo(0.4);
+  });
+
+  it('hides the pie before any progress has accumulated', () => {
+    expect(pieShaderProgress(0)).toBe(0);
+  });
+
+  it('hides the pie once progress completes', () => {
+    expect(pieShaderProgress(1)).toBe(0);
   });
 });

--- a/src/components/VirtualWalkthrough/xr-progress-pie.ts
+++ b/src/components/VirtualWalkthrough/xr-progress-pie.ts
@@ -2,6 +2,16 @@
 const PIE_START_ANGLE = -Math.PI / 2;
 
 /**
+ * Progress to hand the pie shader, where 0 draws nothing at all: an untouched target wears no faint
+ * track, and a completed one has already opened its annotation or ended the session.
+ *
+ * The quad stays enabled and draws nothing at 0 rather than toggling its entity, because a mesh
+ * instance compiles its shader variant the first time it is actually drawn. Toggling would put that
+ * compile on the frame the pie first appears, which is exactly the frame that has to stay smooth.
+ */
+export const pieShaderProgress = (progress: number): number => (progress > 0 && progress < 1 ? progress : 0);
+
+/**
  * Draws a circular progress pie into the `size` x `size` region at the context origin: a faint
  * full-circle track under a wedge that sweeps clockwise as `progress` goes 0 -> 1. A `progress`
  * above 1 simply sweeps a full circle. Neither clears the context nor uploads a texture, so callers

--- a/src/components/VirtualWalkthrough/xr-progress-pie.ts
+++ b/src/components/VirtualWalkthrough/xr-progress-pie.ts
@@ -5,9 +5,9 @@ const PIE_START_ANGLE = -Math.PI / 2;
  * Progress to hand the pie shader, where 0 draws nothing at all: an untouched target wears no faint
  * track, and a completed one has already opened its annotation or ended the session.
  *
- * The quad stays enabled and draws nothing at 0 rather than toggling its entity, because a mesh
- * instance compiles its shader variant the first time it is actually drawn. Toggling would put that
- * compile on the frame the pie first appears, which is exactly the frame that has to stay smooth.
+ * Visibility rides on this value so the quad can stay enabled for the whole session. A mesh
+ * instance compiles its shader variant the first time it is drawn, and that compile has to land
+ * somewhere other than the frame a pie first appears.
  */
 export const pieShaderProgress = (progress: number): number => (progress > 0 && progress < 1 ? progress : 0);
 


### PR DESCRIPTION
Instead of repainting a canvas and reuploading a texture every frame of the dwell, use a shader and progress number to draw the progress pie.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>