### PR TITLE
Make large panel text in VR scrollable using right thumbstick

### DIFF
--- a/src/components/VirtualWalkthrough/vr-annotation-panel-layout.test.ts
+++ b/src/components/VirtualWalkthrough/vr-annotation-panel-layout.test.ts
@@ -5,6 +5,7 @@ import {
   PANEL_MAX_HEIGHT,
   PANEL_MIN_HEIGHT,
   PANEL_PAD_Y,
+  TEXT_CANVAS_MAX_HEIGHT,
   TITLE_LINE_HEIGHT,
   layoutPanel,
   wrapText,
@@ -91,13 +92,40 @@ describe('layoutPanel', () => {
     expect(result.title.y).toBeGreaterThanOrEqual(PANEL_PAD_Y + CHIP_HEIGHT);
   });
 
-  it('drops body lines that would overflow the maximum height and clamps to it', () => {
+  it('shows a body that fits in full without scrolling', () => {
+    const body = Array.from({ length: 4 }, () => 'body').join(' ');
+    const result = layout({ bodyText: body, contentWidth: 4 });
+
+    expect(result.body.contentHeight).toBe(4 * BODY_LINE_HEIGHT);
+    expect(result.body.viewportHeight).toBe(result.body.contentHeight);
+    expect(result.body.scrollable).toBe(false);
+  });
+
+  it('keeps body lines that overflow the panel and caps the viewport so they can be scrolled to', () => {
+    const body = Array.from({ length: 40 }, () => 'body').join(' ');
+    const result = layout({ bodyText: body, contentWidth: 4 });
+
+    expect(result.body.lines).toHaveLength(40);
+    expect(result.body.scrollable).toBe(true);
+    expect(result.height).toBe(PANEL_MAX_HEIGHT);
+    expect(result.body.viewportHeight).toBe(PANEL_MAX_HEIGHT - PANEL_PAD_Y - result.body.y);
+    expect(result.body.contentHeight).toBeGreaterThan(result.body.viewportHeight);
+  });
+
+  it('is not scrollable when a tall header leaves the body no room at all', () => {
+    const title = Array.from({ length: 200 }, () => 'title').join(' ');
+    const result = layout({ title, bodyText: 'body', contentWidth: 5 });
+
+    expect(result.body.viewportHeight).toBe(0);
+    expect(result.body.scrollable).toBe(false);
+  });
+
+  it('drops body lines beyond what the text canvas can hold', () => {
     const body = Array.from({ length: 200 }, () => 'body').join(' ');
     const result = layout({ bodyText: body, contentWidth: 4 });
 
-    expect(result.height).toBe(PANEL_MAX_HEIGHT);
-    expect(result.body.y + result.body.lines.length * BODY_LINE_HEIGHT).toBeLessThanOrEqual(PANEL_MAX_HEIGHT);
     expect(result.body.lines.length).toBeLessThan(200);
+    expect(result.body.contentHeight).toBeLessThanOrEqual(TEXT_CANVAS_MAX_HEIGHT);
   });
 
   it('drops title lines that would overflow the maximum height', () => {

--- a/src/components/VirtualWalkthrough/vr-annotation-panel-layout.ts
+++ b/src/components/VirtualWalkthrough/vr-annotation-panel-layout.ts
@@ -46,6 +46,12 @@ export const TITLE_LINE_HEIGHT = 56;
 const TITLE_GAP = 16;
 export const BODY_LINE_HEIGHT = 40;
 
+/**
+ * Tallest canvas the body text is rasterised into. The body scrolls as a window onto this canvas,
+ * so it bounds how much text an annotation can show — far more than the panel itself holds.
+ */
+export const TEXT_CANVAS_MAX_HEIGHT = 2048;
+
 export const PANEL_FONTS = {
   label: '600 28px sans-serif',
   title: '700 48px sans-serif',
@@ -70,7 +76,16 @@ export interface PanelLayout {
   dotsY: number | null;
   chip: { y: number; width: number; height: number } | null;
   title: { y: number; lines: string[] };
-  body: { y: number; lines: string[] };
+  body: {
+    /** Top of the body viewport, in panel coordinates. */
+    y: number;
+    lines: string[];
+    /** Height of all the lines together, which is also the text canvas height. */
+    contentHeight: number;
+    /** Height of the visible window onto that canvas. */
+    viewportHeight: number;
+    scrollable: boolean;
+  };
 }
 
 /** Keeps the lines whose full line box fits above the bottom padding. */
@@ -82,8 +97,9 @@ const fitLines = (lines: string[], y: number, lineHeight: number): string[] => {
 
 /**
  * Lays the panel's blocks out top-to-bottom and reports the height they need, so the quad
- * can be sized to the content instead of a fixed aspect. Content that cannot fit within
- * `PANEL_MAX_HEIGHT` is dropped and the panel is drawn at full height.
+ * can be sized to the content instead of a fixed aspect. Everything above the body is a header
+ * that has to fit within `PANEL_MAX_HEIGHT`; the body instead scrolls within whatever height
+ * the header leaves it.
  */
 export const layoutPanel = ({
   title,
@@ -117,13 +133,12 @@ export const layoutPanel = ({
   y += fittedTitle.length * TITLE_LINE_HEIGHT + TITLE_GAP;
 
   const bodyLines = bodyText ? wrapText(bodyText, contentWidth, (segment) => measure(segment, 'body')) : [];
-  const fittedBody = fitLines(bodyLines, y, BODY_LINE_HEIGHT);
+  const fittedBody = bodyLines.slice(0, Math.floor(TEXT_CANVAS_MAX_HEIGHT / BODY_LINE_HEIGHT));
   const bodyY = y;
-  y += fittedBody.length * BODY_LINE_HEIGHT;
+  const contentHeight = fittedBody.length * BODY_LINE_HEIGHT;
+  const viewportHeight = Math.min(contentHeight, Math.max(0, PANEL_MAX_HEIGHT - PANEL_PAD_Y - bodyY));
 
-  const truncated = fittedTitle.length < titleLines.length || fittedBody.length < bodyLines.length;
-  const contentHeight = y + PANEL_PAD_Y;
-  const height = truncated ? PANEL_MAX_HEIGHT : Math.max(PANEL_MIN_HEIGHT, Math.min(PANEL_MAX_HEIGHT, contentHeight));
+  const height = Math.max(PANEL_MIN_HEIGHT, Math.min(PANEL_MAX_HEIGHT, bodyY + viewportHeight + PANEL_PAD_Y));
 
   return {
     height,
@@ -131,6 +146,12 @@ export const layoutPanel = ({
     dotsY,
     chip,
     title: { y: titleY, lines: fittedTitle },
-    body: { y: bodyY, lines: fittedBody },
+    body: {
+      y: bodyY,
+      lines: fittedBody,
+      contentHeight,
+      viewportHeight,
+      scrollable: viewportHeight > 0 && contentHeight > viewportHeight,
+    },
   };
 };

--- a/src/components/VirtualWalkthrough/vr-annotation-panel.ts
+++ b/src/components/VirtualWalkthrough/vr-annotation-panel.ts
@@ -25,12 +25,25 @@ import {
   TITLE_LINE_HEIGHT,
   layoutPanel,
 } from './vr-annotation-panel-layout';
+import { nextScrollY, readScrollAxis } from './vr-annotation-scroll';
 import { rayQuadHit } from './xr-ray-quad';
 
 const PANEL_WIDTH = 7.5;
 
 /** Gap (m) between the top of the hotspot and the bottom edge of the panel. */
 const PANEL_GAP = 0.75;
+
+const PX_TO_M = PANEL_WIDTH / PANEL_CANVAS_WIDTH;
+
+/** Local +z faces the viewer, so the overlay quads sit just in front of the chrome quad. Their
+ * draw order would otherwise depend on how the transparent sort breaks a tie between coplanar
+ * quads, all of which have depth testing off. */
+const TEXT_Z = 0.001;
+const THUMB_Z = 0.002;
+
+const SCROLLBAR_WIDTH = 10;
+const SCROLLBAR_INSET = 18;
+const SCROLLBAR_MIN_HEIGHT = 48;
 
 /** Local +z (the quad's front face) — used to derive the panel's yaw toward the viewer. */
 const FORWARD_Z = new Vec3(0, 0, 1);
@@ -53,17 +66,31 @@ export class VrAnnotationPanel extends Script {
   imageUrls?: string[];
   annotationIndex = -1;
 
-  private _material?: StandardMaterial;
-  private _texture?: Texture;
-  private _mesh?: Mesh;
-  private _canvas?: HTMLCanvasElement;
+  private _chromeMaterial?: StandardMaterial;
+  private _chromeTexture?: Texture;
+  private _chromeMesh?: Mesh;
+  private _chromeCanvas?: HTMLCanvasElement;
+
+  private _textMaterial?: StandardMaterial;
+  private _textTexture?: Texture;
+  private _textMesh?: Mesh;
+  private _textCanvas?: HTMLCanvasElement;
+  private _textInstance?: MeshInstance;
+
+  private _thumbMaterial?: StandardMaterial;
+  private _thumbMesh?: Mesh;
+  private _thumbInstance?: MeshInstance;
+
   private _drawnSignature: string | null = null;
   private _currentImage = 0;
   private _loadToken = 0;
+  private _loadedImage?: HTMLImageElement;
   private _layout?: PanelLayout;
-  /** Height (canvas px) the content currently occupies; the rest of the canvas is unused. */
+  private _scrollY = 0;
+  private _maxScroll = 0;
+  /** Height (canvas px) the chrome occupies; the rest of its canvas is unused. */
   private _canvasHeight = PANEL_MAX_HEIGHT;
-  private _panelHeight = (PANEL_WIDTH * PANEL_MAX_HEIGHT) / PANEL_CANVAS_WIDTH;
+  private _panelHeight = PANEL_MAX_HEIGHT * PX_TO_M;
 
   private _headRotation = new Quat();
   private _anchor = new Vec3();
@@ -87,6 +114,7 @@ export class VrAnnotationPanel extends Script {
       return;
     }
     const cx = ((hit.u + 1) / 2) * PANEL_CANVAS_WIDTH;
+    // The image sits on the chrome quad, which doesn't scroll, so this needs no scroll offset.
     const cy = ((1 - hit.v) / 2) * this._canvasHeight;
     if (cy < band.y || cy > band.y + band.height) {
       return;
@@ -99,38 +127,40 @@ export class VrAnnotationPanel extends Script {
   };
 
   initialize() {
-    this._canvas = document.createElement('canvas');
-    this._canvas.width = PANEL_CANVAS_WIDTH;
-    this._canvas.height = PANEL_MAX_HEIGHT;
+    this._chromeCanvas = document.createElement('canvas');
+    this._chromeCanvas.width = PANEL_CANVAS_WIDTH;
+    this._chromeCanvas.height = PANEL_MAX_HEIGHT;
+    this._chromeTexture = this._createTexture('vr-annotation-panel', this._chromeCanvas);
+    this._chromeMaterial = this._createTexturedMaterial(this._chromeTexture);
+    this._chromeMesh = this._createQuadMesh();
 
-    this._texture = new Texture(this.app.graphicsDevice, {
-      name: 'vr-annotation-panel',
-      width: PANEL_CANVAS_WIDTH,
-      height: PANEL_MAX_HEIGHT,
-      addressU: ADDRESS_CLAMP_TO_EDGE,
-      addressV: ADDRESS_CLAMP_TO_EDGE,
-      minFilter: FILTER_LINEAR,
-      magFilter: FILTER_LINEAR,
-      mipmaps: true,
+    // Sized once the first layout runs; until then it has nothing to show.
+    this._textMesh = this._createQuadMesh();
+    this._textMaterial = new StandardMaterial();
+    this._textInstance = new MeshInstance(this._textMesh, this._textMaterial);
+    this._textInstance.visible = false;
+
+    this._thumbMaterial = new StandardMaterial();
+    this._thumbMaterial.useLighting = false;
+    this._thumbMaterial.emissive = new Color(0, 0, 0);
+    this._thumbMaterial.opacity = 0.3;
+    this._thumbMaterial.blendType = BLEND_NORMAL;
+    this._thumbMaterial.depthTest = false;
+    this._thumbMaterial.depthWrite = false;
+    this._thumbMaterial.cull = CULLFACE_NONE;
+    this._thumbMaterial.update();
+    this._thumbMesh = this._createQuadMesh();
+    this._thumbInstance = new MeshInstance(this._thumbMesh, this._thumbMaterial);
+    this._thumbInstance.visible = false;
+
+    this.entity.addComponent('render', {
+      meshInstances: [
+        new MeshInstance(this._chromeMesh, this._chromeMaterial),
+        this._textInstance,
+        this._thumbInstance,
+      ],
+      layers: [LAYERID_IMMEDIATE],
     });
-    this._texture.setSource(this._canvas);
-
-    const material = new StandardMaterial();
-    material.useLighting = false;
-    material.emissive = new Color(1, 1, 1);
-    material.emissiveMap = this._texture;
-    material.opacityMap = this._texture;
-    material.opacityMapChannel = 'a';
-    material.blendType = BLEND_NORMAL;
-    material.depthTest = false;
-    material.depthWrite = false;
-    material.cull = CULLFACE_NONE;
-    material.update();
-    this._material = material;
-
-    this._mesh = this._createMesh();
-    const meshInstance = new MeshInstance(this._mesh, material);
-    this.entity.addComponent('render', { meshInstances: [meshInstance], layers: [LAYERID_IMMEDIATE] });
 
     this.app.xr?.input?.on('select', this._onSelect);
     // Script removal fires a 'destroy' event rather than calling a destroy() method, so the
@@ -138,35 +168,119 @@ export class VrAnnotationPanel extends Script {
     this.once('destroy', () => this._teardown());
   }
 
-  private _createMesh(): Mesh {
+  private _createTexture(name: string, source: HTMLCanvasElement): Texture {
+    const texture = new Texture(this.app.graphicsDevice, {
+      name,
+      width: source.width,
+      height: source.height,
+      addressU: ADDRESS_CLAMP_TO_EDGE,
+      addressV: ADDRESS_CLAMP_TO_EDGE,
+      minFilter: FILTER_LINEAR,
+      magFilter: FILTER_LINEAR,
+      mipmaps: true,
+    });
+    texture.setSource(source);
+
+    return texture;
+  }
+
+  private _createTexturedMaterial(texture: Texture): StandardMaterial {
+    const material = new StandardMaterial();
+    material.useLighting = false;
+    material.emissive = new Color(1, 1, 1);
+    material.emissiveMap = texture;
+    material.opacityMap = texture;
+    material.opacityMapChannel = 'a';
+    material.blendType = BLEND_NORMAL;
+    material.depthTest = false;
+    material.depthWrite = false;
+    material.cull = CULLFACE_NONE;
+    material.update();
+
+    return material;
+  }
+
+  private _createQuadMesh(): Mesh {
     const mesh = new Mesh(this.app.graphicsDevice);
     mesh.setNormals([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1]);
     mesh.setIndices([0, 1, 2, 0, 2, 3]);
-    this._writeQuad(mesh);
+    this._writeQuad(mesh, -PANEL_WIDTH / 2, PANEL_WIDTH / 2, 0, 0, 0, 0, 1);
 
     return mesh;
   }
 
-  /** Positions the quad for the current panel height and maps it onto the used slice of the
-   * canvas, leaving the unused remainder of the (fixed-size) texture off the mesh. */
-  private _writeQuad(mesh: Mesh) {
-    const hw = PANEL_WIDTH / 2;
-    const hh = this._panelHeight / 2;
-    const vBottom = this._canvasHeight / PANEL_MAX_HEIGHT;
-    mesh.setPositions([-hw, -hh, 0, hw, -hh, 0, hw, hh, 0, -hw, hh, 0]);
-    mesh.setUvs(0, [0, vBottom, 1, vBottom, 1, 0, 0, 0]);
+  /** Rewrites the quad's four corners and the slice of its texture they map to. */
+  private _writeQuad(
+    mesh: Mesh,
+    left: number,
+    right: number,
+    top: number,
+    bottom: number,
+    z: number,
+    vTop: number,
+    vBottom: number
+  ) {
+    mesh.setPositions([left, bottom, z, right, bottom, z, right, top, z, left, top, z]);
+    mesh.setUvs(0, [0, vBottom, 1, vBottom, 1, vTop, 0, vTop]);
     mesh.update();
   }
 
-  private _setPanelHeight(canvasHeight: number) {
-    if (canvasHeight === this._canvasHeight) {
+  /** Converts a y in panel canvas coordinates to the entity's local space. */
+  private _localY(canvasY: number): number {
+    return this._panelHeight / 2 - canvasY * PX_TO_M;
+  }
+
+  private _writeChromeQuad() {
+    if (!this._chromeMesh) {
       return;
     }
-    this._canvasHeight = canvasHeight;
-    this._panelHeight = (PANEL_WIDTH * canvasHeight) / PANEL_CANVAS_WIDTH;
-    if (this._mesh) {
-      this._writeQuad(this._mesh);
+    const hw = PANEL_WIDTH / 2;
+    const hh = this._panelHeight / 2;
+    this._writeQuad(this._chromeMesh, -hw, hw, hh, -hh, 0, 0, this._canvasHeight / PANEL_MAX_HEIGHT);
+  }
+
+  /** Maps the visible window of the (much taller) text texture onto the body quad. */
+  private _writeTextQuad() {
+    const body = this._layout?.body;
+    if (!this._textMesh || !this._textInstance || !body || body.contentHeight === 0) {
+      return;
     }
+    this._writeQuad(
+      this._textMesh,
+      -PANEL_WIDTH / 2,
+      PANEL_WIDTH / 2,
+      this._localY(body.y),
+      this._localY(body.y + body.viewportHeight),
+      TEXT_Z,
+      this._scrollY / body.contentHeight,
+      (this._scrollY + body.viewportHeight) / body.contentHeight
+    );
+  }
+
+  private _writeThumbQuad() {
+    const body = this._layout?.body;
+    if (!this._thumbMesh || !body?.scrollable) {
+      return;
+    }
+    // The minimum keeps the thumb grabbable on very long text, but never past the track itself.
+    const height = Math.min(
+      body.viewportHeight,
+      Math.max(SCROLLBAR_MIN_HEIGHT, (body.viewportHeight * body.viewportHeight) / body.contentHeight)
+    );
+    const travel = body.viewportHeight - height;
+    const top = body.y + (this._maxScroll > 0 ? (this._scrollY / this._maxScroll) * travel : 0);
+    const right = PANEL_CANVAS_WIDTH - SCROLLBAR_INSET;
+
+    this._writeQuad(
+      this._thumbMesh,
+      (right - SCROLLBAR_WIDTH) * PX_TO_M - PANEL_WIDTH / 2,
+      right * PX_TO_M - PANEL_WIDTH / 2,
+      this._localY(top),
+      this._localY(top + height),
+      THUMB_Z,
+      0,
+      1
+    );
   }
 
   private _roundRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number) {
@@ -208,28 +322,55 @@ export class VrAnnotationPanel extends Script {
     }
   }
 
-  private _drawContent(image?: HTMLImageElement) {
-    const ctx = this._canvas?.getContext('2d');
+  /** Re-measures the content, resizes the panel, and repaints both canvases. */
+  private _rebuild() {
+    const ctx = this._chromeCanvas?.getContext('2d');
     if (!ctx) {
       return;
     }
 
-    const contentWidth = PANEL_CANVAS_WIDTH - PANEL_PAD_X * 2;
     const images = this.imageUrls ?? [];
-    const layout = layoutPanel({
+    this._layout = layoutPanel({
       title: this.title,
       label: this.label,
       bodyText: this.bodyText,
       imageCount: images.length,
-      contentWidth,
+      contentWidth: PANEL_CANVAS_WIDTH - PANEL_PAD_X * 2,
       measure: (text, style) => {
         ctx.font = PANEL_FONTS[style];
 
         return ctx.measureText(text).width;
       },
     });
-    this._layout = layout;
-    this._setPanelHeight(layout.height);
+
+    const { body } = this._layout;
+    this._maxScroll = body.contentHeight - body.viewportHeight;
+    this._canvasHeight = this._layout.height;
+    this._panelHeight = this._layout.height * PX_TO_M;
+
+    this._drawChrome();
+    this._drawText();
+
+    this._writeChromeQuad();
+    this._writeTextQuad();
+    this._writeThumbQuad();
+    if (this._textInstance) {
+      this._textInstance.visible = body.contentHeight > 0;
+    }
+    if (this._thumbInstance) {
+      this._thumbInstance.visible = body.scrollable;
+    }
+  }
+
+  private _drawChrome() {
+    const ctx = this._chromeCanvas?.getContext('2d');
+    const layout = this._layout;
+    if (!ctx || !layout) {
+      return;
+    }
+
+    const contentWidth = PANEL_CANVAS_WIDTH - PANEL_PAD_X * 2;
+    const images = this.imageUrls ?? [];
 
     ctx.clearRect(0, 0, PANEL_CANVAS_WIDTH, PANEL_MAX_HEIGHT);
 
@@ -242,6 +383,7 @@ export class VrAnnotationPanel extends Script {
       ctx.save();
       this._roundRect(ctx, PANEL_PAD_X, bandY, contentWidth, bandH, 16);
       ctx.clip();
+      const image = this._loadedImage;
       if (image) {
         const scale = Math.max(contentWidth / image.width, bandH / image.height);
         const dw = image.width * scale;
@@ -278,18 +420,59 @@ export class VrAnnotationPanel extends Script {
       ctx.fillText(line, PANEL_PAD_X, layout.title.y + index * TITLE_LINE_HEIGHT);
     });
 
+    if (layout.body.scrollable) {
+      ctx.fillStyle = 'rgba(0, 0, 0, 0.08)';
+      const trackX = PANEL_CANVAS_WIDTH - SCROLLBAR_INSET - SCROLLBAR_WIDTH;
+      this._roundRect(ctx, trackX, layout.body.y, SCROLLBAR_WIDTH, layout.body.viewportHeight, SCROLLBAR_WIDTH / 2);
+      ctx.fill();
+    }
+
+    this._chromeTexture?.upload();
+  }
+
+  /**
+   * Paints every body line onto its own canvas, tall enough to hold all of them. Scrolling then
+   * only moves the quad's UV window over this texture, so no repaint or upload happens per frame.
+   */
+  private _drawText() {
+    const body = this._layout?.body;
+    if (!body) {
+      return;
+    }
+
+    const height = Math.max(1, body.contentHeight);
+    if (!this._textCanvas || this._textCanvas.height !== height) {
+      this._textCanvas = document.createElement('canvas');
+      this._textCanvas.width = PANEL_CANVAS_WIDTH;
+      this._textCanvas.height = height;
+      this._textTexture?.destroy();
+      this._textTexture = this._createTexture('vr-annotation-panel-text', this._textCanvas);
+      this._textMaterial?.destroy();
+      this._textMaterial = this._createTexturedMaterial(this._textTexture);
+      if (this._textInstance) {
+        this._textInstance.material = this._textMaterial;
+      }
+    }
+
+    const ctx = this._textCanvas.getContext('2d');
+    if (!ctx) {
+      return;
+    }
+    ctx.clearRect(0, 0, PANEL_CANVAS_WIDTH, height);
+    ctx.textBaseline = 'top';
     ctx.font = PANEL_FONTS.body;
     ctx.fillStyle = 'rgba(0, 0, 0, 0.85)';
-    layout.body.lines.forEach((line, index) => {
-      ctx.fillText(line, PANEL_PAD_X, layout.body.y + index * BODY_LINE_HEIGHT);
+    body.lines.forEach((line, index) => {
+      ctx.fillText(line, PANEL_PAD_X, index * BODY_LINE_HEIGHT);
     });
 
-    this._texture?.upload();
+    this._textTexture?.upload();
   }
 
   private _setImage(index: number) {
     this._currentImage = index;
-    this._drawContent();
+    this._loadedImage = undefined;
+    this._drawChrome();
     this._loadCurrentImage();
   }
 
@@ -304,7 +487,8 @@ export class VrAnnotationPanel extends Script {
     img.onload = () => {
       // Ignore a stale load that a newer navigation has superseded.
       if (token === this._loadToken) {
-        this._drawContent(img);
+        this._loadedImage = img;
+        this._drawChrome();
       }
     };
     // onerror (e.g. a host without CORS headers): keep the placeholder + text already drawn.
@@ -335,7 +519,7 @@ export class VrAnnotationPanel extends Script {
     return this._rayQuadHit(origin, direction) !== null;
   }
 
-  update() {
+  update(dt: number) {
     if (this.app.xr?.active !== true) {
       return;
     }
@@ -344,10 +528,13 @@ export class VrAnnotationPanel extends Script {
     if (signature !== this._drawnSignature) {
       this._drawnSignature = signature;
       this._currentImage = 0;
-      this._drawContent();
+      this._scrollY = 0;
+      this._loadedImage = undefined;
+      this._rebuild();
       this._loadCurrentImage();
     }
 
+    this._scroll(dt);
     this._trackHead();
 
     const anchor = this.app.root.findByName(`annotation-${this.annotationIndex}`);
@@ -366,6 +553,28 @@ export class VrAnnotationPanel extends Script {
     this.entity.setRotation(this._yawQuat);
   }
 
+  private _scroll(dt: number) {
+    if (this._maxScroll <= 0) {
+      return;
+    }
+
+    let axis = 0;
+    for (const inputSource of this.app.xr?.input?.inputSources ?? []) {
+      const sourceAxis = readScrollAxis(inputSource);
+      if (Math.abs(sourceAxis) > Math.abs(axis)) {
+        axis = sourceAxis;
+      }
+    }
+
+    const scrollY = nextScrollY(this._scrollY, axis, dt, this._maxScroll);
+    if (scrollY === this._scrollY) {
+      return;
+    }
+    this._scrollY = scrollY;
+    this._writeTextQuad();
+    this._writeThumbQuad();
+  }
+
   private _trackHead() {
     const views = this.app.xr?.views?.list;
     if (!views || views.length === 0) {
@@ -379,11 +588,21 @@ export class VrAnnotationPanel extends Script {
     if (this.entity.render) {
       this.entity.render.meshInstances = [];
     }
-    this._mesh?.destroy();
-    this._material?.destroy();
-    this._texture?.destroy();
-    this._mesh = undefined;
-    this._material = undefined;
-    this._texture = undefined;
+    this._chromeMesh?.destroy();
+    this._textMesh?.destroy();
+    this._thumbMesh?.destroy();
+    this._chromeMaterial?.destroy();
+    this._textMaterial?.destroy();
+    this._thumbMaterial?.destroy();
+    this._chromeTexture?.destroy();
+    this._textTexture?.destroy();
+    this._chromeMesh = undefined;
+    this._textMesh = undefined;
+    this._thumbMesh = undefined;
+    this._chromeMaterial = undefined;
+    this._textMaterial = undefined;
+    this._thumbMaterial = undefined;
+    this._chromeTexture = undefined;
+    this._textTexture = undefined;
   }
 }

--- a/src/components/VirtualWalkthrough/vr-annotation-scroll.test.ts
+++ b/src/components/VirtualWalkthrough/vr-annotation-scroll.test.ts
@@ -1,0 +1,54 @@
+import { SCROLL_DEADZONE, SCROLL_SPEED, nextScrollY, readScrollAxis } from './vr-annotation-scroll';
+
+const source = (handedness: string, axes?: number[]) =>
+  ({ handedness, gamepad: axes ? { axes } : null }) as Parameters<typeof readScrollAxis>[0];
+
+describe('readScrollAxis', () => {
+  it('reads the right thumbstick Y axis', () => {
+    expect(readScrollAxis(source('right', [0, 0, 0.2, -0.8]))).toBe(-0.8);
+  });
+
+  it('ignores the left hand, which still drives locomotion', () => {
+    expect(readScrollAxis(source('left', [0, 0, 0.2, -0.8]))).toBe(0);
+  });
+
+  it('ignores sources without a gamepad', () => {
+    expect(readScrollAxis(source('right'))).toBe(0);
+  });
+
+  it('ignores gamepads without thumbstick axes, which read as NaN', () => {
+    expect(readScrollAxis(source('right', [0, 0]))).toBe(0);
+  });
+});
+
+describe('nextScrollY', () => {
+  it('holds position for deflections inside the deadzone', () => {
+    expect(nextScrollY(100, SCROLL_DEADZONE - 0.01, 0.1, 500)).toBe(100);
+    expect(nextScrollY(100, -SCROLL_DEADZONE + 0.01, 0.1, 500)).toBe(100);
+  });
+
+  it('scrolls further into the text when the stick is pushed forward', () => {
+    // xr-standard reports a forward push as negative Y.
+    expect(nextScrollY(0, -1, 0.5, 5000)).toBe(SCROLL_SPEED * 0.5);
+  });
+
+  it('scrolls back toward the top when the stick is pulled back', () => {
+    expect(nextScrollY(1000, 1, 0.5, 5000)).toBe(1000 - SCROLL_SPEED * 0.5);
+  });
+
+  it('ramps from a standstill at the deadzone edge rather than jumping', () => {
+    expect(nextScrollY(0, -SCROLL_DEADZONE, 0.5, 5000)).toBe(0);
+
+    const halfway = nextScrollY(0, -(SCROLL_DEADZONE + (1 - SCROLL_DEADZONE) / 2), 0.5, 5000);
+    expect(halfway).toBeCloseTo((SCROLL_SPEED * 0.5) / 2);
+  });
+
+  it('clamps to the ends of the scroll range', () => {
+    expect(nextScrollY(10, 1, 1, 5000)).toBe(0);
+    expect(nextScrollY(4900, -1, 1, 5000)).toBe(5000);
+  });
+
+  it('stays at the top when there is nothing to scroll', () => {
+    expect(nextScrollY(0, -1, 1, 0)).toBe(0);
+  });
+});

--- a/src/components/VirtualWalkthrough/vr-annotation-scroll.ts
+++ b/src/components/VirtualWalkthrough/vr-annotation-scroll.ts
@@ -1,0 +1,40 @@
+/** Deflection the stick must pass before the text moves, so a resting thumb doesn't drift it. */
+export const SCROLL_DEADZONE = 0.15;
+
+/** Canvas px per second at full deflection. */
+export const SCROLL_SPEED = 1200;
+
+interface ThumbstickSource {
+  handedness: string;
+  gamepad?: { axes: ArrayLike<number> } | null;
+}
+
+/**
+ * Thumbstick Y for a source that can scroll the panel. Only the right hand scrolls: the left
+ * stick drives locomotion, and right-stick Y is free because snap-vertical is turned off.
+ * Hand-tracked sources report a gamepad with no axes, which would read as NaN.
+ */
+export const readScrollAxis = (inputSource: ThumbstickSource): number => {
+  const axes = inputSource.gamepad?.axes;
+  if (inputSource.handedness !== 'right' || !axes || axes.length < 4) {
+    return 0;
+  }
+
+  return axes[3];
+};
+
+/**
+ * Advances the scroll position for one frame of stick deflection, ramping from a standstill at
+ * the deadzone edge. A forward push reports negative Y and moves further into the text.
+ */
+export const nextScrollY = (scrollY: number, axisY: number, dt: number, maxScroll: number): number => {
+  const magnitude = Math.abs(axisY);
+  if (magnitude <= SCROLL_DEADZONE) {
+    return Math.min(Math.max(scrollY, 0), maxScroll);
+  }
+
+  const ramped = (magnitude - SCROLL_DEADZONE) / (1 - SCROLL_DEADZONE);
+  const delta = -Math.sign(axisY) * ramped * SCROLL_SPEED * dt;
+
+  return Math.min(Math.max(scrollY + delta, 0), maxScroll);
+};

--- a/src/stories/VirtualWalkthroughViewer.stories.tsx
+++ b/src/stories/VirtualWalkthroughViewer.stories.tsx
@@ -61,6 +61,13 @@ const sampleAnnotations: AnnotationProps[] = [
     bodyText:
       'The boardwalk lets visitors cross the wetland without trampling seedlings, and doubles as the route rangers use for weekly surveys.',
   },
+  {
+    position: [8.75, 1.2, -10.5],
+    title: 'BIG annotation',
+    label: 'Super BIG',
+    bodyText:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+  },
 ];
 
 const sceneArgs: VirtualWalkthroughViewerProps = {


### PR DESCRIPTION
Set a max annotation panel height in VR, and make the text scrollable using the right thumbstick (which currently doesn't do anything)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>