### PR TITLE
Change VR panel size depending on height of text

### DIFF
--- a/src/components/VirtualWalkthrough/vr-annotation-panel-layout.test.ts
+++ b/src/components/VirtualWalkthrough/vr-annotation-panel-layout.test.ts
@@ -1,7 +1,20 @@
-import { wrapText } from './vr-annotation-panel-layout';
+import {
+  BODY_LINE_HEIGHT,
+  CHIP_HEIGHT,
+  IMAGE_BAND_HEIGHT,
+  PANEL_MAX_HEIGHT,
+  PANEL_MIN_HEIGHT,
+  PANEL_PAD_Y,
+  TITLE_LINE_HEIGHT,
+  layoutPanel,
+  wrapText,
+} from './vr-annotation-panel-layout';
 
 // Each character is 1 unit wide; a space counts as a character within a line.
 const measure = (s: string) => s.length;
+
+const layout = (overrides: Partial<Parameters<typeof layoutPanel>[0]> = {}) =>
+  layoutPanel({ title: 'Title', imageCount: 0, contentWidth: 100, measure: (text) => text.length, ...overrides });
 
 describe('wrapText', () => {
   it('returns an empty array for empty or whitespace-only input', () => {
@@ -28,5 +41,70 @@ describe('wrapText', () => {
 
   it('collapses runs of whitespace', () => {
     expect(wrapText('a    b', 10, measure)).toEqual(['a b']);
+  });
+});
+
+describe('layoutPanel', () => {
+  it('sizes a text-only panel to its content rather than the full panel height', () => {
+    const body = Array.from({ length: 4 }, () => 'body').join(' ');
+    const result = layout({ title: 'Title', bodyText: body, contentWidth: 4 });
+
+    const titleBottom = PANEL_PAD_Y + TITLE_LINE_HEIGHT;
+    expect(result.body.lines).toHaveLength(4);
+    expect(result.height).toBe(result.body.y + 4 * BODY_LINE_HEIGHT + PANEL_PAD_Y);
+    expect(result.body.y).toBeGreaterThan(titleBottom);
+    expect(result.height).toBeLessThan(PANEL_MAX_HEIGHT);
+  });
+
+  it('never shrinks below the minimum height', () => {
+    expect(layout({ title: 'Hi' }).height).toBe(PANEL_MIN_HEIGHT);
+  });
+
+  it('places the title at the top when there is no image or label', () => {
+    const result = layout();
+
+    expect(result.image).toBeNull();
+    expect(result.chip).toBeNull();
+    expect(result.title.y).toBe(PANEL_PAD_Y);
+    expect(result.title.lines).toEqual(['Title']);
+  });
+
+  it('reserves a fixed image band above the text so it holds still while images load', () => {
+    const result = layout({ imageCount: 1 });
+
+    expect(result.image).toEqual({ y: PANEL_PAD_Y, height: IMAGE_BAND_HEIGHT });
+    expect(result.title.y).toBeGreaterThanOrEqual(PANEL_PAD_Y + IMAGE_BAND_HEIGHT);
+  });
+
+  it('positions pagination dots below the image band only when there are several images', () => {
+    expect(layout({ imageCount: 1 }).dotsY).toBeNull();
+
+    const result = layout({ imageCount: 3 });
+    expect(result.dotsY).toBeGreaterThan(PANEL_PAD_Y + IMAGE_BAND_HEIGHT);
+    expect(result.title.y).toBeGreaterThan(result.dotsY!);
+  });
+
+  it('sizes the label chip from the measured label and pushes the title below it', () => {
+    const result = layout({ label: 'Oak' });
+
+    expect(result.chip).toEqual({ y: PANEL_PAD_Y, width: 'Oak'.length + 32, height: CHIP_HEIGHT });
+    expect(result.title.y).toBeGreaterThanOrEqual(PANEL_PAD_Y + CHIP_HEIGHT);
+  });
+
+  it('drops body lines that would overflow the maximum height and clamps to it', () => {
+    const body = Array.from({ length: 200 }, () => 'body').join(' ');
+    const result = layout({ bodyText: body, contentWidth: 4 });
+
+    expect(result.height).toBe(PANEL_MAX_HEIGHT);
+    expect(result.body.y + result.body.lines.length * BODY_LINE_HEIGHT).toBeLessThanOrEqual(PANEL_MAX_HEIGHT);
+    expect(result.body.lines.length).toBeLessThan(200);
+  });
+
+  it('drops title lines that would overflow the maximum height', () => {
+    const title = Array.from({ length: 200 }, () => 'title').join(' ');
+    const result = layout({ title, contentWidth: 5 });
+
+    expect(result.height).toBe(PANEL_MAX_HEIGHT);
+    expect(result.title.y + result.title.lines.length * TITLE_LINE_HEIGHT).toBeLessThanOrEqual(PANEL_MAX_HEIGHT);
   });
 });

--- a/src/components/VirtualWalkthrough/vr-annotation-panel-layout.ts
+++ b/src/components/VirtualWalkthrough/vr-annotation-panel-layout.ts
@@ -23,3 +23,114 @@ export const wrapText = (text: string, maxWidth: number, measure: (segment: stri
 
   return lines;
 };
+
+export const PANEL_CANVAS_WIDTH = 1024;
+/** Tallest the panel can grow; also the canvas the content is painted into. */
+export const PANEL_MAX_HEIGHT = 768;
+/** Shortest the panel can shrink, so a bare title still reads as a panel rather than a sliver. */
+export const PANEL_MIN_HEIGHT = 200;
+
+export const PANEL_PAD_X = 48;
+export const PANEL_PAD_Y = 40;
+
+export const IMAGE_BAND_HEIGHT = 360;
+const IMAGE_GAP = 16;
+const DOTS_BLOCK_HEIGHT = 32;
+const DOTS_CENTER_OFFSET = 4;
+
+export const CHIP_HEIGHT = 44;
+const CHIP_PAD_X = 16;
+const CHIP_GAP = 24;
+
+export const TITLE_LINE_HEIGHT = 56;
+const TITLE_GAP = 16;
+export const BODY_LINE_HEIGHT = 40;
+
+export const PANEL_FONTS = {
+  label: '600 28px sans-serif',
+  title: '700 48px sans-serif',
+  body: '400 32px sans-serif',
+} as const;
+
+export type PanelTextStyle = keyof typeof PANEL_FONTS;
+
+export interface PanelLayoutInput {
+  title: string;
+  label?: string;
+  bodyText?: string;
+  imageCount: number;
+  contentWidth: number;
+  measure: (text: string, style: PanelTextStyle) => number;
+}
+
+export interface PanelLayout {
+  /** Painted height of the panel, between the min and max bounds. */
+  height: number;
+  image: { y: number; height: number } | null;
+  dotsY: number | null;
+  chip: { y: number; width: number; height: number } | null;
+  title: { y: number; lines: string[] };
+  body: { y: number; lines: string[] };
+}
+
+/** Keeps the lines whose full line box fits above the bottom padding. */
+const fitLines = (lines: string[], y: number, lineHeight: number): string[] => {
+  const room = Math.max(0, Math.floor((PANEL_MAX_HEIGHT - PANEL_PAD_Y - y) / lineHeight));
+
+  return lines.slice(0, room);
+};
+
+/**
+ * Lays the panel's blocks out top-to-bottom and reports the height they need, so the quad
+ * can be sized to the content instead of a fixed aspect. Content that cannot fit within
+ * `PANEL_MAX_HEIGHT` is dropped and the panel is drawn at full height.
+ */
+export const layoutPanel = ({
+  title,
+  label,
+  bodyText,
+  imageCount,
+  contentWidth,
+  measure,
+}: PanelLayoutInput): PanelLayout => {
+  let y = PANEL_PAD_Y;
+
+  const image = imageCount > 0 ? { y, height: IMAGE_BAND_HEIGHT } : null;
+  let dotsY: number | null = null;
+  if (image) {
+    y += IMAGE_BAND_HEIGHT + IMAGE_GAP;
+    if (imageCount > 1) {
+      dotsY = y + DOTS_CENTER_OFFSET;
+      y += DOTS_BLOCK_HEIGHT;
+    }
+    y += IMAGE_GAP;
+  }
+
+  const chip = label ? { y, width: measure(label, 'label') + CHIP_PAD_X * 2, height: CHIP_HEIGHT } : null;
+  if (chip) {
+    y += CHIP_HEIGHT + CHIP_GAP;
+  }
+
+  const titleLines = wrapText(title, contentWidth, (segment) => measure(segment, 'title'));
+  const fittedTitle = fitLines(titleLines, y, TITLE_LINE_HEIGHT);
+  const titleY = y;
+  y += fittedTitle.length * TITLE_LINE_HEIGHT + TITLE_GAP;
+
+  const bodyLines = bodyText ? wrapText(bodyText, contentWidth, (segment) => measure(segment, 'body')) : [];
+  const fittedBody = fitLines(bodyLines, y, BODY_LINE_HEIGHT);
+  const bodyY = y;
+  y += fittedBody.length * BODY_LINE_HEIGHT;
+
+  const truncated = fittedTitle.length < titleLines.length || fittedBody.length < bodyLines.length;
+  const contentHeight = y + PANEL_PAD_Y;
+  const height = truncated ? PANEL_MAX_HEIGHT : Math.max(PANEL_MIN_HEIGHT, Math.min(PANEL_MAX_HEIGHT, contentHeight));
+
+  return {
+    height,
+    image,
+    dotsY,
+    chip,
+    title: { y: titleY, lines: fittedTitle },
+    body: { y: bodyY, lines: fittedBody },
+  };
+};

--- a/src/components/VirtualWalkthrough/vr-annotation-panel.ts
+++ b/src/components/VirtualWalkthrough/vr-annotation-panel.ts
@@ -354,7 +354,6 @@ export class VrAnnotationPanel extends Script {
     if (!anchor) {
       return;
     }
-    // Raise the panel above the hotspot so it clears the hotspot rather than covering it.
     this._anchor.copy(anchor.getPosition());
     this.entity.setPosition(this._anchor.x, this._anchor.y + this._panelHeight / 2 + PANEL_GAP, this._anchor.z);
 

--- a/src/components/VirtualWalkthrough/vr-annotation-panel.ts
+++ b/src/components/VirtualWalkthrough/vr-annotation-panel.ts
@@ -15,23 +15,22 @@ import {
   XrInputSource,
 } from 'playcanvas';
 
-import { wrapText } from './vr-annotation-panel-layout';
+import {
+  BODY_LINE_HEIGHT,
+  PANEL_CANVAS_WIDTH,
+  PANEL_FONTS,
+  PANEL_MAX_HEIGHT,
+  PANEL_PAD_X,
+  type PanelLayout,
+  TITLE_LINE_HEIGHT,
+  layoutPanel,
+} from './vr-annotation-panel-layout';
 import { rayQuadHit } from './xr-ray-quad';
 
-const CANVAS_WIDTH = 1024;
-const CANVAS_HEIGHT = 768;
-
 const PANEL_WIDTH = 7.5;
-const PANEL_HEIGHT = (PANEL_WIDTH * CANVAS_HEIGHT) / CANVAS_WIDTH;
 
 /** Gap (m) between the top of the hotspot and the bottom edge of the panel. */
 const PANEL_GAP = 0.75;
-
-/** World-space offset from the anchored hotspot: raise the panel above it so the
- * (tall) panel clears the hotspot rather than covering it. */
-const PANEL_OFFSET = new Vec3(0, PANEL_HEIGHT / 2 + PANEL_GAP, 0);
-
-const PAD_X = 48;
 
 /** Local +z (the quad's front face) — used to derive the panel's yaw toward the viewer. */
 const FORWARD_Z = new Vec3(0, 0, 1);
@@ -40,10 +39,6 @@ const RIGHT_AXIS = new Vec3(1, 0, 0);
 const UP_AXIS = new Vec3(0, 1, 0);
 
 const RAD_TO_DEG = 180 / Math.PI;
-
-/** Fixed image band (canvas px) so arrows/dots keep a stable position while images load. */
-const IMAGE_Y = 40;
-const IMAGE_H = 360;
 
 /** Width (canvas px) of the left/right arrow hit + draw zones over the image band. */
 const ARROW_ZONE_W = 170;
@@ -65,6 +60,10 @@ export class VrAnnotationPanel extends Script {
   private _drawnSignature: string | null = null;
   private _currentImage = 0;
   private _loadToken = 0;
+  private _layout?: PanelLayout;
+  /** Height (canvas px) the content currently occupies; the rest of the canvas is unused. */
+  private _canvasHeight = PANEL_MAX_HEIGHT;
+  private _panelHeight = (PANEL_WIDTH * PANEL_MAX_HEIGHT) / PANEL_CANVAS_WIDTH;
 
   private _headRotation = new Quat();
   private _anchor = new Vec3();
@@ -79,34 +78,35 @@ export class VrAnnotationPanel extends Script {
       return;
     }
     const images = this.imageUrls ?? [];
-    if (images.length <= 1) {
+    const band = this._layout?.image;
+    if (images.length <= 1 || !band) {
       return;
     }
     const hit = this._rayQuadHit(inputSource.getOrigin(), inputSource.getDirection());
     if (!hit) {
       return;
     }
-    const cx = ((hit.u + 1) / 2) * CANVAS_WIDTH;
-    const cy = ((1 - hit.v) / 2) * CANVAS_HEIGHT;
-    if (cy < IMAGE_Y || cy > IMAGE_Y + IMAGE_H) {
+    const cx = ((hit.u + 1) / 2) * PANEL_CANVAS_WIDTH;
+    const cy = ((1 - hit.v) / 2) * this._canvasHeight;
+    if (cy < band.y || cy > band.y + band.height) {
       return;
     }
     if (cx <= ARROW_ZONE_W) {
       this._setImage((this._currentImage - 1 + images.length) % images.length);
-    } else if (cx >= CANVAS_WIDTH - ARROW_ZONE_W) {
+    } else if (cx >= PANEL_CANVAS_WIDTH - ARROW_ZONE_W) {
       this._setImage((this._currentImage + 1) % images.length);
     }
   };
 
   initialize() {
     this._canvas = document.createElement('canvas');
-    this._canvas.width = CANVAS_WIDTH;
-    this._canvas.height = CANVAS_HEIGHT;
+    this._canvas.width = PANEL_CANVAS_WIDTH;
+    this._canvas.height = PANEL_MAX_HEIGHT;
 
     this._texture = new Texture(this.app.graphicsDevice, {
       name: 'vr-annotation-panel',
-      width: CANVAS_WIDTH,
-      height: CANVAS_HEIGHT,
+      width: PANEL_CANVAS_WIDTH,
+      height: PANEL_MAX_HEIGHT,
       addressU: ADDRESS_CLAMP_TO_EDGE,
       addressV: ADDRESS_CLAMP_TO_EDGE,
       minFilter: FILTER_LINEAR,
@@ -139,16 +139,34 @@ export class VrAnnotationPanel extends Script {
   }
 
   private _createMesh(): Mesh {
-    const hw = PANEL_WIDTH / 2;
-    const hh = PANEL_HEIGHT / 2;
     const mesh = new Mesh(this.app.graphicsDevice);
-    mesh.setPositions([-hw, -hh, 0, hw, -hh, 0, hw, hh, 0, -hw, hh, 0]);
     mesh.setNormals([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1]);
-    mesh.setUvs(0, [0, 1, 1, 1, 1, 0, 0, 0]);
     mesh.setIndices([0, 1, 2, 0, 2, 3]);
-    mesh.update();
+    this._writeQuad(mesh);
 
     return mesh;
+  }
+
+  /** Positions the quad for the current panel height and maps it onto the used slice of the
+   * canvas, leaving the unused remainder of the (fixed-size) texture off the mesh. */
+  private _writeQuad(mesh: Mesh) {
+    const hw = PANEL_WIDTH / 2;
+    const hh = this._panelHeight / 2;
+    const vBottom = this._canvasHeight / PANEL_MAX_HEIGHT;
+    mesh.setPositions([-hw, -hh, 0, hw, -hh, 0, hw, hh, 0, -hw, hh, 0]);
+    mesh.setUvs(0, [0, vBottom, 1, vBottom, 1, 0, 0, 0]);
+    mesh.update();
+  }
+
+  private _setPanelHeight(canvasHeight: number) {
+    if (canvasHeight === this._canvasHeight) {
+      return;
+    }
+    this._canvasHeight = canvasHeight;
+    this._panelHeight = (PANEL_WIDTH * canvasHeight) / PANEL_CANVAS_WIDTH;
+    if (this._mesh) {
+      this._writeQuad(this._mesh);
+    }
   }
 
   private _roundRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number) {
@@ -181,7 +199,7 @@ export class VrAnnotationPanel extends Script {
 
   private _drawDots(ctx: CanvasRenderingContext2D, count: number, dotY: number) {
     const gap = 26;
-    const startX = CANVAS_WIDTH / 2 - ((count - 1) * gap) / 2;
+    const startX = PANEL_CANVAS_WIDTH / 2 - ((count - 1) * gap) / 2;
     for (let i = 0; i < count; i++) {
       ctx.beginPath();
       ctx.arc(startX + i * gap, dotY, 7, 0, Math.PI * 2);
@@ -195,82 +213,76 @@ export class VrAnnotationPanel extends Script {
     if (!ctx) {
       return;
     }
-    ctx.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+    const contentWidth = PANEL_CANVAS_WIDTH - PANEL_PAD_X * 2;
+    const images = this.imageUrls ?? [];
+    const layout = layoutPanel({
+      title: this.title,
+      label: this.label,
+      bodyText: this.bodyText,
+      imageCount: images.length,
+      contentWidth,
+      measure: (text, style) => {
+        ctx.font = PANEL_FONTS[style];
+
+        return ctx.measureText(text).width;
+      },
+    });
+    this._layout = layout;
+    this._setPanelHeight(layout.height);
+
+    ctx.clearRect(0, 0, PANEL_CANVAS_WIDTH, PANEL_MAX_HEIGHT);
 
     ctx.fillStyle = 'rgba(255, 255, 255, 0.96)';
-    this._roundRect(ctx, 0, 0, CANVAS_WIDTH, CANVAS_HEIGHT, 32);
+    this._roundRect(ctx, 0, 0, PANEL_CANVAS_WIDTH, layout.height, 32);
     ctx.fill();
 
-    let y = IMAGE_Y;
-    const contentWidth = CANVAS_WIDTH - PAD_X * 2;
-    const images = this.imageUrls ?? [];
-
-    if (images.length > 0) {
+    if (layout.image) {
+      const { y: bandY, height: bandH } = layout.image;
       ctx.save();
-      this._roundRect(ctx, PAD_X, IMAGE_Y, contentWidth, IMAGE_H, 16);
+      this._roundRect(ctx, PANEL_PAD_X, bandY, contentWidth, bandH, 16);
       ctx.clip();
       if (image) {
-        const scale = Math.max(contentWidth / image.width, IMAGE_H / image.height);
+        const scale = Math.max(contentWidth / image.width, bandH / image.height);
         const dw = image.width * scale;
         const dh = image.height * scale;
-        ctx.drawImage(image, PAD_X + (contentWidth - dw) / 2, IMAGE_Y + (IMAGE_H - dh) / 2, dw, dh);
+        ctx.drawImage(image, PANEL_PAD_X + (contentWidth - dw) / 2, bandY + (bandH - dh) / 2, dw, dh);
       } else {
         ctx.fillStyle = 'rgba(0, 0, 0, 0.06)';
-        ctx.fillRect(PAD_X, IMAGE_Y, contentWidth, IMAGE_H);
+        ctx.fillRect(PANEL_PAD_X, bandY, contentWidth, bandH);
       }
       ctx.restore();
 
-      y = IMAGE_Y + IMAGE_H + 16;
-
-      if (images.length > 1) {
-        const bandCenterY = IMAGE_Y + IMAGE_H / 2;
+      if (layout.dotsY !== null) {
+        const bandCenterY = bandY + bandH / 2;
         this._drawArrow(ctx, ARROW_ZONE_W / 2, bandCenterY, true);
-        this._drawArrow(ctx, CANVAS_WIDTH - ARROW_ZONE_W / 2, bandCenterY, false);
-        this._drawDots(ctx, images.length, y + 4);
-        y += 32;
+        this._drawArrow(ctx, PANEL_CANVAS_WIDTH - ARROW_ZONE_W / 2, bandCenterY, false);
+        this._drawDots(ctx, images.length, layout.dotsY);
       }
-
-      y += 16;
     }
 
-    if (this.label) {
-      ctx.font = '600 28px sans-serif';
+    if (layout.chip && this.label) {
+      ctx.font = PANEL_FONTS.label;
       ctx.textBaseline = 'middle';
-      const chipW = ctx.measureText(this.label).width + 32;
-      const chipH = 44;
       ctx.fillStyle = 'rgba(44, 134, 88, 0.95)';
-      this._roundRect(ctx, PAD_X, y, chipW, chipH, 12);
+      this._roundRect(ctx, PANEL_PAD_X, layout.chip.y, layout.chip.width, layout.chip.height, 12);
       ctx.fill();
       ctx.fillStyle = '#ffffff';
-      ctx.fillText(this.label, PAD_X + 16, y + chipH / 2);
-      y += chipH + 24;
+      ctx.fillText(this.label, PANEL_PAD_X + 16, layout.chip.y + layout.chip.height / 2);
     }
 
     ctx.textBaseline = 'top';
     ctx.fillStyle = '#000000';
-    ctx.font = '700 48px sans-serif';
-    const titleLines = wrapText(this.title, contentWidth, (s) => ctx.measureText(s).width);
-    for (const line of titleLines) {
-      if (y > CANVAS_HEIGHT - 40) {
-        break;
-      }
-      ctx.fillText(line, PAD_X, y);
-      y += 56;
-    }
-    y += 16;
+    ctx.font = PANEL_FONTS.title;
+    layout.title.lines.forEach((line, index) => {
+      ctx.fillText(line, PANEL_PAD_X, layout.title.y + index * TITLE_LINE_HEIGHT);
+    });
 
-    if (this.bodyText) {
-      ctx.font = '400 32px sans-serif';
-      ctx.fillStyle = 'rgba(0, 0, 0, 0.85)';
-      const lines = wrapText(this.bodyText, contentWidth, (s) => ctx.measureText(s).width);
-      for (const line of lines) {
-        if (y > CANVAS_HEIGHT - 40) {
-          break;
-        }
-        ctx.fillText(line, PAD_X, y);
-        y += 40;
-      }
-    }
+    ctx.font = PANEL_FONTS.body;
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.85)';
+    layout.body.lines.forEach((line, index) => {
+      ctx.fillText(line, PANEL_PAD_X, layout.body.y + index * BODY_LINE_HEIGHT);
+    });
 
     this._texture?.upload();
   }
@@ -305,7 +317,7 @@ export class VrAnnotationPanel extends Script {
     rotation.transformVector(UP_AXIS, this._axisUp);
     this.entity.getWorldTransform().getScale(this._scratchScale);
     const halfWidth = (PANEL_WIDTH / 2) * this._scratchScale.x;
-    const halfHeight = (PANEL_HEIGHT / 2) * this._scratchScale.y;
+    const halfHeight = (this._panelHeight / 2) * this._scratchScale.y;
 
     return rayQuadHit(
       origin,
@@ -342,12 +354,9 @@ export class VrAnnotationPanel extends Script {
     if (!anchor) {
       return;
     }
+    // Raise the panel above the hotspot so it clears the hotspot rather than covering it.
     this._anchor.copy(anchor.getPosition());
-    this.entity.setPosition(
-      this._anchor.x + PANEL_OFFSET.x,
-      this._anchor.y + PANEL_OFFSET.y,
-      this._anchor.z + PANEL_OFFSET.z
-    );
+    this.entity.setPosition(this._anchor.x, this._anchor.y + this._panelHeight / 2 + PANEL_GAP, this._anchor.z);
 
     // Billboard on yaw only: face the viewer horizontally but stay upright and level, so
     // tilting/rolling the headset does not tilt the panel. Derived from the head's forward


### PR DESCRIPTION
The VR annotation panel was displaying a fixed height regardless of content. Make this dynamic based on the content size.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>