### PR TITLE
Fix splat reveal rain for scale factor, restart on VR

### DIFF
--- a/src/components/VirtualWalkthrough/SplatModel.tsx
+++ b/src/components/VirtualWalkthrough/SplatModel.tsx
@@ -100,7 +100,7 @@ const SplatModel = ({
         ) : (
           <SplatCrop aabbMin={cropAabbMin} aabbMax={cropAabbMax} edgeScaleFactor={cropEdgeScaleFactor} />
         ))}
-      <SplatRevealRain enabled={revealRain} />
+      <SplatRevealRain enabled={revealRain} scaleFactor={scaleFactor} />
     </Entity>
   );
 };

--- a/src/components/VirtualWalkthrough/SplatRevealRain.tsx
+++ b/src/components/VirtualWalkthrough/SplatRevealRain.tsx
@@ -27,7 +27,7 @@ interface SplatRevealRainProps {
 const SplatRevealRain = ({
   enabled = true,
   restartOnVr = true,
-  scaleFactor = 15,
+  scaleFactor = 1,
   center = [0, 0, 0],
   distance = 3,
   speed = 1,

--- a/src/components/VirtualWalkthrough/SplatRevealRain.tsx
+++ b/src/components/VirtualWalkthrough/SplatRevealRain.tsx
@@ -1,11 +1,15 @@
-import React from 'react';
+import React, { useRef } from 'react';
 
 import { Script } from '@playcanvas/react/components';
-import { Color, Vec3 } from 'playcanvas';
+import { Color, Script as PcScript, Vec3 } from 'playcanvas';
 import { GSplatRevealRain } from 'playcanvas/scripts/esm/gsplat/reveal-rain.mjs';
+
+import { useRestartOnVr } from './useRestartOnVr';
 
 interface SplatRevealRainProps {
   enabled?: boolean;
+  restartOnVr?: boolean;
+  scaleFactor?: number;
   center?: [number, number, number];
   distance?: number;
   speed?: number;
@@ -22,9 +26,11 @@ interface SplatRevealRainProps {
 
 const SplatRevealRain = ({
   enabled = true,
+  restartOnVr = true,
+  scaleFactor = 15,
   center = [0, 0, 0],
   distance = 3,
-  speed = 10,
+  speed = 1,
   acceleration = 5,
   flightTime = 0.25,
   rainSize = 0.0,
@@ -35,22 +41,28 @@ const SplatRevealRain = ({
   hitDuration = 0,
   endRadius = 5,
 }: SplatRevealRainProps) => {
+  const scale = (value: number) => value * scaleFactor;
+  const scriptRef = useRef<PcScript | null>(null);
+
+  useRestartOnVr(scriptRef, enabled && restartOnVr);
+
   return (
     <Script
+      ref={scriptRef}
       script={GSplatRevealRain}
       enabled={enabled}
-      center={new Vec3(...center)}
-      distance={distance}
-      speed={speed}
-      acceleration={acceleration}
+      center={new Vec3(...center).mulScalar(scaleFactor)}
+      distance={scale(distance)}
+      speed={scale(speed)}
+      acceleration={scale(acceleration)}
       flightTime={flightTime}
-      rainSize={rainSize}
+      rainSize={scale(rainSize)}
       rotation={rotation}
       fallTint={new Color(...fallTint)}
       fallTintIntensity={fallTintIntensity}
       hitTint={new Color(...hitTint)}
       hitDuration={hitDuration}
-      endRadius={endRadius}
+      endRadius={scale(endRadius)}
     />
   );
 };

--- a/src/components/VirtualWalkthrough/useRestartOnVr.test.tsx
+++ b/src/components/VirtualWalkthrough/useRestartOnVr.test.tsx
@@ -1,0 +1,128 @@
+import { createRef } from 'react';
+
+import { renderHook } from '@testing-library/react';
+import { Script, XRTYPE_AR, XRTYPE_VR } from 'playcanvas';
+
+import { useRestartOnVr } from './useRestartOnVr';
+
+const handlers = new Map<string, () => void>();
+
+// Plain functions rather than jest.fn: the app-wide `resetMocks` would strip their implementations
+// before each test, leaving nothing to register the handlers.
+const mockApp = {
+  xr: {
+    type: null as string | null,
+    on: (name: string, handler: () => void) => {
+      handlers.set(name, handler);
+    },
+    off: (name: string, handler: () => void) => {
+      if (handlers.get(name) === handler) {
+        handlers.delete(name);
+      }
+    },
+  },
+};
+
+// Virtual: jest's resolver doesn't follow the package's subpath exports.
+jest.mock('@playcanvas/react/hooks', () => ({ useApp: () => mockApp }), { virtual: true });
+
+/**
+ * Stands in for a script instance, recording the transitions its `enabled` setter would turn into
+ * `enable` and `disable` events. PlayCanvas only fires those on a change of state.
+ */
+const createScript = (enabled: boolean) => {
+  const transitions: boolean[] = [];
+
+  const script = {
+    get enabled() {
+      return enabled;
+    },
+    set enabled(value: boolean) {
+      if (value !== enabled) {
+        transitions.push(value);
+      }
+      enabled = value;
+    },
+  };
+
+  return { script: script as unknown as Script, transitions };
+};
+
+const startSession = (type: string) => {
+  mockApp.xr.type = type;
+  handlers.get('start')?.();
+};
+
+beforeEach(() => {
+  handlers.clear();
+  mockApp.xr.type = null;
+});
+
+describe('useRestartOnVr', () => {
+  it('re-enables an effect that has already played out', () => {
+    const { script, transitions } = createScript(false);
+    const ref = createRef<Script>();
+    ref.current = script;
+
+    renderHook(() => useRestartOnVr(ref, true));
+    startSession(XRTYPE_VR);
+
+    expect(transitions).toEqual([true]);
+  });
+
+  it('takes an effect that is still playing back through disabled', () => {
+    const { script, transitions } = createScript(true);
+    const ref = createRef<Script>();
+    ref.current = script;
+
+    renderHook(() => useRestartOnVr(ref, true));
+    startSession(XRTYPE_VR);
+
+    // Without the trip through false the setter sees no change and never fires `enable`, which is
+    // what resets the effect's timeline.
+    expect(transitions).toEqual([false, true]);
+  });
+
+  it('leaves the effect alone for an AR session', () => {
+    const { script, transitions } = createScript(false);
+    const ref = createRef<Script>();
+    ref.current = script;
+
+    renderHook(() => useRestartOnVr(ref, true));
+    startSession(XRTYPE_AR);
+
+    expect(transitions).toEqual([]);
+  });
+
+  it('does not enable an effect the caller has turned off', () => {
+    const { script, transitions } = createScript(false);
+    const ref = createRef<Script>();
+    ref.current = script;
+
+    renderHook(() => useRestartOnVr(ref, false));
+    startSession(XRTYPE_VR);
+
+    expect(transitions).toEqual([]);
+  });
+
+  it('survives a session that starts before the script instance exists', () => {
+    const ref = createRef<Script>();
+
+    renderHook(() => useRestartOnVr(ref, true));
+
+    expect(() => startSession(XRTYPE_VR)).not.toThrow();
+  });
+
+  it('stops listening when unmounted', () => {
+    const { script, transitions } = createScript(false);
+    const ref = createRef<Script>();
+    ref.current = script;
+
+    const { unmount } = renderHook(() => useRestartOnVr(ref, true));
+    unmount();
+    startSession(XRTYPE_VR);
+
+    expect(handlers.has('start')).toBe(false);
+    expect(transitions).toEqual([]);
+  });
+});

--- a/src/components/VirtualWalkthrough/useRestartOnVr.ts
+++ b/src/components/VirtualWalkthrough/useRestartOnVr.ts
@@ -1,0 +1,43 @@
+import { RefObject, useEffect } from 'react';
+
+import { useApp } from '@playcanvas/react/hooks';
+import { Script, XRTYPE_VR } from 'playcanvas';
+
+/**
+ * Replays a one-shot script effect at the start of every VR session.
+ *
+ * `GSplatShaderEffect` zeroes its timeline on the script's `enable` event and switches itself off
+ * once the animation has played out, so re-enabling a finished effect runs it again. The `enabled`
+ * setter only fires the event on a change of state, which is why an effect still mid-play is taken
+ * back through disabled first.
+ *
+ * @param scriptRef - The script instance to replay, as handed back by `Script`'s ref.
+ * @param enabled - Whether the effect is in use at all. No session is watched while false.
+ */
+export const useRestartOnVr = (scriptRef: RefObject<Script | null>, enabled: boolean) => {
+  const app = useApp();
+
+  useEffect(() => {
+    const xr = app?.xr;
+    if (!xr || !enabled) {
+      return;
+    }
+
+    const restart = () => {
+      const script = scriptRef.current;
+      if (!script || xr.type !== XRTYPE_VR) {
+        return;
+      }
+      script.enabled = false;
+      script.enabled = true;
+    };
+
+    xr.on('start', restart);
+
+    return () => {
+      xr.off('start', restart);
+    };
+  }, [app, enabled, scriptRef]);
+};
+
+export default useRestartOnVr;


### PR DESCRIPTION
Account for the scale factor within the display of splats using the reveal-rain script.
Restart the rain effect when entering VR.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>