### PR TITLE
Reduce garbage collection for annotations

### DIFF
--- a/src/components/VirtualWalkthrough/xr-annotation-candidate-buffer.test.ts
+++ b/src/components/VirtualWalkthrough/xr-annotation-candidate-buffer.test.ts
@@ -1,0 +1,146 @@
+import { Vec3 } from 'playcanvas';
+
+import { AnnotationCandidateBuffer } from './xr-annotation-candidate-buffer';
+
+interface FakeAnnotationOptions {
+  name: string;
+  position?: Vec3;
+  scale?: number;
+  enabled?: boolean;
+  openable?: boolean;
+}
+
+const fakeAnnotation = ({
+  name,
+  position = new Vec3(),
+  scale = 1,
+  enabled = true,
+  openable = true,
+}: FakeAnnotationOptions) => ({
+  name,
+  position,
+  scale,
+  annotationScript: {
+    enabled,
+    ...(openable ? { onVrOpenCallback: () => undefined } : {}),
+  },
+  getPosition(): Vec3 {
+    return this.position;
+  },
+  getWorldTransform() {
+    return {
+      getScale: (out: Vec3) => {
+        out.set(this.scale, this.scale, this.scale);
+
+        return out;
+      },
+    };
+  },
+});
+
+type FakeAnnotation = ReturnType<typeof fakeAnnotation>;
+
+const fakeApp = (children: FakeAnnotation[]) => ({
+  root: { findByName: (name: string) => (name === 'annotations-root' ? { children } : null) },
+});
+
+const newBuffer = () => new AnnotationCandidateBuffer((entity: any) => entity.annotationScript);
+
+describe('AnnotationCandidateBuffer', () => {
+  it('hands back the same array on every collect, so a per-frame caller allocates nothing', () => {
+    const buffer = newBuffer();
+    const app = fakeApp([fakeAnnotation({ name: 'annotation-0' })]);
+
+    expect(buffer.collect(app, 1)).toBe(buffer.collect(app, 1));
+  });
+
+  it('reuses the candidate objects rather than rebuilding them', () => {
+    const buffer = newBuffer();
+    const app = fakeApp([fakeAnnotation({ name: 'annotation-0' })]);
+
+    const first = buffer.collect(app, 1)[0];
+
+    expect(first).toBeDefined();
+    expect(buffer.collect(app, 1)[0]).toBe(first);
+  });
+
+  it('derives the hit radius from the hotspot scale and the pad', () => {
+    const buffer = newBuffer();
+    const app = fakeApp([fakeAnnotation({ name: 'annotation-0', scale: 3 })]);
+
+    expect(buffer.collect(app, 2)[0].radius).toBeCloseTo(0.5 * 3 * 2);
+  });
+
+  it('picks up a hotspot that has moved or resized since the last collect', () => {
+    const buffer = newBuffer();
+    const annotation = fakeAnnotation({ name: 'annotation-0', position: new Vec3(1, 0, 0) });
+    const app = fakeApp([annotation]);
+
+    buffer.collect(app, 1);
+    annotation.position = new Vec3(9, 0, 0);
+    annotation.scale = 4;
+    const candidate = buffer.collect(app, 1)[0];
+
+    expect(candidate.position.x).toBeCloseTo(9);
+    expect(candidate.radius).toBeCloseTo(0.5 * 4);
+  });
+
+  it('shrinks when an annotation is removed', () => {
+    const buffer = newBuffer();
+    const children = [fakeAnnotation({ name: 'annotation-0' }), fakeAnnotation({ name: 'annotation-1' })];
+    const app = fakeApp(children);
+
+    expect(buffer.collect(app, 1)).toHaveLength(2);
+    children.pop();
+
+    expect(buffer.collect(app, 1)).toHaveLength(1);
+  });
+
+  it('grows when an annotation is added', () => {
+    const buffer = newBuffer();
+    const children = [fakeAnnotation({ name: 'annotation-0' })];
+    const app = fakeApp(children);
+
+    buffer.collect(app, 1);
+    children.push(fakeAnnotation({ name: 'annotation-1' }));
+
+    expect(buffer.collect(app, 1)).toHaveLength(2);
+  });
+
+  it('leaves out the excluded entity', () => {
+    const buffer = newBuffer();
+    const app = fakeApp([fakeAnnotation({ name: 'annotation-0' }), fakeAnnotation({ name: 'annotation-1' })]);
+
+    const candidates = buffer.collect(app, 1, 'annotation-0');
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].entity.name).toBe('annotation-1');
+  });
+
+  it('keeps unnamed annotations when nothing is excluded', () => {
+    const buffer = newBuffer();
+    const unnamed = fakeAnnotation({ name: undefined as unknown as string });
+
+    expect(buffer.collect(fakeApp([unnamed]), 1)).toHaveLength(1);
+  });
+
+  it('leaves out disabled annotations and ones that cannot be opened', () => {
+    const buffer = newBuffer();
+    const app = fakeApp([
+      fakeAnnotation({ name: 'annotation-0', enabled: false }),
+      fakeAnnotation({ name: 'annotation-1', openable: false }),
+      fakeAnnotation({ name: 'annotation-2' }),
+    ]);
+
+    const candidates = buffer.collect(app, 1);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].entity.name).toBe('annotation-2');
+  });
+
+  it('is empty when the annotations root is missing', () => {
+    const buffer = newBuffer();
+
+    expect(buffer.collect({ root: { findByName: () => null } }, 1)).toHaveLength(0);
+  });
+});

