### PR TITLE
Allow camera to be optionally passed in

### DIFF
--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useTheme } from '@mui/material';
 import { Entity } from '@playcanvas/react';
@@ -53,6 +53,11 @@ const MAX_HOTSPOT_WORLD_SIZE = 0.75;
 export interface VirtualWalkthroughViewerProps {
   splatSrc: string;
   splatFormat?: SplatFormat;
+  /**
+   * Camera component mounted on the camera entity. Defaults to a 60 degree camera clearing to the
+   * horizon color.
+   */
+  camera?: ReactNode;
   /** World-space point the camera looks at. */
   origin?: [number, number, number];
   /** World-space point the camera starts at. */
@@ -99,6 +104,7 @@ export interface VirtualWalkthroughViewerProps {
 const VirtualWalkthroughViewer = ({
   splatSrc,
   splatFormat,
+  camera = <Camera clearColor='#EAF8FF' fov={60} />,
   origin = DEFAULT_FOCUS_POINT,
   cameraPosition = DEFAULT_POSITION,
   sceneBounds,
@@ -398,7 +404,7 @@ const VirtualWalkthroughViewer = ({
 
       <Entity name='camera-root'>
         <Entity name='camera'>
-          <Camera clearColor='#EAF8FF' fov={60} />
+          {camera}
           {!isCurrentlyInXr && (
             <Script
               script={WalkthroughCamera}

--- a/src/stories/VirtualWalkthroughViewer.stories.tsx
+++ b/src/stories/VirtualWalkthroughViewer.stories.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState } from 'react';
 
+import { Camera } from '@playcanvas/react/components';
 import { action } from '@storybook/addon-actions';
 import { Story } from '@storybook/react';
 
@@ -110,6 +111,12 @@ const Template: Story<Partial<VirtualWalkthroughViewerProps>> = (args) => (
 );
 
 export const Default = Template.bind({});
+
+// Exercises a camera being passed into the viewer
+export const WideFieldOfView = Template.bind({});
+WideFieldOfView.args = {
+  camera: <Camera clearColor='#EAF8FF' fov={120} />,
+};
 
 // Browsers only grant a session from a user gesture, and selecting a story is a click in Storybook's
 // manager frame, which leaves the preview iframe without one.


### PR DESCRIPTION
In order to support new use cases of virtual walkthroughs, allow the Camera component to be optionally passed in to the viewer. If it is not passed in it will use what it was previously.