### PR TITLE
Update open-pr workflow to node 24

### DIFF
--- a/.github/workflows/open-pr.yml
+++ b/.github/workflows/open-pr.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: mshick/add-pr-comment@v2
+      - uses: mshick/add-pr-comment@v3
         with:
           message: |
             To increment version on merge, please add one of `patch` (default), `minor`, or `major` label to this PR.


### PR DESCRIPTION
We updated to node 24 a while back but missed this one hidden in another action.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>