--- a/src/components/VirtualWalkthrough/xr-annotation-candidate-buffer.test.ts
+++ b/src/components/VirtualWalkthrough/xr-annotation-candidate-buffer.test.ts
@@ -40,9 +40,42 @@ const fakeAnnotation = ({
 
 type FakeAnnotation = ReturnType<typeof fakeAnnotation>;
 
-const fakeApp = (children: FakeAnnotation[]) => ({
-  root: { findByName: (name: string) => (name === 'annotations-root' ? { children } : null) },
-});
+/**
+ * App whose `annotations-root` hangs off the scene root the way a mounted one does. `detach` stands
+ * in for the teardown React does when the annotation list empties: the root leaves the scene but,
+ * like a destroyed PlayCanvas entity, keeps an emptied `children` array behind.
+ */
+const fakeApp = (children: FakeAnnotation[]) => {
+  const sceneRoot: any = {
+    findByName: (name: string) => (name === 'annotations-root' ? sceneRoot.annotationsRoot : null),
+    annotationsRoot: null as any,
+    lookups: 0,
+  };
+
+  const mount = (mounted: FakeAnnotation[]) => {
+    sceneRoot.annotationsRoot = { children: mounted, parent: sceneRoot };
+  };
+
+  mount(children);
+
+  const findByName = sceneRoot.findByName;
+  sceneRoot.findByName = (name: string) => {
+    sceneRoot.lookups++;
+
+    return findByName(name);
+  };
+
+  return {
+    root: sceneRoot,
+    lookups: () => sceneRoot.lookups,
+    mount,
+    detach: () => {
+      sceneRoot.annotationsRoot.children.length = 0;
+      sceneRoot.annotationsRoot.parent = null;
+      sceneRoot.annotationsRoot = null;
+    },
+  };
+};
 
 const newBuffer = () => new AnnotationCandidateBuffer((entity: any) => entity.annotationScript);
 
@@ -136,6 +169,32 @@ describe('AnnotationCandidateBuffer', () => {
 
     expect(candidates).toHaveLength(1);
     expect(candidates[0].entity.name).toBe('annotation-2');
+  });
+
+  it('holds onto the annotations root instead of looking it up again every collect', () => {
+    const buffer = newBuffer();
+    const app = fakeApp([fakeAnnotation({ name: 'annotation-0' })]);
+
+    buffer.collect(app, 1);
+    buffer.collect(app, 1);
+
+    expect(app.lookups()).toBe(1);
+  });
+
+  it('finds the annotations root again after it is torn down and rebuilt', () => {
+    const buffer = newBuffer();
+    const app = fakeApp([fakeAnnotation({ name: 'annotation-0' })]);
+
+    buffer.collect(app, 1);
+    app.detach();
+
+    expect(buffer.collect(app, 1)).toHaveLength(0);
+
+    app.mount([fakeAnnotation({ name: 'annotation-1' })]);
+    const candidates = buffer.collect(app, 1);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].entity.name).toBe('annotation-1');
   });
 
   it('is empty when the annotations root is missing', () => {

--- a/src/components/VirtualWalkthrough/xr-annotation-candidate-buffer.ts
+++ b/src/components/VirtualWalkthrough/xr-annotation-candidate-buffer.ts
@@ -1,0 +1,81 @@
+import { Vec3 } from 'playcanvas';
+
+/** Local half-extent of the unit-plane hotspot quad. */
+export const HOTSPOT_HALF_EXTENT = 0.5;
+
+export interface AnnotationCandidate {
+  entity: any;
+  script: any;
+  position: Vec3;
+  radius: number;
+}
+
+/** Pulls the stock annotation script off a hotspot entity, or undefined if it carries none. */
+export type AnnotationScriptLookup = (entity: any) => any;
+
+const scratchScale = new Vec3();
+
+/**
+ * Collects world-space hit candidates for the openable annotation hotspots into a buffer it owns and
+ * reuses, so a caller running every frame allocates nothing. The returned array and the candidate
+ * objects inside it are overwritten by the next `collect`, which is why each caller holds its own
+ * buffer rather than sharing one.
+ *
+ * Positions and radii are re-read on every call rather than cached, so hotspots that move or resize
+ * stay targetable. That read is cheap; it was the array and object churn around it that cost.
+ */
+export class AnnotationCandidateBuffer {
+  private readonly _candidates: AnnotationCandidate[] = [];
+  private _root: any = null;
+
+  constructor(private readonly _getScript: AnnotationScriptLookup) {}
+
+  /**
+   * Hit candidates for every openable hotspot except `excludeName`, with hit spheres derived from
+   * each hotspot's rendered world size and padded by `radiusPad` for easier aiming.
+   */
+  collect(app: any, radiusPad: number, excludeName?: string): AnnotationCandidate[] {
+    // The root is looked up by a walk of the whole scene graph, so it is held onto between frames.
+    // It is re-resolved whenever it goes missing, since annotations mount after the scene does.
+    if (!this._root || this._root.children === undefined) {
+      this._root = app.root.findByName('annotations-root');
+    }
+
+    const children = this._root?.children;
+    if (!children) {
+      this._candidates.length = 0;
+
+      return this._candidates;
+    }
+
+    let count = 0;
+    for (const entity of children) {
+      if (excludeName !== undefined && entity.name === excludeName) {
+        continue;
+      }
+
+      const script = this._getScript(entity);
+      if (!script || script.enabled === false || typeof script.onVrOpenCallback !== 'function') {
+        continue;
+      }
+
+      entity.getWorldTransform().getScale(scratchScale);
+      const radius = HOTSPOT_HALF_EXTENT * scratchScale.x * radiusPad;
+      const existing = this._candidates[count];
+
+      if (existing) {
+        existing.entity = entity;
+        existing.script = script;
+        existing.position = entity.getPosition();
+        existing.radius = radius;
+      } else {
+        this._candidates.push({ entity, script, position: entity.getPosition(), radius });
+      }
+      count++;
+    }
+
+    this._candidates.length = count;
+
+    return this._candidates;
+  }
+}

--- a/src/components/VirtualWalkthrough/xr-annotation-candidate-buffer.ts
+++ b/src/components/VirtualWalkthrough/xr-annotation-candidate-buffer.ts
@@ -21,8 +21,8 @@ const scratchScale = new Vec3();
  * objects inside it are overwritten by the next `collect`, which is why each caller holds its own
  * buffer rather than sharing one.
  *
- * Positions and radii are re-read on every call rather than cached, so hotspots that move or resize
- * stay targetable. That read is cheap; it was the array and object churn around it that cost.
+ * Positions and radii are re-read on every call, so hotspots that move or resize stay targetable.
+ * That read is cheap; it is the allocation around it that a per-frame caller cannot afford.
  */
 export class AnnotationCandidateBuffer {
   private readonly _candidates: AnnotationCandidate[] = [];

--- a/src/components/VirtualWalkthrough/xr-annotation-candidate-buffer.ts
+++ b/src/components/VirtualWalkthrough/xr-annotation-candidate-buffer.ts
@@ -16,6 +16,21 @@ export type AnnotationScriptLookup = (entity: any) => any;
 const scratchScale = new Vec3();
 
 /**
+ * Whether `node` still hangs beneath `sceneRoot`. An entity that has been removed from the scene
+ * keeps its own `children` array - a destroyed one keeps it as an empty array - so only a walk back
+ * up the parent chain tells a live root apart from a detached one.
+ */
+const isInScene = (node: any, sceneRoot: any): boolean => {
+  for (let current = node; current; current = current.parent) {
+    if (current === sceneRoot) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+/**
  * Collects world-space hit candidates for the openable annotation hotspots into a buffer it owns and
  * reuses, so a caller running every frame allocates nothing. The returned array and the candidate
  * objects inside it are overwritten by the next `collect`, which is why each caller holds its own
@@ -36,8 +51,9 @@ export class AnnotationCandidateBuffer {
    */
   collect(app: any, radiusPad: number, excludeName?: string): AnnotationCandidate[] {
     // The root is looked up by a walk of the whole scene graph, so it is held onto between frames.
-    // It is re-resolved whenever it goes missing, since annotations mount after the scene does.
-    if (!this._root || this._root.children === undefined) {
+    // It is re-resolved whenever it leaves the scene: annotations mount after the scene does, and
+    // the root is torn down and built afresh every time the annotation list empties and refills.
+    if (!isInScene(this._root, app.root)) {
       this._root = app.root.findByName('annotations-root');
     }
 

--- a/src/components/VirtualWalkthrough/xr-annotation-candidates.ts
+++ b/src/components/VirtualWalkthrough/xr-annotation-candidates.ts
@@ -1,43 +1,23 @@
-import { Vec3 } from 'playcanvas';
 import { Annotation as PcAnnotation } from 'playcanvas/scripts/esm/annotations.mjs';
 
-/** Local half-extent of the unit-plane hotspot quad. */
-export const HOTSPOT_HALF_EXTENT = 0.5;
+import { AnnotationCandidate, AnnotationCandidateBuffer, HOTSPOT_HALF_EXTENT } from './xr-annotation-candidate-buffer';
+
+export { HOTSPOT_HALF_EXTENT };
+export type { AnnotationCandidate };
 
 /** Multiplier on the hotspot's world radius to make controller targeting forgiving. */
 export const HIT_RADIUS_PAD = 2.5;
 
-export interface AnnotationCandidate {
-  entity: any;
-  script: any;
-  position: Vec3;
-  radius: number;
-}
+const annotationScriptOf = (entity: any) => entity.script?.get(PcAnnotation.scriptName);
 
-const scratchScale = new Vec3();
+/** A buffer wired to the stock annotation script. Callers that collect every frame hold one of
+ * these; its results are overwritten on the next collect, so one buffer cannot be shared. */
+export const createAnnotationCandidateBuffer = (): AnnotationCandidateBuffer =>
+  new AnnotationCandidateBuffer(annotationScriptOf);
 
 /**
- * World-space hit candidates for every openable annotation hotspot: its entity, its stock
- * annotation script (which carries `onVrOpenCallback`), its world position, and a hit-sphere
- * radius derived from the hotspot's rendered world size, padded by `radiusPad` for easier aiming.
+ * One-shot collection for callers that run on an input event rather than every frame, and so have no
+ * reason to hold a buffer of their own.
  */
-export const collectAnnotationHitCandidates = (app: any, radiusPad: number): AnnotationCandidate[] => {
-  const root = app.root.findByName('annotations-root');
-  if (!root) {
-    return [];
-  }
-
-  return root.children
-    .map((entity: any) => ({ entity, script: entity.script?.get(PcAnnotation.scriptName) }))
-    .filter(({ script }: any) => script && script.enabled !== false && typeof script.onVrOpenCallback === 'function')
-    .map(({ entity, script }: any) => {
-      entity.getWorldTransform().getScale(scratchScale);
-
-      return {
-        entity,
-        script,
-        position: entity.getPosition(),
-        radius: HOTSPOT_HALF_EXTENT * scratchScale.x * radiusPad,
-      };
-    });
-};
+export const collectAnnotationHitCandidates = (app: any, radiusPad: number): AnnotationCandidate[] =>
+  createAnnotationCandidateBuffer().collect(app, radiusPad);

--- a/src/components/VirtualWalkthrough/xr-annotation-targeting.ts
+++ b/src/components/VirtualWalkthrough/xr-annotation-targeting.ts
@@ -5,7 +5,7 @@ export interface AnnotationHitCandidate {
   radius: number;
 }
 
-// Reused across calls: this runs per candidate per frame, and the allocations showed up as GC churn.
+// Reused across calls: this runs per candidate per frame, where fresh vectors would be steady GC churn.
 const scratchDir = new Vec3();
 const scratchToCenter = new Vec3();
 

--- a/src/components/VirtualWalkthrough/xr-annotation-targeting.ts
+++ b/src/components/VirtualWalkthrough/xr-annotation-targeting.ts
@@ -5,12 +5,16 @@ export interface AnnotationHitCandidate {
   radius: number;
 }
 
+// Reused across calls: this runs per candidate per frame, and the allocations showed up as GC churn.
+const scratchDir = new Vec3();
+const scratchToCenter = new Vec3();
+
 /**
  * Distance along a (normalized) ray to where it first enters the sphere, or null if it never does.
  * A ray starting inside the sphere returns 0.
  */
 const raySphereEntryDistance = (origin: Vec3, dir: Vec3, center: Vec3, radius: number): number | null => {
-  const m = new Vec3().sub2(origin, center);
+  const m = scratchToCenter.sub2(origin, center);
   const b = m.dot(dir);
   const c = m.dot(m) - radius * radius;
   if (c > 0 && b > 0) {
@@ -33,17 +37,18 @@ export const nearestAnnotationHit = (
   direction: Vec3,
   candidates: AnnotationHitCandidate[]
 ): number | null => {
-  const dir = direction.clone().normalize();
+  const dir = scratchDir.copy(direction).normalize();
   let bestIndex: number | null = null;
   let bestDistance = Infinity;
 
-  candidates.forEach((candidate, index) => {
+  for (let index = 0; index < candidates.length; index++) {
+    const candidate = candidates[index];
     const distance = raySphereEntryDistance(origin, dir, candidate.position, candidate.radius);
     if (distance !== null && distance < bestDistance) {
       bestDistance = distance;
       bestIndex = index;
     }
-  });
+  }
 
   return bestIndex;
 };

--- a/src/components/VirtualWalkthrough/xr-gaze-dwell.ts
+++ b/src/components/VirtualWalkthrough/xr-gaze-dwell.ts
@@ -11,7 +11,7 @@ import {
   XRTYPE_VR,
 } from 'playcanvas';
 
-import { HOTSPOT_HALF_EXTENT, collectAnnotationHitCandidates } from './xr-annotation-candidates';
+import { HOTSPOT_HALF_EXTENT, createAnnotationCandidateBuffer } from './xr-annotation-candidates';
 import { nearestAnnotationHit } from './xr-annotation-targeting';
 import { DwellState, INITIAL_DWELL_STATE, advanceDwell } from './xr-gaze-dwell-state';
 import { pieShaderProgress } from './xr-progress-pie';
@@ -36,6 +36,7 @@ export class XrGazeDwell extends Script {
   activeIndex = -1;
 
   private _dwell: DwellState = INITIAL_DWELL_STATE;
+  private _candidates = createAnnotationCandidateBuffer();
 
   private _pieEntity?: Entity;
   private _pieMaterial?: ShaderMaterial;
@@ -112,10 +113,7 @@ export class XrGazeDwell extends Script {
       return;
     }
 
-    const activeName = `annotation-${this.activeIndex}`;
-    const candidates = collectAnnotationHitCandidates(this.app, GAZE_HIT_RADIUS_PAD).filter(
-      (candidate) => candidate.entity.name !== activeName
-    );
+    const candidates = this._candidates.collect(this.app, GAZE_HIT_RADIUS_PAD, `annotation-${this.activeIndex}`);
     this._headRot.transformVector(LOCAL_FORWARD, this._forward);
     const target = nearestAnnotationHit(this._headPos, this._forward, candidates);
 


### PR DESCRIPTION
Reduce garbage collection for annotations by using a buffer that is owned by the caller and reused. 

This stack has a net effect of reducing the GPU load on VR headsets so that it renders better. 

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>