### PR TITLE
Add separate onXrClose functionality

### DIFF
--- a/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
+++ b/src/components/VirtualWalkthrough/VirtualWalkthroughViewer.tsx
@@ -92,6 +92,12 @@ export interface VirtualWalkthroughViewerProps {
    * but couldn't be started, in which case the error says why.
    */
   onXrExit?: (error?: Error) => void;
+  /**
+   * Runs instead of ending the XR session when the user activates the in-headset exit button.
+   * Without it the button ends the session, which in turn reports `onXrExit`; with it the session
+   * stays running and neither happens, leaving the handler to decide what closing means.
+   */
+  onXrClose?: () => void;
   annotations: AnnotationProps[];
   onSaveAnnotations: (annotations: AnnotationProps[]) => void | Promise<void>;
   editable?: boolean;
@@ -116,6 +122,7 @@ const VirtualWalkthroughViewer = ({
   splatModelProps,
   autoStartVr = false,
   onXrExit,
+  onXrClose,
   annotations,
   onSaveAnnotations,
   editable = false,
@@ -417,7 +424,7 @@ const VirtualWalkthroughViewer = ({
         </Entity>
         {/* Sibling of the camera (not a child): WalkthroughCamera rewrites the camera entity's
             transform every frame, so the button drives its own world pose from the XR head pose. */}
-        <XrExitButton />
+        <XrExitButton onClose={onXrClose} />
         <Script script={XrControllers} enabled={!isEdit} />
         <XrAnnotationInteraction onDismiss={handleCloseAnnotation} />
         <XrPointerRay />

--- a/src/components/VirtualWalkthrough/XrExitButton.tsx
+++ b/src/components/VirtualWalkthrough/XrExitButton.tsx
@@ -5,9 +5,14 @@ import { Script } from '@playcanvas/react/components';
 
 import { XrExitButton as XrExitButtonScript } from './xr-exit-button';
 
-const XrExitButton = () => (
+interface XrExitButtonProps {
+  /** Runs instead of ending the XR session when the button is activated. */
+  onClose?: () => void;
+}
+
+const XrExitButton = ({ onClose }: XrExitButtonProps) => (
   <Entity name='xr-exit-button'>
-    <Script script={XrExitButtonScript} />
+    <Script script={XrExitButtonScript} onClose={onClose} />
   </Entity>
 );
 

--- a/src/components/VirtualWalkthrough/xr-exit-button.test.ts
+++ b/src/components/VirtualWalkthrough/xr-exit-button.test.ts
@@ -1,6 +1,6 @@
 import { Vec3 } from 'playcanvas';
 
-import { raySphereIntersect } from './xr-exit-button';
+import { XrExitButton, raySphereIntersect } from './xr-exit-button';
 
 describe('raySphereIntersect', () => {
   const CENTER = new Vec3(0, 0, 0);
@@ -27,5 +27,34 @@ describe('raySphereIntersect', () => {
 
   it('grazes a tangent sphere', () => {
     expect(raySphereIntersect(new Vec3(0, 1, 5), new Vec3(0, 0, -1), CENTER, 1)).toBe(true);
+  });
+});
+
+describe('XrExitButton.close', () => {
+  const makeButton = () => {
+    const end = jest.fn();
+    const button = Object.create(XrExitButton.prototype) as XrExitButton;
+    Object.assign(button, { app: { xr: { end } } });
+
+    return { button, end };
+  };
+
+  it('ends the session when no handler is set', () => {
+    const { button, end } = makeButton();
+
+    button.close();
+
+    expect(end).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls the handler and leaves the session running', () => {
+    const { button, end } = makeButton();
+    const onClose = jest.fn();
+    button.onClose = onClose;
+
+    button.close();
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(end).not.toHaveBeenCalled();
   });
 });

--- a/src/components/VirtualWalkthrough/xr-exit-button.ts
+++ b/src/components/VirtualWalkthrough/xr-exit-button.ts
@@ -56,6 +56,12 @@ export class XrExitButton extends Script {
   /** World-space radius of the hover/hit sphere. Slightly larger than halfSize for easier targeting. */
   hitRadius = 0.15;
 
+  /**
+   * Called in place of ending the XR session when the user activates the button, leaving the
+   * session running so the handler decides what happens next.
+   */
+  onClose?: () => void;
+
   private _material?: ShaderMaterial;
   private _texture?: Texture;
   private _mesh?: Mesh;
@@ -89,7 +95,7 @@ export class XrExitButton extends Script {
       return;
     }
     if (this.rayHitsButton(inputSource.getOrigin(), inputSource.getDirection())) {
-      this.app.xr?.end();
+      this.close();
     }
   };
 
@@ -100,6 +106,16 @@ export class XrExitButton extends Script {
     }
 
     return raySphereIntersect(origin, direction, this.entity.getPosition(), this.hitRadius);
+  }
+
+  /** The button's exit action: the `onClose` handler when one is set, otherwise ending the session. */
+  close() {
+    if (this.onClose) {
+      this.onClose();
+
+      return;
+    }
+    this.app.xr?.end();
   }
 
   /** The button's static artwork, painted once. Only the sweep changes per frame, and that lives in
@@ -177,7 +193,7 @@ export class XrExitButton extends Script {
       const facePressed = this._faceButtons.justPressed(source);
 
       if (sourceHovers && facePressed) {
-        this.app.xr?.end();
+        this.close();
 
         return;
       }
@@ -194,7 +210,7 @@ export class XrExitButton extends Script {
     this._material?.setParameter('uProgress', pieShaderProgress(hold.progress));
 
     if (hold.justFired) {
-      this.app.xr?.end();
+      this.close();
 
       return;
     }


### PR DESCRIPTION
We want to be able to optionally not exit VR when pressing the X button, so add an optional `onXrClose` function to the viewer that lets the client override the exit-vr behavior.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>