### PR TITLE
Make annotation panel text scrollable in desktop

### DIFF
--- a/src/components/VirtualWalkthrough/AnnotationPanel.tsx
+++ b/src/components/VirtualWalkthrough/AnnotationPanel.tsx
@@ -57,8 +57,6 @@ const CAROUSEL_STYLE: React.CSSProperties = {
   flexShrink: 0,
 };
 
-// The image, label and title stay put; only the body scrolls, so the panel keeps
-// its heading visible however long the text is.
 const TEXT_BLOCK_STYLE: React.CSSProperties = {
   padding: '24px',
   display: 'flex',

--- a/src/components/VirtualWalkthrough/AnnotationPanel.tsx
+++ b/src/components/VirtualWalkthrough/AnnotationPanel.tsx
@@ -45,7 +45,7 @@ const PANEL_STYLE: React.CSSProperties = {
   backgroundColor: '#ffffff',
   borderRadius: 12,
   boxShadow: '0 8px 32px rgba(0,0,0,0.32)',
-  overflowY: 'auto',
+  overflow: 'hidden',
   display: 'flex',
   flexDirection: 'column',
 };
@@ -57,11 +57,24 @@ const CAROUSEL_STYLE: React.CSSProperties = {
   flexShrink: 0,
 };
 
+// The image, label and title stay put; only the body scrolls, so the panel keeps
+// its heading visible however long the text is.
 const TEXT_BLOCK_STYLE: React.CSSProperties = {
   padding: '24px',
   display: 'flex',
   flexDirection: 'column',
   gap: 8,
+  minHeight: 0,
+};
+
+const BODY_STYLE: React.CSSProperties = {
+  fontSize: 16,
+  lineHeight: '24px',
+  margin: 0,
+  minHeight: 0,
+  overflowY: 'auto',
+  overscrollBehavior: 'contain',
+  scrollbarWidth: 'thin',
 };
 
 const AnnotationPanel = ({ annotation, hotspotPosition, onClose }: AnnotationPanelProps) => {
@@ -190,15 +203,7 @@ const AnnotationPanel = ({ annotation, hotspotPosition, onClose }: AnnotationPan
             {annotation.title}
           </h2>
           {annotation.bodyText && (
-            <p
-              data-testid='annotation-panel-description'
-              style={{
-                fontSize: 16,
-                color: theme.palette.TwClrTxt,
-                lineHeight: '24px',
-                margin: 0,
-              }}
-            >
+            <p data-testid='annotation-panel-description' style={{ ...BODY_STYLE, color: theme.palette.TwClrTxt }}>
               {annotation.bodyText}
             </p>
           )}

--- a/src/components/VirtualWalkthrough/AnnotationPanel.tsx
+++ b/src/components/VirtualWalkthrough/AnnotationPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
-import { useTheme } from '@mui/material';
+import { Box, type SxProps, useTheme } from '@mui/material';
 
 import PhotosCarousel, { PhotoItem } from '../PhotosCarousel';
 import type { AnnotationProps } from './Annotation';
@@ -45,16 +45,18 @@ const PANEL_STYLE: React.CSSProperties = {
   backgroundColor: '#ffffff',
   borderRadius: 12,
   boxShadow: '0 8px 32px rgba(0,0,0,0.32)',
-  overflow: 'hidden',
+  overflowY: 'auto',
   display: 'flex',
   flexDirection: 'column',
 };
 
-const CAROUSEL_STYLE: React.CSSProperties = {
+const CAROUSEL_SX: SxProps = {
   width: 'min(60vw, 640px)',
   borderRadius: '12px 12px 0 0',
   overflow: 'hidden',
   flexShrink: 0,
+  '& .photos-carousel-image': { height: 'min(400px, 40vh)' },
+  '& .photos-carousel-container': { minHeight: 'min(200px, 20vh)' },
 };
 
 const TEXT_BLOCK_STYLE: React.CSSProperties = {
@@ -162,13 +164,13 @@ const AnnotationPanel = ({ annotation, hotspotPosition, onClose }: AnnotationPan
       </svg>
       <div ref={panelRef} data-testid='annotation-panel' style={panelStyle}>
         {annotation.imageUrls && annotation.imageUrls.length > 0 && (
-          <div style={CAROUSEL_STYLE}>
+          <Box sx={CAROUSEL_SX}>
             <PhotosCarousel
               photos={annotation.imageUrls.map((url): PhotoItem => ({ url, alt: annotation.title }))}
               showArrows={true}
               dots={false}
             />
-          </div>
+          </Box>
         )}
         <div style={TEXT_BLOCK_STYLE}>
           {annotation.label && (

--- a/src/stories/AnnotationPanel.stories.tsx
+++ b/src/stories/AnnotationPanel.stories.tsx
@@ -51,6 +51,17 @@ WithImage.args = {
   onClose: () => window.alert('Closed'),
 };
 
+export const LongText = Template.bind({});
+LongText.args = {
+  annotation: {
+    ...baseAnnotation,
+    label: 'Restoration site',
+    imageUrls: [SAMPLE_PHOTOS[0].url],
+    bodyText: Array(8).fill(baseAnnotation.bodyText).join(' '),
+  },
+  onClose: () => window.alert('Closed'),
+};
+
 export const MultipleImages = Template.bind({});
 MultipleImages.args = {
   annotation: {

--- a/src/stories/AnnotationPanel.stories.tsx
+++ b/src/stories/AnnotationPanel.stories.tsx
@@ -62,6 +62,20 @@ LongText.args = {
   onClose: () => window.alert('Closed'),
 };
 
+// A viewport short enough that the image alone would crowd out the panel's 80vh
+// budget. The label, title and a readable slice of the description all have to stay
+// on screen, with the description scrolling for the rest.
+export const ShortViewport = Template.bind({});
+ShortViewport.args = LongText.args;
+ShortViewport.parameters = {
+  viewport: {
+    viewports: {
+      short: { name: 'Short (600px tall)', styles: { width: '1200px', height: '600px' } },
+    },
+    defaultViewport: 'short',
+  },
+};
+
 export const MultipleImages = Template.bind({});
 MultipleImages.args = {
   annotation: {


### PR DESCRIPTION
Now that the annotation panel text is scrollable in VR when there's a lot of content, make it scrollable in desktop too and set a max height for it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>